### PR TITLE
Start using qtpy

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-as-ma-launcher.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ma-launcher.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from pydm.PyQt.QtGui import QAction, QMenuBar
+from qtpy.QtWidgets import QAction, QMenuBar
 
 from siriushla.sirius_application import SiriusApplication
 from siriushla.as_ps_control.PSControlWindow import PSControlWindow

--- a/pyqt-apps/scripts/sirius-hla-as-ps-launcher.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-launcher.py
@@ -4,7 +4,7 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
-from pydm.PyQt.QtGui import QAction, QMenuBar
+from qtpy.QtWidgets import QAction, QMenuBar
 from siriushla.as_ps_control.PSControlWindow import PSControlWindow
 from siriushla.as_ps_control.PSTabControlWindow \
     import PSTabControlWindow

--- a/pyqt-apps/siriushla/as_ap_currlt/HLCurrentLifetime.py
+++ b/pyqt-apps/siriushla/as_ap_currlt/HLCurrentLifetime.py
@@ -4,7 +4,7 @@
 import epics as _epics
 import numpy as _np
 from qtpy.uic import loadUi
-from qtpy.QtCore import pyqtSlot
+from qtpy.QtCore import Slot
 from siriushla.widgets import SiriusMainWindow
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 from siriuspy.envars import vaca_prefix as _vaca_prefix
@@ -51,13 +51,13 @@ class CurrLTWindow(SiriusMainWindow):
             lt_str = H + ':' + m + ':' + s
             self.centralwidget.CurrLT.setText(lt_str)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setGraphBufferSize(self, value):
         """Set graph buffer size."""
         self.centralwidget.PyDMTimePlot_Current.setBufferSize(value)
         self.centralwidget.PyDMTimePlot_Lifetime.setBufferSize(value)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setGraphTimeSpan(self, value):
         """Set graph time span."""
         self.centralwidget.PyDMTimePlot_Current.setTimeSpan(float(value))

--- a/pyqt-apps/siriushla/as_ap_currlt/HLCurrentLifetime.py
+++ b/pyqt-apps/siriushla/as_ap_currlt/HLCurrentLifetime.py
@@ -3,8 +3,8 @@
 
 import epics as _epics
 import numpy as _np
-from pydm.PyQt.uic import loadUi
-from pydm.PyQt.QtCore import pyqtSlot
+from qtpy.uic import loadUi
+from qtpy.QtCore import pyqtSlot
 from siriushla.widgets import SiriusMainWindow
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 from siriuspy.envars import vaca_prefix as _vaca_prefix

--- a/pyqt-apps/siriushla/as_ap_injection/BarGraphWidget.py
+++ b/pyqt-apps/siriushla/as_ap_injection/BarGraphWidget.py
@@ -6,7 +6,7 @@ import numpy as np
 import pyqtgraph as pg
 
 from pydm.widgets.channel import PyDMChannel
-from pydm.PyQt.QtCore import QTimer, QSize
+from qtpy.QtCore import QTimer, QSize
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/pyqt-apps/siriushla/as_ap_injection/BarGraphWidget.py
+++ b/pyqt-apps/siriushla/as_ap_injection/BarGraphWidget.py
@@ -177,7 +177,7 @@ class PyDMBarGraphModel:
         """Return connection status."""
         return self._connected
 
-    # @pyqtSlot(bool)
+    # @Slot(bool)
     def connectionChanged(self, conn):
         """Slot called when connection state changes."""
         logging.debug("Connection changed to {}".format(conn))
@@ -188,12 +188,12 @@ class PyDMBarGraphModel:
         self.waveform = value
         self.size = len(value)
 
-    # @pyqtSlot(list)
+    # @Slot(list)
     # def waveformChanged(self, waveform):
     #     """Slot called when value changes (PV of type array)."""
     #     self.waveform = waveform
 
-    # @pyqtSlot(int)
+    # @Slot(int)
     # def countChanged(self, count):
     #     """Slot called when count changes."""
     #     self.size = count

--- a/pyqt-apps/siriushla/as_ap_injection/InjectionWindow.py
+++ b/pyqt-apps/siriushla/as_ap_injection/InjectionWindow.py
@@ -1,6 +1,6 @@
 """GUI for injection."""
 from pydm import PyDMApplication
-from qtpy.QtCore import pyqtSlot, QTimer, Qt
+from qtpy.QtCore import Slot, QTimer, Qt
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, \
     QRadioButton, QPushButton, QSpinBox, QGridLayout, QMessageBox, QDialog, \
     QLabel, QDockWidget
@@ -45,7 +45,7 @@ class WaitingDlg(QDialog):
         self.setLayout(self.layout)
         self.setWindowTitle(self.title)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def done(self, r):
         """Override done method."""
         self.may_close = True
@@ -135,7 +135,7 @@ class InjectionWindow(SiriusMainWindow):
         # self.show()
 
     # Public
-    @pyqtSlot()
+    @Slot()
     def startInjection(self):
         """Start injection."""
         if self.controller.injecting:
@@ -157,7 +157,7 @@ class InjectionWindow(SiriusMainWindow):
 
         # self._dialog = None
 
-    @pyqtSlot()
+    @Slot()
     def stopInjection(self):
         """Stop injection."""
         if not self.controller.injecting:
@@ -174,25 +174,25 @@ class InjectionWindow(SiriusMainWindow):
 
         # self._dialog = None
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setInitialBucket(self, value):
         """Set controller initial bucket and update bucket profile."""
         self.controller.initial_bucket = value
         self._setBucketProfile()
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setFinalBucket(self, value):
         """Set controller final graph and update bucket profile."""
         self.controller.final_bucket = value
         self._setBucketProfile()
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setStep(self, value):
         """Set controller step and update bucket profile."""
         self.controller.step = value
         self._setBucketProfile()
 
-    @pyqtSlot(int)
+    @Slot(int)
     def setCycle(self, value):
         """Set controller cycles."""
         self.controller.cycles = value
@@ -270,16 +270,16 @@ class InjectionWindow(SiriusMainWindow):
         self.startInjectionBtn.setEnabled(value)
         self.stopInjectionBtn.setEnabled(value)
 
-    @pyqtSlot(str)
+    @Slot(str)
     def _showErrorMsg(self, msg):
         self._showMsgBox("Error", msg, QMessageBox.Warning)
 
-    @pyqtSlot()
+    @Slot()
     def _showStartedMsg(self):
         self._showMsgBox("[InjectionControlWindow]",
                          "Injection started", QMessageBox.Information)
 
-    @pyqtSlot()
+    @Slot()
     def _showStoppedMsg(self):
         self._showMsgBox("[InjectionControlWindow]",
                          "Injection stopped", QMessageBox.Information)

--- a/pyqt-apps/siriushla/as_ap_injection/InjectionWindow.py
+++ b/pyqt-apps/siriushla/as_ap_injection/InjectionWindow.py
@@ -1,7 +1,7 @@
 """GUI for injection."""
 from pydm import PyDMApplication
-from pydm.PyQt.QtCore import pyqtSlot, QTimer, Qt
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QHBoxLayout, \
+from qtpy.QtCore import pyqtSlot, QTimer, Qt
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, \
     QRadioButton, QPushButton, QSpinBox, QGridLayout, QMessageBox, QDialog, \
     QLabel, QDockWidget
 from pydm.widgets.label import PyDMLabel

--- a/pyqt-apps/siriushla/as_ap_opticscorr/HLOpticsCorr.py
+++ b/pyqt-apps/siriushla/as_ap_opticscorr/HLOpticsCorr.py
@@ -2,13 +2,13 @@
 """Booster Optics Correction HLA Module."""
 
 import epics as _epics
-from pydm.PyQt.uic import loadUi
-from pydm.PyQt.QtCore import Qt
-from pydm.PyQt.QtGui import (QPushButton, QGridLayout, QLabel, QFrame,
-                             QSpacerItem, QAbstractItemView, QGroupBox,
-                             QSizePolicy as QSzPlcy)
-from pydm.widgets import (PyDMEnumComboBox, PyDMLabel, PyDMLineEdit,
-                          PyDMWaveformTable)
+from qtpy.uic import loadUi
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QPushButton, QGridLayout, QLabel, QFrame, \
+                            QSpacerItem, QAbstractItemView, QGroupBox, \
+                            QSizePolicy as QSzPlcy
+from pydm.widgets import PyDMEnumComboBox, PyDMLabel, PyDMLineEdit, \
+                            PyDMWaveformTable
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriushla.widgets.state_button import PyDMStateButton

--- a/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
+++ b/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
@@ -3,7 +3,7 @@
 """HLA as_ap_posang module."""
 
 import epics as _epics
-from pydm.PyQt.uic import loadUi as _loadUi
+from qtpy.uic import loadUi as _loadUi
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy.csdevice.posang import Const

--- a/pyqt-apps/siriushla/as_config_manager/ConfigManagerWindow.py
+++ b/pyqt-apps/siriushla/as_config_manager/ConfigManagerWindow.py
@@ -1,9 +1,10 @@
 """Define a window to manage offline configurations."""
 # from pymysql.err import IntegrityError, InternalError, OperationalError
-from pydm.PyQt.QtCore import Qt, QPoint, pyqtSlot
-from pydm.PyQt.QtGui import QVBoxLayout, QPushButton, \
+from qtpy.QtCore import Qt, QPoint, pyqtSlot
+from qtpy.QtWidgets import QVBoxLayout, QPushButton, \
         QTableView, QWidget, QHBoxLayout, QInputDialog, QMenu, QAction, \
-        QMessageBox, QKeySequence
+        QMessageBox
+from qtpy.QtGui import QKeySequence
 from siriushla.widgets import SiriusMainWindow
 from siriushla.widgets import LoadingDialog
 from .ConfigModel import ConfigModel

--- a/pyqt-apps/siriushla/as_config_manager/ConfigManagerWindow.py
+++ b/pyqt-apps/siriushla/as_config_manager/ConfigManagerWindow.py
@@ -1,6 +1,6 @@
 """Define a window to manage offline configurations."""
 # from pymysql.err import IntegrityError, InternalError, OperationalError
