### PR TITLE
API: change PyDMStateButton to respond only to left clicks of the mouse.

### DIFF
--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -3,7 +3,7 @@
 from qtpy.QtWidgets import QStyleOption, QFrame
 from qtpy.QtGui import QPainter
 from qtpy.QtCore import Property, Q_ENUMS, QByteArray, QRectF, \
-                        QSize, Signal
+                        QSize, Signal, Qt
 from qtpy.QtSvg import QSvgRenderer
 from pydm.widgets.base import PyDMWritableWidget
 
@@ -1431,9 +1431,13 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
 
     def mousePressEvent(self, ev):
         """Deal with mouse clicks. Only accept clicks within the figure."""
-        if (ev.x() < self.width()/2+self.height() and
-                ev.x() > self.width()/2-self.height()):
+        cond = ev.button() == Qt.LeftButton
+        cond &= ev.x() < self.width()/2+self.height()
+        cond &= ev.x() > self.width()/2-self.height()
+        if cond:
             self.clicked.emit()
+        else:
+            super().mousePressEvent(ev)
 
     def value_changed(self, new_val):
         """

--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -1436,8 +1436,6 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         cond &= ev.x() > self.width()/2-self.height()
         if cond:
             self.clicked.emit()
-        else:
-            super().mouseReleaseEvent(ev)
 
     def value_changed(self, new_val):
         """

--- a/pyqt-apps/siriushla/widgets/state_button.py
+++ b/pyqt-apps/siriushla/widgets/state_button.py
@@ -1429,7 +1429,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         self.shape = 0
         self.renderer = QSvgRenderer()
 
-    def mousePressEvent(self, ev):
+    def mouseReleaseEvent(self, ev):
         """Deal with mouse clicks. Only accept clicks within the figure."""
         cond = ev.button() == Qt.LeftButton
         cond &= ev.x() < self.width()/2+self.height()
@@ -1437,7 +1437,7 @@ class PyDMStateButton(QFrame, PyDMWritableWidget):
         if cond:
             self.clicked.emit()
         else:
-            super().mousePressEvent(ev)
+            super().mouseReleaseEvent(ev)
 
     def value_changed(self, new_val):
         """


### PR DESCRIPTION
This PR proposes changing the behavior of PyDMStateButton.

Currently this widget toggle its state with clicks from any mouse button. If this PR is approved, it will respond only to clicks of the left button.
Besides, instead of reacting to the event mousePressEvent, the button now responds to mouseReleaseEvent.