-from qtpy.QtCore import Qt, QPoint, pyqtSlot
+from qtpy.QtCore import Qt, QPoint, Slot
 from qtpy.QtWidgets import QVBoxLayout, QPushButton, \
         QTableView, QWidget, QHBoxLayout, QInputDialog, QMenu, QAction, \
         QMessageBox
@@ -114,7 +114,7 @@ class ConfigManagerWindow(SiriusMainWindow):
                 self._model._redo.pop()[1]()
             return
 
-    @pyqtSlot(QPoint)
+    @Slot(QPoint)
     def _showHeaderMenu(self, point):
         column = self.headers.logicalIndexAt(point.x())
         if column == -1:
@@ -165,7 +165,7 @@ class ConfigManagerWindow(SiriusMainWindow):
         menu.popup(self.mapToGlobal(point))
 
     # ContextMenu Actions
-    @pyqtSlot(int)
+    @Slot(int)
     def _saveConfiguration(self, column):
         try:
             self._model.saveConfiguration(column)
@@ -175,17 +175,17 @@ class ConfigManagerWindow(SiriusMainWindow):
                         "{}, {}".format(e, type(e))).exec_()
         return False
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _renameConfiguration(self, column):
         new_name, ok = QInputDialog.getText(self, "New name", "Rename to:")
         if ok and new_name:
             return self._model.renameConfiguration(column, new_name)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _closeConfiguration(self, column):
         self._closeConfigurations([column])
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _closeConfigurationsToTheRight(self, column):
         columns = list()
         i = len(self._model.configurations) - 1
@@ -195,7 +195,7 @@ class ConfigManagerWindow(SiriusMainWindow):
 
         self._closeConfigurations(columns)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _closeOtherConfigurations(self, column):
         columns = list()
         i = len(self._model.configurations) - 1
@@ -208,7 +208,7 @@ class ConfigManagerWindow(SiriusMainWindow):
 
         self._closeConfigurations(columns)
 
-    @pyqtSlot()
+    @Slot()
     def _closeAllConfigurations(self):
         columns = list()
         i = len(self._model.configurations) - 1
@@ -237,7 +237,7 @@ class ConfigManagerWindow(SiriusMainWindow):
         else:
             return False
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _tuneConfiguration(self, column):
         dlg = TuneDlg(self)
         ok1 = dlg.exec_()
@@ -268,7 +268,7 @@ class ConfigManagerWindow(SiriusMainWindow):
                                                     ConfigModel.TUNE,
                                                     [delta_d, delta_f])
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _barConfiguration(self, cols):
         if len(cols) != 2:
             raise SystemError("Must interpolate 2 columns")
@@ -281,7 +281,7 @@ class ConfigManagerWindow(SiriusMainWindow):
                 new_name, cols[0].column(), cols[1].column())
 
     # Window menu slots
-    @pyqtSlot()
+    @Slot()
     def _addConfiguration(self):
         try:
             configs = self._model.getConfigurations()
@@ -309,7 +309,7 @@ class ConfigManagerWindow(SiriusMainWindow):
                 self._showMessageBox("No configuration found")
         return
 
-    @pyqtSlot()
+    @Slot()
     def _removeConfiguration(self):
         try:
             configs = self._model.getConfigurations()
@@ -347,7 +347,7 @@ class ConfigManagerWindow(SiriusMainWindow):
                 self._showMessageBox("No configuration found")
         return
 
-    @pyqtSlot()
+    @Slot()
     def _loadCurrentConfiguration(self):
         try:
             t = LoadingThread(

--- a/pyqt-apps/siriushla/as_config_manager/ConfigModel.py
+++ b/pyqt-apps/siriushla/as_config_manager/ConfigModel.py
@@ -1,7 +1,8 @@
 """Configuration window model definition."""
 import re
-from pydm.PyQt.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant
-from pydm.PyQt.QtGui import QItemDelegate, QColor, QDoubleSpinBox
+from qtpy.QtCore import Qt, QAbstractTableModel, QModelIndex, QVariant
+from qtpy.QtWidgets import QItemDelegate, QDoubleSpinBox
+from qtpy.QtGui import QColor
 from siriuspy.servconf.conf_service import ConfigService
 from siriuspy.servconf.conf_types import get_config_type_template
 

--- a/pyqt-apps/siriushla/as_config_manager/LoadingThread.py
+++ b/pyqt-apps/siriushla/as_config_manager/LoadingThread.py
@@ -1,13 +1,13 @@
 import os
 from epics import caget
-from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QDialog
 
 class LoadingThread(QThread):
     VACA_PREFIX = os.environ.get('VACA_PREFIX', default='')
 
-    taskUpdated = pyqtSignal(int)
-    taskFinished = pyqtSignal(int)
+    taskUpdated = Signal(int)
+    taskFinished = Signal(int)
 
     def __init__(self, name, pv_list, parent=None):
         super(LoadingThread, self).__init__(parent)

--- a/pyqt-apps/siriushla/as_config_manager/LoadingThread.py
+++ b/pyqt-apps/siriushla/as_config_manager/LoadingThread.py
@@ -1,7 +1,7 @@
 import os
 from epics import caget
-from pydm.PyQt.QtCore import pyqtSignal, QThread
-from pydm.PyQt.QtGui import QDialog
+from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtWidgets import QDialog
 
 class LoadingThread(QThread):
     VACA_PREFIX = os.environ.get('VACA_PREFIX', default='')

--- a/pyqt-apps/siriushla/as_config_manager/TuneDlg.py
+++ b/pyqt-apps/siriushla/as_config_manager/TuneDlg.py
@@ -1,5 +1,6 @@
-from pydm.PyQt.QtGui import QDialog, QDoubleSpinBox, QDialogButtonBox, \
+from qtpy.QtWidgets import QDialog, QDoubleSpinBox, QDialogButtonBox, \
     QGridLayout, QLabel
+
 
 class TuneDlg(QDialog):
     def __init__(self, parent=None):

--- a/pyqt-apps/siriushla/as_config_manager/config_server.py
+++ b/pyqt-apps/siriushla/as_config_manager/config_server.py
@@ -2,10 +2,10 @@
 import logging
 import time
 
-from pydm.PyQt.QtGui import QGridLayout, QHBoxLayout, QVBoxLayout, \
+from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QVBoxLayout, \
     QWidget, QFrame, QLabel, QComboBox, QPushButton, QMessageBox, QTabWidget, \
     QTableView, QTreeView, QHeaderView
-from pydm.PyQt.QtCore import Qt, pyqtSlot, pyqtSignal, QModelIndex, \
+from qtpy.QtCore import Qt, pyqtSlot, pyqtSignal, QModelIndex, \
     QAbstractItemModel, QAbstractTableModel
 
 from siriushla.widgets.windows import SiriusMainWindow

--- a/pyqt-apps/siriushla/as_config_manager/config_server.py
+++ b/pyqt-apps/siriushla/as_config_manager/config_server.py
@@ -5,7 +5,7 @@ import time
 from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QVBoxLayout, \
     QWidget, QFrame, QLabel, QComboBox, QPushButton, QMessageBox, QTabWidget, \
     QTableView, QTreeView, QHeaderView
-from qtpy.QtCore import Qt, pyqtSlot, pyqtSignal, QModelIndex, \
+from qtpy.QtCore import Qt, Slot, Signal, QModelIndex, \
     QAbstractItemModel, QAbstractTableModel
 
 from siriushla.widgets.windows import SiriusMainWindow
@@ -187,8 +187,8 @@ class JsonTreeModel(QAbstractItemModel):
 class ConfigDbTableModel(QAbstractTableModel):
     """Model for configuration database."""
 
-    removeRow = pyqtSignal(QModelIndex)
-    connectionError = pyqtSignal(int, str, str)
+    removeRow = Signal(QModelIndex)
+    connectionError = Signal(int, str, str)
 
     def __init__(self, config_type, connection, discarded=False, parent=None):
         """Constructor."""
@@ -573,7 +573,7 @@ class ConfigurationManager(SiriusMainWindow):
         self.editor.resizeColumnsToContents()
         self.d_editor.resizeColumnsToContents()
 
-    @pyqtSlot(str)
+    @Slot(str)
     def _fill_table(self, config_type):
         """Fill table with configuration of `config_type`."""
         request = self._model.find_nr_configs(
@@ -590,7 +590,7 @@ class ConfigurationManager(SiriusMainWindow):
         self.editor.resizeColumnsToContents()
         self.d_editor.resizeColumnsToContents()
 
-    @pyqtSlot()
+    @Slot()
     def _fill_tree(self):
         if self.editor_tab.currentIndex() == 0:
             configs = list()
@@ -626,7 +626,7 @@ class ConfigurationManager(SiriusMainWindow):
                 self.retrieve_button.style().polish(self.retrieve_button)
         # self.tree.resizeColumnsToContents()
 
-    @pyqtSlot()
+    @Slot()
     def _remove_configuration(self):
         type = QMessageBox.Question
         title = 'Remove configuration?'
@@ -649,7 +649,7 @@ class ConfigurationManager(SiriusMainWindow):
         self.editor.selectionModel().clearSelection()
         self._fill_table(self.config_type.currentText())
 
-    @pyqtSlot()
+    @Slot()
     def _retrieve_configuration(self):
         type = QMessageBox.Question
         title = 'Retrieve configuration?'
@@ -677,7 +677,7 @@ class ConfigurationManager(SiriusMainWindow):
         self.editor.selectionModel().clearSelection()
         self._fill_table(self.config_type.currentText())
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _tab_changed(self, index):
         if index == 0:
             self.editor.selectionModel().clearSelection()
@@ -690,7 +690,7 @@ class ConfigurationManager(SiriusMainWindow):
             self.retrieve_button.style().polish(self.retrieve_button)
         self.tree_model.setupModelData([])
 
-    @pyqtSlot(int, str, str)
+    @Slot(int, str, str)
     def _database_error(self, code, message, operation):
         type = QMessageBox.Warning
         title = 'Something went wrong'

--- a/pyqt-apps/siriushla/as_pm_control/PulsedMagnetControlWindow.py
+++ b/pyqt-apps/siriushla/as_pm_control/PulsedMagnetControlWindow.py
@@ -1,6 +1,6 @@
 """Modulet that defines the window class that control pulsed mangets."""
 from pydm import PyDMApplication
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QTabWidget
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QTabWidget
 
 from siriuspy.search import MASearch
 from siriushla.widgets import SiriusMainWindow

--- a/pyqt-apps/siriushla/as_pm_control/PulsedMagnetDetailWidget.py
+++ b/pyqt-apps/siriushla/as_pm_control/PulsedMagnetDetailWidget.py
@@ -1,5 +1,5 @@
 """Detailed widget for controlling a pulsed mangnet."""
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, \
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, \
     QLabel, QGroupBox
 from pydm.widgets.label import PyDMLabel
 

--- a/pyqt-apps/siriushla/as_ps_control/PSDetailWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/PSDetailWindow.py
@@ -1,6 +1,6 @@
 """Define a window with detailed controls for a given magnet."""
 from pydm import PyDMApplication
-from pydm.PyQt.QtGui import QPushButton
+from qtpy.QtWidgets import QPushButton
 from siriushla.widgets import SiriusMainWindow
 from siriushla.as_ps_control.detail_widget.DetailWidgetFactory \
     import DetailWidgetFactory

--- a/pyqt-apps/siriushla/as_ps_control/PSTabControlWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/PSTabControlWindow.py
@@ -1,5 +1,5 @@
 """Defines a class to control elements from a given class."""
-from pydm.PyQt.QtGui import QTabWidget, QWidget, QGridLayout
+from qtpy.QtWidgets import QTabWidget, QWidget, QGridLayout
 
 from siriushla.as_ps_control.PSControlWindow import PSControlWindow
 from .control_widget.ControlWidgetFactory import ControlWidgetFactory

--- a/pyqt-apps/siriushla/as_ps_control/PSTrimWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/PSTrimWindow.py
@@ -1,6 +1,6 @@
 """Defines window class to show trims of a magnet."""
 from pydm import PyDMApplication
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout
+from qtpy.QtWidgets import QWidget, QVBoxLayout
 
 from siriushla.widgets import SiriusMainWindow
 from siriushla.as_ps_control.PSWidget import PSWidgetFactory

--- a/pyqt-apps/siriushla/as_ps_control/PSWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/PSWidget.py
@@ -7,9 +7,10 @@ Exposes basic controls like:
 """
 import re
 
-from pydm.PyQt.QtGui import QWidget, QHBoxLayout, QVBoxLayout, QLabel, \
-    QPushButton, QStyleOption, QStyle, QPainter
-from pydm.PyQt.QtCore import QSize
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, \
+    QPushButton, QStyleOption, QStyle
+from qtpy.QtGui import QPainter
+from qtpy.QtCore import QSize
 from pydm.widgets.label import PyDMLabel
 
 from siriuspy.envars import vaca_prefix as _VACA_PREFIX

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
@@ -3,8 +3,8 @@ import re
 
 from siriuspy.search import PSSearch, MASearch
 from siriushla.as_ps_control.PSWidget import BasePSWidget, PSWidget, MAWidget
-from pydm.PyQt.QtCore import Qt, QPoint, pyqtSlot, QLocale
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QGroupBox, \
+from qtpy.QtCore import Qt, QPoint, pyqtSlot, QLocale
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QGroupBox, \
     QGridLayout, QLabel, QHBoxLayout, QScrollArea, QLineEdit, QAction, \
     QMenu, QInputDialog
 

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
@@ -3,7 +3,7 @@ import re
 
 from siriuspy.search import PSSearch, MASearch
 from siriushla.as_ps_control.PSWidget import BasePSWidget, PSWidget, MAWidget
-from qtpy.QtCore import Qt, QPoint, pyqtSlot, QLocale
+from qtpy.QtCore import Qt, QPoint, Slot, QLocale
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QGroupBox, \
     QGridLayout, QLabel, QHBoxLayout, QScrollArea, QLineEdit, QAction, \
     QMenu, QInputDialog
@@ -62,7 +62,7 @@ class BasePSControlWidget(QWidget):
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.show_context_menu)
 
-    @pyqtSlot(str)
+    @Slot(str)
     def filter_pwrsupplies(self, text):
         """Filter power supply widgets based on text inserted at line edit."""
         try:
@@ -90,7 +90,7 @@ class BasePSControlWidget(QWidget):
             else:
                 widget.setVisible(False)
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def pwrstate_action(self, state):
         """Execute actions from context menu."""
         for key, widget in self.widgets_list.items():
@@ -100,7 +100,7 @@ class BasePSControlWidget(QWidget):
                 else:
                     widget.turn_off()
 
-    @pyqtSlot()
+    @Slot()
     def set_current_sp_action(self):
         """Set current setpoint for every visible widget."""
         dlg = QInputDialog(self)
@@ -113,7 +113,7 @@ class BasePSControlWidget(QWidget):
                     widget.analog_widget.sp_lineedit.setText(str(new_value))
                     widget.analog_widget.sp_lineedit.send_value()
 
-    @pyqtSlot(QPoint)
+    @Slot(QPoint)
     def show_context_menu(self, point):
         """Show a custom context menu."""
         menu = QMenu("Actions", self)

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/DetailWidgetFactory.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/DetailWidgetFactory.py
@@ -7,7 +7,7 @@ from siriushla.as_ps_control.detail_widget.DipoleDetailWidget \
     import DipoleDetailWidget
 from siriushla.as_pm_control.PulsedMagnetDetailWidget \
     import PulsedMagnetDetailWidget
-from pydm.PyQt.QtGui import QWidget, QGridLayout
+from qtpy.QtWidgets import QWidget, QGridLayout
 
 
 class DetailWidgetFactory:

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/DipoleDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/DipoleDetailWidget.py
@@ -1,8 +1,8 @@
 """Widget for controlling a dipole."""
 import re
 
-from pydm.PyQt.QtCore import Qt
-from pydm.PyQt.QtGui import QGridLayout, QLabel, QSizePolicy, \
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy, \
     QFrame, QHBoxLayout, QPushButton, QVBoxLayout
 
 from siriuspy.envars import vaca_prefix

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/MagnetInterlockWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/MagnetInterlockWidget.py
@@ -3,8 +3,7 @@ from epics import get_pv
 
 from siriushla.widgets import SiriusMainWindow
 from siriushla.widgets import SiriusLedAlert
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QHBoxLayout, QGridLayout, \
-    QLabel
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QLabel
 from siriuspy.envars import vaca_prefix as _VACA_PREFIX
 
 

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -1,10 +1,11 @@
 """MagnetDetailWidget definition."""
 import re
 
-from pydm.PyQt.QtCore import Qt
-from pydm.PyQt.QtGui import QWidget, QGroupBox, QGridLayout, QLabel, \
-    QSizePolicy, QPushButton, QVBoxLayout, QHBoxLayout, QColor, QApplication, \
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QGroupBox, QGridLayout, QLabel, \
+    QSizePolicy, QPushButton, QVBoxLayout, QHBoxLayout, QApplication, \
     QFormLayout
+from qtpy.QtGui import QColor
 # from epics import get_pv
 
 from siriuspy.envars import vaca_prefix

--- a/pyqt-apps/siriushla/as_ps_cycle/cycle_status_list.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/cycle_status_list.py
@@ -1,7 +1,7 @@
 """List with magnet cycling status."""
-from pydm.PyQt.QtCore import Qt
-from pydm.PyQt.QtGui import QListView, QStandardItemModel, QStandardItem, \
-    QIcon, QApplication
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QListView, QApplication
+from qtpy.QtGui import QStandardItemModel, QStandardItem, QIcon
 
 from siriushla.as_ps_control.PSDetailWindow import PSDetailWindow
 

--- a/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
@@ -3,8 +3,8 @@ from math import isclose
 import time
 import epics
 
-from pydm.PyQt.QtCore import pyqtSignal, QThread
-from pydm.PyQt.QtGui import QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, \
+from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, \
     QPushButton, QDialog, QLabel, QMessageBox
 
 from siriuspy.envars import vaca_prefix as VACA_PREFIX

--- a/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
@@ -3,7 +3,7 @@ from math import isclose
 import time
 import epics
 
-from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, \
     QPushButton, QDialog, QLabel, QMessageBox
 
@@ -265,7 +265,7 @@ class CyclingDlg(QDialog):
 class SetToCycle(QThread):
     """Set magnet to cycle."""
 
-    itemDone = pyqtSignal()
+    itemDone = Signal()
 
     def __init__(self, cyclers, parent=None):
         """Constructor."""
@@ -297,9 +297,9 @@ class SetToCycle(QThread):
 class VerifyCycle(QThread):
     """Verify cycle."""
 
-    currentItem = pyqtSignal(MagnetCycler)
-    itemDone = pyqtSignal()
-    itemChecked = pyqtSignal(MagnetCycler, bool)
+    currentItem = Signal(MagnetCycler)
+    itemDone = Signal()
+    itemChecked = Signal(MagnetCycler, bool)
 
     def __init__(self, cyclers, parent=None):
         """Constructor."""
@@ -334,7 +334,7 @@ class VerifyCycle(QThread):
 class WaitCycle(QThread):
     """Cycle."""
 
-    itemDone = pyqtSignal()
+    itemDone = Signal()
 
     def __init__(self, cyclers, parent=None):
         """Build PVs."""

--- a/pyqt-apps/siriushla/as_ps_cycle/magnets_tree.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/magnets_tree.py
@@ -1,8 +1,8 @@
 """Magnet selection tree view."""
 import re
 
-from pydm.PyQt.QtCore import Qt, QSize
-from pydm.PyQt.QtGui import QTreeWidget, QTreeWidgetItem
+from qtpy.QtCore import Qt, QSize
+from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem
 
 from siriuspy.search.ma_search import MASearch
 

--- a/pyqt-apps/siriushla/as_ps_cycle/progress_dialog.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/progress_dialog.py
@@ -7,8 +7,8 @@ Task QThread Interface:
 """
 import time
 
-from pydm.PyQt.QtCore import pyqtSignal, QThread
-from pydm.PyQt.QtGui import QDialog, QVBoxLayout, QLabel, QPushButton, \
+from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, \
     QProgressBar
 
 

--- a/pyqt-apps/siriushla/as_ps_cycle/progress_dialog.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/progress_dialog.py
@@ -1,13 +1,13 @@
 """Dialog that handle thread that implement a task interface.
 
 Task QThread Interface:
-- itemDone: pyqtSignal
+- itemDone: Signal
 - size: method that return task size
 - exit_task: set quit_thread flag True
 """
 import time
 
-from qtpy.QtCore import pyqtSignal, QThread
+from qtpy.QtCore import Signal, QThread
 from qtpy.QtWidgets import QDialog, QVBoxLayout, QLabel, QPushButton, \
     QProgressBar
 
@@ -22,7 +22,7 @@ class ProgressDialog(QDialog):
     parent - QObject
     """
 
-    canceled = pyqtSignal()
+    canceled = Signal()
 
     def __init__(self, label, task, parent=None):
         """Constructor."""

--- a/pyqt-apps/siriushla/as_ps_diagnostic/main_window.py
+++ b/pyqt-apps/siriushla/as_ps_diagnostic/main_window.py
@@ -1,5 +1,5 @@
 from pydm import Display
-from PyQt5.QtCore import pyqtSlot, QTimer
+from PyQt5.QtCore import Slot, QTimer
 from PyQt5.QtWidgets import QApplication
 from epics import PV
 from os import path
@@ -45,18 +45,18 @@ class DiagnosticsMainWindow(Display):
         super(Display, self).showEvent(event)
         self._timer.start()
 
-    @pyqtSlot()
+    @Slot()
     def _update_time_interval(self):
 
         self._time_between_readings = self.ui.sb_time_interval.value()
 
-    @pyqtSlot()
+    @Slot()
     def _start_sequence(self):
 
         self._timer.setInterval(1000 * self._time_between_readings)
         self.test_thread.start()
 
-    @pyqtSlot(list, list)
+    @Slot(list, list)
     def update_interface(self, magps_ok, magps_pane):
 
         self.ui.lb_msg_inicio.clear()

--- a/pyqt-apps/siriushla/as_ps_diagnostic/main_window.py
+++ b/pyqt-apps/siriushla/as_ps_diagnostic/main_window.py
@@ -1,13 +1,12 @@
 from pydm import Display
-from PyQt5.QtCore import Slot, QTimer
-from PyQt5.QtWidgets import QApplication
-from epics import PV
+from qtpy.QtCore import Slot, QTimer
+from qtpy.QtWidgets import QApplication
 from os import path
 from psdiag import Test
 # from siriuspy.magnet import magdata as _magdata
-from siriuspy.magnet.data import MAData as _MAData
 from siriuspy.search.ma_search import MASearch as _MASearch
 import datetime
+
 
 class DiagnosticsMainWindow(Display):
 

--- a/pyqt-apps/siriushla/as_ps_diagnostic/psdiag.py
+++ b/pyqt-apps/siriushla/as_ps_diagnostic/psdiag.py
@@ -4,11 +4,10 @@
     are igual to reference values, with a tolerance
 '''
 from epics import PV
-import time
+from qtpy.QtCore import QThread, Signal
 from pvnaming import PVNaming as _pvnaming
 # from siriuspy.magnet import magdata as _magdata
 from siriuspy.magnet.data import MAData as _MAData
-from PyQt5.QtCore import QThread, Signal
 
 
 class Test(QThread):

--- a/pyqt-apps/siriushla/as_ps_diagnostic/psdiag.py
+++ b/pyqt-apps/siriushla/as_ps_diagnostic/psdiag.py
@@ -8,12 +8,12 @@ import time
 from pvnaming import PVNaming as _pvnaming
 # from siriuspy.magnet import magdata as _magdata
 from siriuspy.magnet.data import MAData as _MAData
-from PyQt5.QtCore import QThread, pyqtSignal
+from PyQt5.QtCore import QThread, Signal
 
 
 class Test(QThread):
 
-    job_done = pyqtSignal(list, list)
+    job_done = Signal(list, list)
 
     def __init__(self, magps_list):
         QThread.__init__(self)

--- a/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
+++ b/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
@@ -3,7 +3,7 @@ import time
 import sys
 
 import epics
-from qtpy.QtCore import Qt, pyqtSignal, QThread
+from qtpy.QtCore import Qt, Signal, QThread
 from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QMainWindow, \
     QPushButton, QListWidget, QLabel, QApplication
 
@@ -106,7 +106,7 @@ class PSTestWindow(QMainWindow):
 class ResetPS(QThread):
     """Reset."""
 
-    itemDone = pyqtSignal()
+    itemDone = Signal()
 
     def __init__(self, devices, parent=None):
         """Constructor."""
@@ -138,7 +138,7 @@ class ResetPS(QThread):
 class TurnPSOn(QThread):
     """Turn PS on."""
 
-    itemDone = pyqtSignal()
+    itemDone = Signal()
 
     def __init__(self, devices, parent=None):
         """Constructor."""
@@ -175,8 +175,8 @@ class TurnPSOn(QThread):
 class CheckPSOn(QThread):
     """Check if PS is on."""
 
-    itemDone = pyqtSignal()
-    isOn = pyqtSignal(str, bool)
+    itemDone = Signal()
+    isOn = Signal(str, bool)
 
     def __init__(self, devices, parent=None):
         """Constructor."""
@@ -221,8 +221,8 @@ class CheckPSOn(QThread):
 class TestPS(QThread):
     """Set value and check if it rb is achieved."""
 
-    itemDone = pyqtSignal()
-    itemTested = pyqtSignal(str, bool)
+    itemDone = Signal()
+    itemTested = Signal(str, bool)
 
     def __init__(self, devices, parent=None):
         """Constructor."""

--- a/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
+++ b/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
@@ -3,8 +3,8 @@ import time
 import sys
 
 import epics
-from pydm.PyQt.QtCore import Qt, pyqtSignal, QThread
-from pydm.PyQt.QtGui import QFrame, QHBoxLayout, QVBoxLayout, QMainWindow, \
+from qtpy.QtCore import Qt, pyqtSignal, QThread
+from qtpy.QtWidgets import QFrame, QHBoxLayout, QVBoxLayout, QMainWindow, \
     QPushButton, QListWidget, QLabel, QApplication
 
 from siriushla.as_ps_cycle.magnets_tree import MagnetTree

--- a/pyqt-apps/siriushla/bo_rf_monitor/main_window.py
+++ b/pyqt-apps/siriushla/bo_rf_monitor/main_window.py
@@ -1,5 +1,5 @@
 from pydm import Display
-from PyQt5.QtCore import pyqtSlot, QTimer
+from PyQt5.QtCore import Slot, QTimer
 from PyQt5.QtWidgets import QApplication
 from epics import PV
 from os import path

--- a/pyqt-apps/siriushla/bo_rf_monitor/main_window.py
+++ b/pyqt-apps/siriushla/bo_rf_monitor/main_window.py
@@ -1,6 +1,6 @@
 from pydm import Display
-from PyQt5.QtCore import Slot, QTimer
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import Slot, QTimer
+from qtpy.QtWidgets import QApplication
 from epics import PV
 from os import path
 from siriuspy.magnet import magdata

--- a/pyqt-apps/siriushla/si_ap_sofb/graphic_controller.py
+++ b/pyqt-apps/siriushla/si_ap_sofb/graphic_controller.py
@@ -2,7 +2,7 @@
 
 import numpy as _np
 from datetime import datetime as _datetime
-from PyQt5.QtCore import pyqtSignal, QObject, QTimer
+from PyQt5.QtCore import Signal, QObject, QTimer
 from pyqtgraph import mkBrush, mkPen
 from PyQt5.QtWidgets import QFileDialog
 from siriushla.si_ap_sofb.selection_matrix import NR_BPMs
@@ -16,10 +16,10 @@ class GraphicOrbitControllers(QObject):
     EXT_FLT = 'Text Files (*.txt)'
     FMT = '{0:8.3g}'
 
-    averagex_str_signal = pyqtSignal(str)
-    stdx_str_signal = pyqtSignal(str)
-    averagey_str_signal = pyqtSignal(str)
-    stdy_str_signal = pyqtSignal(str)
+    averagex_str_signal = Signal(str)
+    stdx_str_signal = Signal(str)
+    averagey_str_signal = Signal(str)
+    stdy_str_signal = Signal(str)
 
     def __init__(self, mWin, index):
         """Initialize the instance."""

--- a/pyqt-apps/siriushla/si_ap_sofb/register_menu.py
+++ b/pyqt-apps/siriushla/si_ap_sofb/register_menu.py
@@ -3,7 +3,7 @@
 import numpy as _np
 from datetime import datetime as _datetime
 from PyQt5.QtWidgets import QMenu, QFileDialog
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import Signal
 from siriushla.si_ap_sofb.selection_matrix import NR_BPMs
 
 
@@ -14,9 +14,9 @@ class RegisterMenu(QMenu):
     EXT = '.siorb'
     EXT_FLT = 'Sirius Orbit Files (*.siorb)'
 
-    new_orbitx_signal = pyqtSignal(_np.ndarray)
-    new_orbity_signal = pyqtSignal(_np.ndarray)
-    new_string_signal = pyqtSignal(str)
+    new_orbitx_signal = Signal(_np.ndarray)
+    new_orbity_signal = Signal(_np.ndarray)
+    new_string_signal = Signal(str)
 
     def __init__(self, main_win, register, parent=None):
         """Initialize the Context Menu."""

--- a/pyqt-apps/siriushla/si_ap_sofb/si_ap_sofb.py
+++ b/pyqt-apps/siriushla/si_ap_sofb/si_ap_sofb.py
@@ -4,7 +4,7 @@ import sys as _sys
 import os as _os
 import numpy as np
 from PyQt5 import uic as _uic
-from PyQt5.QtCore import Qt, pyqtSignal
+from PyQt5.QtCore import Qt, Signal
 from PyQt5.QtWidgets import QWidget
 from pydm import PyDMApplication as _PyDMApplication
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
@@ -22,7 +22,7 @@ UI_FILE = _os.path.sep.join([_dir, 'SOFBMain.ui'])
 
 class _PyDMWidget(PyDMWritableWidget, QWidget):
 
-    receive_value_signal = pyqtSignal([int], [float], [str], [bool],
+    receive_value_signal = Signal([int], [float], [str], [bool],
                                       [np.ndarray])
 
     def __init__(self, parent=None, init_channel=None, visible=False):

--- a/pyqt-apps/siriushla/si_rf_monitor/main_window.py
+++ b/pyqt-apps/siriushla/si_rf_monitor/main_window.py
@@ -1,5 +1,5 @@
 from pydm import Display
-from PyQt5.QtCore import pyqtSlot, QTimer
+from PyQt5.QtCore import Slot, QTimer
 from PyQt5.QtWidgets import QApplication
 from epics import PV
 from os import path

--- a/pyqt-apps/siriushla/si_rf_monitor/main_window.py
+++ b/pyqt-apps/siriushla/si_rf_monitor/main_window.py
@@ -1,6 +1,6 @@
 from pydm import Display
-from PyQt5.QtCore import Slot, QTimer
-from PyQt5.QtWidgets import QApplication
+from qtpy.QtCore import Slot, QTimer
+from qtpy.QtWidgets import QApplication
 from epics import PV
 from os import path
 from siriuspy.magnet import magdata

--- a/pyqt-apps/siriushla/sirius_application.py
+++ b/pyqt-apps/siriushla/sirius_application.py
@@ -1,7 +1,7 @@
 """Definition of the Sirius Application class."""
 from pydm import PyDMApplication
-from pydm.PyQt.QtGui import QWidget, QDialog, QMainWindow, QMessageBox
-from pydm.PyQt.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QDialog, QMainWindow, QMessageBox
+from qtpy.QtCore import Qt
 
 from .util import get_window_id
 

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -7,7 +7,7 @@ from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas)
 import epics as _epics
 from qtpy.uic import loadUi
-from qtpy.QtCore import pyqtSlot, Qt, QPoint
+from qtpy.QtCore import Slot, Qt, QPoint
 from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QGridLayout, \
                             QSpacerItem, QFileDialog, QAction, QMenuBar, \
                             QWidget, QLabel, QPushButton, \
@@ -469,7 +469,7 @@ class TLAPControlWindow(SiriusMainWindow):
         reference = self.centralwidget.widget_Scrn.grab()
         reference.save(fn)
 
-    @pyqtSlot()
+    @Slot()
     def _setScrnWidget(self):
         app = SiriusApplication.instance()
         sender = self.sender()
@@ -623,14 +623,14 @@ class ShowICTHstr(SiriusMainWindow):
         self.centralwidget.checkBox_2.stateChanged.connect(
             self._setICT2CurveVisibility)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _setICT1CurveVisibility(self, value):
         """Set curves visibility."""
         self.centralwidget.PyDMTimePlot_Charge._curves[0].setVisible(value)
         self.centralwidget.PyDMWaveformPlot_ChargeHstr._curves[0].setVisible(
             value)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _setICT2CurveVisibility(self, value):
         """Set curves visibility."""
         self.centralwidget.PyDMTimePlot_Charge._curves[1].setVisible(value)

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -6,13 +6,14 @@ from datetime import datetime as _datetime
 from matplotlib.backends.backend_qt5agg import (
     FigureCanvasQTAgg as FigureCanvas)
 import epics as _epics
-from pydm.PyQt.uic import loadUi
-from pydm.PyQt.QtCore import pyqtSlot, Qt, QPoint
-from pydm.PyQt.QtGui import QVBoxLayout, QHBoxLayout, QGridLayout, \
+from qtpy.uic import loadUi
+from qtpy.QtCore import pyqtSlot, Qt, QPoint
+from qtpy.QtWidgets import QVBoxLayout, QHBoxLayout, QGridLayout, \
                             QSpacerItem, QFileDialog, QAction, QMenuBar, \
-                            QWidget, QLabel, QPixmap, QPushButton, \
+                            QWidget, QLabel, QPushButton, \
                             QButtonGroup, QCheckBox, QSizePolicy as QSzPlcy
-from pydm.PyQt.QtSvg import QSvgWidget
+from qtpy.QtGui import QPixmap
+from qtpy.QtSvg import QSvgWidget
 from pydm.widgets import PyDMLabel, PyDMEnumComboBox
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 import pyaccel as _pyaccel

--- a/pyqt-apps/siriushla/util.py
+++ b/pyqt-apps/siriushla/util.py
@@ -3,8 +3,8 @@ import os as _os
 import re as _re
 import pathlib as _pathlib
 
-from pydm.PyQt.QtCore import QFile as _QFile
-from pydm.PyQt.QtGui import QPushButton, QAction, QApplication
+from qtpy.QtCore import QFile as _QFile
+from qtpy.QtWidgets import QPushButton, QAction, QApplication
 import siriushla.resources as _resources
 
 

--- a/pyqt-apps/siriushla/widgets/QDoubleScrollBar.py
+++ b/pyqt-apps/siriushla/widgets/QDoubleScrollBar.py
@@ -1,6 +1,5 @@
-from pydm.PyQt.QtGui import QInputDialog
-from pydm.PyQt.QtGui import QScrollBar, QAction, QMenu
-from pydm.PyQt.QtCore import Qt, pyqtSignal, pyqtSlot, pyqtProperty
+from qtpy.QtWidgets import QInputDialog, QScrollBar, QMenu
+from qtpy.QtCore import Qt, pyqtSignal, pyqtSlot, pyqtProperty
 
 
 class QDoubleScrollBar(QScrollBar):

--- a/pyqt-apps/siriushla/widgets/QDoubleScrollBar.py
+++ b/pyqt-apps/siriushla/widgets/QDoubleScrollBar.py
@@ -1,11 +1,11 @@
 from qtpy.QtWidgets import QInputDialog, QScrollBar, QMenu
-from qtpy.QtCore import Qt, pyqtSignal, pyqtSlot, pyqtProperty
+from qtpy.QtCore import Qt, Signal, Slot, Property
 
 
 class QDoubleScrollBar(QScrollBar):
-    rangeChanged = pyqtSignal(float, float)
-    sliderMoved = pyqtSignal(float)
-    valueChanged = pyqtSignal(float)
+    rangeChanged = Signal(float, float)
+    sliderMoved = Signal(float)
+    valueChanged = Signal(float)
 
     def __init__(self, orientation=Qt.Horizontal, parent=None):
         self._decimals = 0
@@ -27,7 +27,7 @@ class QDoubleScrollBar(QScrollBar):
         ac.triggered.connect(lambda: self.triggerAction(self.SliderToMaximum))
         self.contextMenu = menu
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def dialogSingleStep(self, value):
         mini = 1/self._scale
         maxi = (self.maximum - self.minimum)/10
@@ -69,21 +69,21 @@ class QDoubleScrollBar(QScrollBar):
         self.setValue(val)
         self.setSliderPosition(slpos)
 
-    decimals = pyqtProperty(int, getDecimals, setDecimals)
+    decimals = Property(int, getDecimals, setDecimals)
 
     def getMinimum(self):
         return super().minimum()/self._scale
 
     def setMinimum(self, value):
         super().setMinimum(round(value*self._scale))
-    minimum = pyqtProperty(float, getMinimum, setMinimum)
+    minimum = Property(float, getMinimum, setMinimum)
 
     def getMaximum(self):
         return super().maximum()/self._scale
 
     def setMaximum(self, value):
         super().setMaximum(round(value*self._scale))
-    maximum = pyqtProperty(float, getMaximum, setMaximum)
+    maximum = Property(float, getMaximum, setMaximum)
 
     def getSingleStep(self):
         return super().singleStep()/self._scale
@@ -98,7 +98,7 @@ class QDoubleScrollBar(QScrollBar):
         else:
             super().setSingleStep(val)
 
-    singleStep = pyqtProperty(float, getSingleStep, setSingleStep)
+    singleStep = Property(float, getSingleStep, setSingleStep)
 
     def getPageStep(self):
         return super().pageStep()/self._scale
@@ -113,17 +113,17 @@ class QDoubleScrollBar(QScrollBar):
         else:
             super().setPageStep(val)
 
-    pageStep = pyqtProperty(float, getPageStep, setPageStep)
+    pageStep = Property(float, getPageStep, setPageStep)
 
     def getValue(self):
         return super().value()/self._scale
 
-    @pyqtSlot(float)
+    @Slot(float)
     def setValue(self, value):
         if value is not None:
             super().setValue(round(value*self._scale))
 
-    value = pyqtProperty(float, getValue, setValue)
+    value = Property(float, getValue, setValue)
 
     def getSliderPosition(self):
         return super().sliderPosition()/self._scale
@@ -131,7 +131,7 @@ class QDoubleScrollBar(QScrollBar):
     def setSliderPosition(self, value):
         super().setSliderPosition(round(value*self._scale))
 
-    sliderPosition = pyqtProperty(float, getSliderPosition, setSliderPosition)
+    sliderPosition = Property(float, getSliderPosition, setSliderPosition)
 
     def keyPressEvent(self, event):
         singlestep = self.getSingleStep()
@@ -145,18 +145,18 @@ class QDoubleScrollBar(QScrollBar):
         else:
             super().keyPressEvent(event)
 
-    @pyqtSlot(float, float)
+    @Slot(float, float)
     def setRange(self, mini, maxi):
         super().setRange(round(mini/self._scale), round(maxi*self._scale))
 
-    @pyqtSlot(int, int)
+    @Slot(int, int)
     def _intercept_rangeChanged(self, mini, maxi):
         self.rangeChanged.emit(mini/self._scale, maxi/self._scale)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _intercept_sliderMoved(self, value):
         self.sliderMoved.emit(value/self._scale)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _intercept_valueChanged(self, value):
         self.valueChanged.emit(value/self._scale)

--- a/pyqt-apps/siriushla/widgets/QLed.py
+++ b/pyqt-apps/siriushla/widgets/QLed.py
@@ -9,8 +9,8 @@ from colorsys import rgb_to_hls, hls_to_rgb
 from qtpy.QtWidgets import QApplication, QWidget, QGridLayout, \
                             QStyleOption, QFrame
 from qtpy.QtGui import QPainter, QColor
-from qtpy.QtCore import pyqtSignal, Qt, QSize, QTimer, QByteArray, \
-                        QRectF, pyqtProperty, Q_ENUMS
+from qtpy.QtCore import Signal, Qt, QSize, QTimer, QByteArray, \
+                        QRectF, Property, Q_ENUMS
 from qtpy.QtSvg import QSvgRenderer
 
 SHAPE = {'Circle': 1, 'Round': 2, 'Square': 3, 'Triangle': 4}
@@ -270,7 +270,7 @@ class QLed(QFrame):
     Red = QColor(207, 0, 0)
     Gray = QColor(90, 90, 90)
 
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def __init__(self, parent=None, **kwargs):
         """Class constructor."""
@@ -292,7 +292,7 @@ class QLed(QFrame):
         self.m_state = value
         self.update()
 
-    state = pyqtProperty(bool, getState, setState)
+    state = Property(bool, getState, setState)
 
     def getOnColor(self):
         """On color property getter."""
@@ -303,7 +303,7 @@ class QLed(QFrame):
         self.m_stateColors[1] = newColor
         self.update()
 
-    onColor = pyqtProperty(QColor, getOnColor, setOnColor)
+    onColor = Property(QColor, getOnColor, setOnColor)
 
     def getOffColor(self):
         """Off color property getter."""
@@ -314,7 +314,7 @@ class QLed(QFrame):
         self.m_stateColors[0] = newColor
         self.update()
 
-    offColor = pyqtProperty(QColor, getOffColor, setOffColor)
+    offColor = Property(QColor, getOffColor, setOffColor)
 
     @property
     def stateColors(self):
@@ -338,7 +338,7 @@ class QLed(QFrame):
         self.m_dsblColor = newColor
         self.update()
 
-    dsblColor = pyqtProperty(QColor, getDsblColor, setDsblColor)
+    dsblColor = Property(QColor, getDsblColor, setDsblColor)
 
     def getShape(self):
         """Shape property getter."""
@@ -349,7 +349,7 @@ class QLed(QFrame):
         self.m_shape = newShape
         self.update()
 
-    shape = pyqtProperty(shapeMap, getShape, setShape)
+    shape = Property(shapeMap, getShape, setShape)
 
     def sizeHint(self):
         """Return the base size of the widget according to shape."""

--- a/pyqt-apps/siriushla/widgets/QLed.py
+++ b/pyqt-apps/siriushla/widgets/QLed.py
@@ -6,11 +6,12 @@ https://pypi.python.org/pypi/QLed or https://github.com/jazzycamel/QLed.
 
 
 from colorsys import rgb_to_hls, hls_to_rgb
-from pydm.PyQt.QtGui import (QApplication, QWidget, QPainter, QGridLayout,
-                             QStyleOption, QColor, QFrame)
-from pydm.PyQt.QtCore import (pyqtSignal, Qt, QSize, QTimer, QByteArray,
-                              QRectF, pyqtProperty, Q_ENUMS)
-from pydm.PyQt.QtSvg import QSvgRenderer
+from qtpy.QtWidgets import QApplication, QWidget, QGridLayout, \
+                            QStyleOption, QFrame
+from qtpy.QtGui import QPainter, QColor
+from qtpy.QtCore import pyqtSignal, Qt, QSize, QTimer, QByteArray, \
+                        QRectF, pyqtProperty, Q_ENUMS
+from qtpy.QtSvg import QSvgRenderer
 
 SHAPE = {'Circle': 1, 'Round': 2, 'Square': 3, 'Triangle': 4}
 

--- a/pyqt-apps/siriushla/widgets/__init__.py
+++ b/pyqt-apps/siriushla/widgets/__init__.py
@@ -8,3 +8,4 @@ from siriushla.widgets.windows import SiriusMainWindow, SiriusDialog
 from siriushla.widgets.ledit_scrollbar import PyDMLinEditScrollbar
 from siriushla.widgets.loading_dialog import LoadingDialog
 from siriushla.widgets.scrn_view import SiriusScrnView
+from siriushla.widgets.signal_channel import SiriusConnectionSignal

--- a/pyqt-apps/siriushla/widgets/__init__.py
+++ b/pyqt-apps/siriushla/widgets/__init__.py
@@ -9,3 +9,4 @@ from siriushla.widgets.ledit_scrollbar import PyDMLinEditScrollbar
 from siriushla.widgets.loading_dialog import LoadingDialog
 from siriushla.widgets.scrn_view import SiriusScrnView
 from siriushla.widgets.signal_channel import SiriusConnectionSignal
+from siriushla.widgets.widget_factory import pydmwidget_factory

--- a/pyqt-apps/siriushla/widgets/led.py
+++ b/pyqt-apps/siriushla/widgets/led.py
@@ -1,5 +1,5 @@
 from qtpy.QtGui import QColor
-from qtpy.QtCore import pyqtProperty
+from qtpy.QtCore import Property
 from pydm.widgets.base import PyDMWidget
 from .QLed import QLed
 
@@ -32,7 +32,7 @@ class PyDMLed(QLed, PyDMWidget):
         self.pvbit = bit
         self.stateColors = color_list or self.default_colorlist
 
-    @pyqtProperty(int)
+    @Property(int)
     def pvbit(self):
         """
         PV bit to be handled by the led.

--- a/pyqt-apps/siriushla/widgets/led.py
+++ b/pyqt-apps/siriushla/widgets/led.py
@@ -1,5 +1,5 @@
-from pydm.PyQt.QtGui import QColor
-from pydm.PyQt.QtCore import pyqtProperty
+from qtpy.QtGui import QColor
+from qtpy.QtCore import pyqtProperty
 from pydm.widgets.base import PyDMWidget
 from .QLed import QLed
 

--- a/pyqt-apps/siriushla/widgets/ledit_scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/ledit_scrollbar.py
@@ -1,7 +1,7 @@
 """Defines PyDM widget with a line edit and a double scrollbar."""
-from pydm.PyQt.QtCore import QLocale
-from pydm.PyQt.QtGui import QWidget, QVBoxLayout, QStyle, QStyleOption, \
-    QPainter, QDoubleValidator
+from qtpy.QtCore import QLocale
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QStyle, QStyleOption
+from qtpy.QtGui import QPainter, QDoubleValidator
 from pydm.widgets.line_edit import PyDMLineEdit
 from siriushla.widgets.scrollbar import PyDMScrollBar
 

--- a/pyqt-apps/siriushla/widgets/loading_dialog.py
+++ b/pyqt-apps/siriushla/widgets/loading_dialog.py
@@ -1,5 +1,5 @@
-from pydm.PyQt.QtCore import pyqtSlot
-from pydm.PyQt.QtGui import QDialog, QLabel, QVBoxLayout, QProgressBar
+from qtpy.QtCore import pyqtSlot
+from qtpy.QtWidgets import QDialog, QLabel, QVBoxLayout, QProgressBar
 
 
 class LoadingDialog(QDialog):

--- a/pyqt-apps/siriushla/widgets/loading_dialog.py
+++ b/pyqt-apps/siriushla/widgets/loading_dialog.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import pyqtSlot
+from qtpy.QtCore import Slot
 from qtpy.QtWidgets import QDialog, QLabel, QVBoxLayout, QProgressBar
 
 
@@ -19,11 +19,11 @@ class LoadingDialog(QDialog):
         self.setWindowTitle(title)
         self.setLayout(layout)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def update(self, value):
         self.progress.setValue(value)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def done(self, r):
         self._may_close = True
         super(LoadingDialog, self).done(r)

--- a/pyqt-apps/siriushla/widgets/log_label.py
+++ b/pyqt-apps/siriushla/widgets/log_label.py
@@ -1,6 +1,6 @@
 import datetime as _datetime
 from qtpy.QtWidgets import QListWidget
-from qtpy.QtCore import pyqtProperty
+from qtpy.QtCore import Property
 from pydm.widgets.base import PyDMWidget
 from pydm.widgets.display_format import DisplayFormat, parse_value_for_display
 
@@ -75,7 +75,7 @@ class PyDMLogLabel(QListWidget, PyDMWidget):
         # is into a string and display it.
         self.addItem(prefix + str(new_value))
 
-    @pyqtProperty(DisplayFormat)
+    @Property(DisplayFormat)
     def displayFormat(self):
         """
         The format to display data.
@@ -102,7 +102,7 @@ class PyDMLogLabel(QListWidget, PyDMWidget):
             # Trigger the update of display format
             self.value_changed(self.value)
 
-    @pyqtProperty(int)
+    @Property(int)
     def bufferSize(self):
         """
         The maximum number of entries to show.
@@ -128,7 +128,7 @@ class PyDMLogLabel(QListWidget, PyDMWidget):
         """
         self._buffer_size = int(value)
 
-    @pyqtProperty(bool)
+    @Property(bool)
     def prependDateTime(self):
         """
         Define if the date and time information will be prepended to the text.
@@ -150,7 +150,7 @@ class PyDMLogLabel(QListWidget, PyDMWidget):
         """
         self._prepend_date_time = bool(value)
 
-    @pyqtProperty(str)
+    @Property(str)
     def dateTimeFmt(self):
         """
         Define the format of the datetime information to be prepended.

--- a/pyqt-apps/siriushla/widgets/scrn_view.py
+++ b/pyqt-apps/siriushla/widgets/scrn_view.py
@@ -3,13 +3,13 @@
 import numpy as np
 import time
 from threading import Thread
-from pydm.PyQt.QtGui import (QGridLayout, QHBoxLayout, QFormLayout,
-                             QSpacerItem, QWidget, QGroupBox, QLabel,
-                             QComboBox, QPushButton, QCheckBox, QMessageBox)
-from pydm.PyQt.QtGui import QSizePolicy as QSzPlcy
-from pydm.PyQt.QtCore import Qt, pyqtSlot, pyqtSignal, pyqtProperty
-from pydm.widgets import (PyDMImageView, PyDMLabel, PyDMSpinbox,
-                          PyDMPushButton, PyDMEnumComboBox)
+from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QFormLayout, \
+                            QSpacerItem, QWidget, QGroupBox, QLabel, \
+                            QComboBox, QPushButton, QCheckBox, QMessageBox, \
+                            QSizePolicy as QSzPlcy
+from qtpy.QtCore import Qt, pyqtSlot, pyqtSignal, pyqtProperty
+from pydm.widgets import PyDMImageView, PyDMLabel, PyDMSpinbox, \
+                            PyDMPushButton, PyDMEnumComboBox
 from pydm.widgets.channel import PyDMChannel
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriushla.widgets import PyDMStateButton, SiriusLedState

--- a/pyqt-apps/siriushla/widgets/scrn_view.py
+++ b/pyqt-apps/siriushla/widgets/scrn_view.py
@@ -7,7 +7,7 @@ from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QFormLayout, \
                             QSpacerItem, QWidget, QGroupBox, QLabel, \
                             QComboBox, QPushButton, QCheckBox, QMessageBox, \
                             QSizePolicy as QSzPlcy
-from qtpy.QtCore import Qt, pyqtSlot, pyqtSignal, pyqtProperty
+from qtpy.QtCore import Qt, Slot, Signal, Property
 from pydm.widgets import PyDMImageView, PyDMLabel, PyDMSpinbox, \
                             PyDMPushButton, PyDMEnumComboBox
 from pydm.widgets.channel import PyDMChannel
@@ -20,7 +20,7 @@ from siriushla import util
 class _SiriusImageView(PyDMImageView):
     """A PyDMImageView with methods to handle screens calibration grids."""
 
-    failToSaveGrid = pyqtSignal()
+    failToSaveGrid = Signal()
 
     def __init__(self, parent=None,
                  image_channel=None, width_channel=None,
@@ -43,7 +43,7 @@ class _SiriusImageView(PyDMImageView):
         self._maxheightchannel = maxheight_channel
         self._show_calibration_grid = False
 
-    @pyqtSlot()
+    @Slot()
     def saveCalibrationGrid(self):
         """Save current image as calibration_grid_image."""
         for i in range(40):
@@ -65,7 +65,7 @@ class _SiriusImageView(PyDMImageView):
         else:
             self.failToSaveGrid.emit()
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def showCalibrationGrid(self, show):
         """Show calibration_grid_image over the current image_waveform."""
         self._show_calibration_grid = show
@@ -173,7 +173,7 @@ class _SiriusImageView(PyDMImageView):
             return
         self._image_maxheight = new_max
 
-    @pyqtProperty(str)
+    @Property(str)
     def ROIOffsetXChannel(self):
         """
         The channel address in use for the image ROI horizontal offset.
@@ -198,7 +198,7 @@ class _SiriusImageView(PyDMImageView):
         if self._offsetxchannel != value:
             self._offsetxchannel = str(value)
 
-    @pyqtProperty(str)
+    @Property(str)
     def ROIOffsetYChannel(self):
         """
         The channel address in use for the image ROI vertical offset.
@@ -223,7 +223,7 @@ class _SiriusImageView(PyDMImageView):
         if self._offsetychannel != value:
             self._offsetychannel = str(value)
 
-    @pyqtProperty(str)
+    @Property(str)
     def maxWidthChannel(self):
         """
         The channel address in use for the image ROI horizontal offset.
@@ -248,7 +248,7 @@ class _SiriusImageView(PyDMImageView):
         if self._maxwidthchannel != value:
             self._maxwidthchannel = str(value)
 
-    @pyqtProperty(str)
+    @Property(str)
     def maxHeightChannel(self):
         """
         The channel address in use for the image ROI vertical offset.
@@ -321,7 +321,7 @@ class SiriusScrnView(QWidget):
 
     To allow saving a grid correctly, control calibrationgrid_flag, which
     indicates if the screen is in calibration grid position.
-    You can control it by using the method/pyqtSlot updateCalibrationGridFlag.
+    You can control it by using the method/Slot updateCalibrationGridFlag.
     """
 
     def __init__(self, parent=None, prefix='', device=None):
@@ -342,7 +342,7 @@ class SiriusScrnView(QWidget):
         """Indicate if the screen device is in calibration grid position."""
         return self._calibrationgrid_flag
 
-    @pyqtSlot(int)
+    @Slot(int)
     def updateCalibrationGridFlag(self, new_state):
         """Update calibrationgrid_flag property."""
         if new_state != self._calibrationgrid_flag:
@@ -773,23 +773,23 @@ class SiriusScrnView(QWidget):
         self.PyDMSpinbox_ROIOffsetY.send_value()
         time.sleep(0.1)
 
-    @pyqtSlot()
+    @Slot()
     def _showFailToSaveGridMsg(self):
         QMessageBox.warning(self, 'Warning',
                             'Could not save calibration grid!',
                             QMessageBox.Ok)
 
-    @pyqtSlot()
+    @Slot()
     def _zoomIn(self):
         """Zoom ImageView to 0.5x current image scale."""
         self.image_view.getView().scaleBy((0.5, 0.5))
 
-    @pyqtSlot()
+    @Slot()
     def _zoomOut(self):
         """Zoom ImageView to 2x current image scale."""
         self.image_view.getView().scaleBy((2.0, 2.0))
 
-    @pyqtSlot()
+    @Slot()
     def _zoomToActualSize(self):
         """Zoom ImqgeView to actual image size."""
         if len(self.image_view.image_waveform) == 0:

--- a/pyqt-apps/siriushla/widgets/scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/scrollbar.py
@@ -1,4 +1,4 @@
-from qtpy.QtCore import Qt, pyqtSignal
+from qtpy.QtCore import Qt, Signal
 from .QDoubleScrollBar import QDoubleScrollBar
 from pydm.widgets.base import PyDMWritableWidget
 
@@ -19,9 +19,9 @@ class PyDMScrollBar(QDoubleScrollBar, PyDMWritableWidget):
         Precision to be use. Used to calculate size of the scroll bar step
     """
 
-    value_changed_signal = pyqtSignal([int], [float], [str])
-    connected_signal = pyqtSignal()
-    disconnected_signal = pyqtSignal()
+    value_changed_signal = Signal([int], [float], [str])
+    connected_signal = Signal()
+    disconnected_signal = Signal()
 
     def __init__(self, parent=None, orientation=Qt.Horizontal,
                  init_channel=None, precision=2):

--- a/pyqt-apps/siriushla/widgets/scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/scrollbar.py
@@ -1,4 +1,4 @@
-from pydm.PyQt.QtCore import Qt, pyqtSignal
+from qtpy.QtCore import Qt, pyqtSignal
 from .QDoubleScrollBar import QDoubleScrollBar
 from pydm.widgets.base import PyDMWritableWidget
 

--- a/pyqt-apps/siriushla/widgets/signal_channel.py
+++ b/pyqt-apps/siriushla/widgets/signal_channel.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python-sirius
+
+import numpy as _np
+from pydm.widgets.channel import PyDMChannel
+from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject
+
+
+class SiriusConnectionSignal(QObject, PyDMChannel):
+    send_value_signal = pyqtSignal(
+        [int], [float], [str], [bool], [_np.ndarray], [list])
+    new_value_signal = pyqtSignal(
+        [int], [float], [str], [bool], [_np.ndarray], [list])
+    connection_state_signal = pyqtSignal(bool)
+    write_access_signal = pyqtSignal(bool)
+    enum_strings_signal = pyqtSignal(tuple)
+    unit_signal = pyqtSignal(str)
+    prec_signal = pyqtSignal(int)
+    new_severity_signal = pyqtSignal(int)
+    upper_ctrl_limit_signal = pyqtSignal([float], [int])
+    lower_ctrl_limit_signal = pyqtSignal([float], [int])
+
+    def __init__(self, address):
+        QObject.__init__(self)
+        PyDMChannel.__init__(self, address)
+
+        self.connection_slot = self._connection_slot
+        self.value_slot = self._value_slot
+        self.severity_slot = self._severity_slot
+        self.write_access_slot = self._write_access_slot
+        self.enum_strings_slot = self._enum_strings_slot
+        self.unit_slot = self._unit_slot
+        self.prec_slot = self._prec_slot
+        self.upper_ctrl_limit_slot = self._upper_ctrl_limit_slot
+        self.lower_ctrl_limit_slot = self._lower_ctrl_limit_slot
+        self.value_signal = self.send_value_signal
+
+        self.channeltype = None
+        self._value = None
+        self.connected = None
+
+    def getvalue(self):
+        if self.connected and self._value is not None:
+            return self._value.copy()
+
+    value = property(fget=getvalue)
+
+    @pyqtSlot(bool)
+    def _connection_slot(self, connection):
+        self.connected = connection
+        self.connection_state_signal.emit(connection)
+
+    @pyqtSlot(int)
+    @pyqtSlot(str)
+    @pyqtSlot(float)
+    @pyqtSlot(list)
+    @pyqtSlot(_np.ndarray)
+    def _value_slot(self, value):
+        self.channeltype = type(value)
+        self._value = value
+        self.new_value_signal[self.channeltype].emit(value)
+
+    @pyqtSlot(int)
+    def _severity_slot(self, severity):
+        self.new_severity_signal.emit(severity)
+
+    @pyqtSlot(bool)
+    def _write_access_slot(self, write_access):
+        self.write_access_signal.emit(write_access)
+
+    @pyqtSlot(tuple)
+    def _enum_strings_slot(self, enum_strings):
+        self.enum_strings_signal.emit(enum_strings)
+
+    @pyqtSlot(str)
+    def _unit_slot(self, unit):
+        self.unit_signal.emit(unit)
+
+    @pyqtSlot(int)
+    def _prec_slot(self, prec):
+        self.prec_signal.emit(prec)
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    def _upper_ctrl_limit_slot(self, upper_ctrl_limit):
+        self.upper_ctrl_limit_signal.emit(upper_ctrl_limit)
+
+    @pyqtSlot(int)
+    @pyqtSlot(float)
+    def _lower_ctrl_limit_slot(self, lower_ctrl_limit):
+        self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)

--- a/pyqt-apps/siriushla/widgets/signal_channel.py
+++ b/pyqt-apps/siriushla/widgets/signal_channel.py
@@ -2,7 +2,7 @@
 
 import numpy as _np
 from pydm.widgets.channel import PyDMChannel
-from PyQt5.QtCore import Signal, Slot, QObject
+from qtpy.QtCore import Signal, Slot, QObject
 
 
 class SiriusConnectionSignal(QObject, PyDMChannel):

--- a/pyqt-apps/siriushla/widgets/signal_channel.py
+++ b/pyqt-apps/siriushla/widgets/signal_channel.py
@@ -2,22 +2,22 @@
 
 import numpy as _np
 from pydm.widgets.channel import PyDMChannel
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject
+from PyQt5.QtCore import Signal, Slot, QObject
 
 
 class SiriusConnectionSignal(QObject, PyDMChannel):
-    send_value_signal = pyqtSignal(
+    send_value_signal = Signal(
         [int], [float], [str], [bool], [_np.ndarray], [list])
-    new_value_signal = pyqtSignal(
+    new_value_signal = Signal(
         [int], [float], [str], [bool], [_np.ndarray], [list])
-    connection_state_signal = pyqtSignal(bool)
-    write_access_signal = pyqtSignal(bool)
-    enum_strings_signal = pyqtSignal(tuple)
-    unit_signal = pyqtSignal(str)
-    prec_signal = pyqtSignal(int)
-    new_severity_signal = pyqtSignal(int)
-    upper_ctrl_limit_signal = pyqtSignal([float], [int])
-    lower_ctrl_limit_signal = pyqtSignal([float], [int])
+    connection_state_signal = Signal(bool)
+    write_access_signal = Signal(bool)
+    enum_strings_signal = Signal(tuple)
+    unit_signal = Signal(str)
+    prec_signal = Signal(int)
+    new_severity_signal = Signal(int)
+    upper_ctrl_limit_signal = Signal([float], [int])
+    lower_ctrl_limit_signal = Signal([float], [int])
 
     def __init__(self, address):
         QObject.__init__(self)
@@ -44,47 +44,47 @@ class SiriusConnectionSignal(QObject, PyDMChannel):
 
     value = property(fget=getvalue)
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def _connection_slot(self, connection):
         self.connected = connection
         self.connection_state_signal.emit(connection)
 
-    @pyqtSlot(int)
-    @pyqtSlot(str)
-    @pyqtSlot(float)
-    @pyqtSlot(list)
-    @pyqtSlot(_np.ndarray)
+    @Slot(int)
+    @Slot(str)
+    @Slot(float)
+    @Slot(list)
+    @Slot(_np.ndarray)
     def _value_slot(self, value):
         self.channeltype = type(value)
         self._value = value
         self.new_value_signal[self.channeltype].emit(value)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _severity_slot(self, severity):
         self.new_severity_signal.emit(severity)
 
-    @pyqtSlot(bool)
+    @Slot(bool)
     def _write_access_slot(self, write_access):
         self.write_access_signal.emit(write_access)
 
-    @pyqtSlot(tuple)
+    @Slot(tuple)
     def _enum_strings_slot(self, enum_strings):
         self.enum_strings_signal.emit(enum_strings)
 
-    @pyqtSlot(str)
+    @Slot(str)
     def _unit_slot(self, unit):
         self.unit_signal.emit(unit)
 
-    @pyqtSlot(int)
+    @Slot(int)
     def _prec_slot(self, prec):
         self.prec_signal.emit(prec)
 
-    @pyqtSlot(int)
-    @pyqtSlot(float)
+    @Slot(int)
+    @Slot(float)
     def _upper_ctrl_limit_slot(self, upper_ctrl_limit):
         self.upper_ctrl_limit_signal.emit(upper_ctrl_limit)
 
-    @pyqtSlot(int)
-    @pyqtSlot(float)
+    @Slot(int)
+    @Slot(float)
     def _lower_ctrl_limit_slot(self, lower_ctrl_limit):
         self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)

--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -1,9 +1,9 @@
 """PyDM State Button Class."""
 
-from pydm.PyQt.QtGui import QPainter, QStyleOption, QFrame
-from pydm.PyQt.QtCore import (pyqtProperty, Q_ENUMS, QByteArray, QRectF,
+from qtpy.QtWidgets import QPainter, QStyleOption, QFrame
+from qtpy.QtCore import (pyqtProperty, Q_ENUMS, QByteArray, QRectF,
                               QSize, pyqtSignal)
-from pydm.PyQt.QtSvg import QSvgRenderer
+from qtpy.QtSvg import QSvgRenderer
 from pydm.widgets.base import PyDMWritableWidget
 
 
@@ -1461,6 +1461,8 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         If :attr:'pvBit' is n>=0 or positive the button toggles the state of
         the n-th digit of the channel. Otherwise it toggles the whole value.
         """
+        if not self._connected:
+            return
         checked = not self._bit_val
         val = checked
         if self._bit >= 0:
@@ -1476,7 +1478,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
 
     def paintEvent(self, event):
         """Treat appearence changes based on connection state and value."""
-        if self._connected is False:
+        if not self.isEnabled():
             state = 'Disconnected'
         elif self._bit_val == 1:
             state = 'On'

--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -1,8 +1,9 @@
 """PyDM State Button Class."""
 
-from qtpy.QtWidgets import QPainter, QStyleOption, QFrame
-from qtpy.QtCore import (Property, Q_ENUMS, QByteArray, QRectF,
-                              QSize, Signal)
+from qtpy.QtWidgets import QStyleOption, QFrame
+from qtpy.QtGui import QPainter
+from qtpy.QtCore import Property, Q_ENUMS, QByteArray, QRectF, \
+                        QSize, Signal
 from qtpy.QtSvg import QSvgRenderer
 from pydm.widgets.base import PyDMWritableWidget
 

--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -1,8 +1,8 @@
 """PyDM State Button Class."""
 
 from qtpy.QtWidgets import QPainter, QStyleOption, QFrame
-from qtpy.QtCore import (pyqtProperty, Q_ENUMS, QByteArray, QRectF,
-                              QSize, pyqtSignal)
+from qtpy.QtCore import (Property, Q_ENUMS, QByteArray, QRectF,
+                              QSize, Signal)
 from qtpy.QtSvg import QSvgRenderer
 from pydm.widgets.base import PyDMWritableWidget
 
@@ -1415,7 +1415,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
                                     """
                                }
 
-    clicked = pyqtSignal()
+    clicked = Signal()
 
     def __init__(self, parent=None, init_channel=None):
         """Initialize all internal states and properties."""
@@ -1514,7 +1514,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         self.renderer.load(QByteArray(buttonstate_bytearray))
         self.renderer.render(painter, bounds)
 
-    @pyqtProperty(buttonShapeMap)
+    @Property(buttonShapeMap)
     def shape(self):
         """
         Property to define the shape of the button.
@@ -1540,7 +1540,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         else:
             raise ValueError('Button shape not defined!')
 
-    @pyqtProperty(int)
+    @Property(int)
     def pvbit(self):
         """
         Property to define which PV bit to control.

--- a/pyqt-apps/siriushla/widgets/widget_factory.py
+++ b/pyqt-apps/siriushla/widgets/widget_factory.py
@@ -1,0 +1,26 @@
+from pydm.widgets.base import (
+    PyDMPrimitiveWidget, PyDMWidget, PyDMWritableWidget)
+
+
+def pydmwidget_factory(widgetclass, pydm_class='read'):
+    if pydm_class.lower().startswith('primi'):
+        pydmclass = PyDMPrimitiveWidget
+    elif pydm_class.lower().startswith('read'):
+        pydmclass = PyDMWidget
+    else:
+        pydmclass = PyDMWritableWidget
+
+    class PyDMCustomWidget(widgetclass, pydmclass):
+
+        def __init__(self, *args, **kwargs):
+            try:
+                init_channel = kwargs.pop('init_channel')
+            except KeyError:
+                init_channel = None
+
+            widgetclass.__init__(self, *args, **kwargs)
+            if pydm_class.lower().startswith('primi'):
+                pydmclass.__init__(self)
+            else:
+                pydmclass.__init__(self, init_channel=init_channel)
+    return PyDMCustomWidget

--- a/pyqt-apps/siriushla/widgets/windows.py
+++ b/pyqt-apps/siriushla/widgets/windows.py
@@ -1,6 +1,6 @@
 """Sirius Windows module."""
-from PyQt5.QtCore import Property
-from PyQt5.QtWidgets import QMainWindow, QDialog
+from qtpy.QtCore import Property
+from qtpy.QtWidgets import QMainWindow, QDialog
 from siriushla.sirius_application import SiriusApplication
 
 

--- a/pyqt-apps/siriushla/widgets/windows.py
+++ b/pyqt-apps/siriushla/widgets/windows.py
@@ -1,5 +1,5 @@
 """Sirius Windows module."""
-from PyQt5.QtCore import pyqtProperty
+from PyQt5.QtCore import Property
 from PyQt5.QtWidgets import QMainWindow, QDialog
 from siriushla.sirius_application import SiriusApplication
 
@@ -52,7 +52,7 @@ def _create_siriuswindow(qt_type):
                 self._is_connected = False
             super().closeEvent(ev)
 
-        @pyqtProperty(bool)
+        @Property(bool)
         def disconnectWhenHidden(self):
             """Disconnect widgets when hidden.
 

--- a/pyqt-apps/siriushla/widgets/windows.py
+++ b/pyqt-apps/siriushla/widgets/windows.py
@@ -25,7 +25,11 @@ def _create_siriuswindow(qt_type):
             super().__init__(parent, **kwargs)
             self._app = SiriusApplication.instance()
             self._is_connected = False
+            self._channels = None
             self._disconnect_when_hidden = disconnect_when_hidden
+
+        def channels(self):
+            return self._channels if self._channels is not None else []
 
         def showEvent(self, ev):
             """Reimplement showEvent to establish widget connections."""


### PR DESCRIPTION
@gu1lhermelp , @anacso17  and @xresende, this PR is kind of **urgent**. I believe that without it all our windows are broken, considering the master branch of our `pydm` fork. Here is why:
 - Recently `pydm` changed the way `PyQt` imports are made. Now they use the python package `qtpy`, which means the subpackage `pydm.PyQt` is gone and all our calls to `pydm.PyQt` are broken.
 - In this PR I substitute all `pydm.PyQt` imports with `qtpy` and try to fix all import errors due to changes in the `PyQt` subpackages.
 - Maybe some of your windows are still broken, so please check if they are running properly.

Additionally, I also implemented new features:
 - `SiriusConnectionSignal` is a `PyDMChannel` that re-emits all `PV` signals and also allow writes on `PVs` through its slot. it is useful to make any widget communicate with a given `PV` using the `pydm` machinery. In order for it to work you must only create a `channels` method in your widget that returns the instances of this class.
 - `widget_factory` is a function to create arbitrary `pydm` `widgets`.
 - I also have created a `channels` method in our windows to allow them to have their own `PyDMChannels`.
 - `PyDMLogLabel` had its parsing and display functions upgraded. Now it has the same options as `PyDMLabel`