### PR TITLE
Change TL Control HLA

### DIFF
--- a/pyqt-apps/siriushla/as_ap_currlt/ui_bo_ap_currlt.ui
+++ b/pyqt-apps/siriushla/as_ap_currlt/ui_bo_ap_currlt.ui
@@ -40,10 +40,13 @@
      <property name="styleSheet">
       <string notr="true">font-size:24pt;
 font-weight:bold;
-background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
+background-color: qlineargradient(spread:pad, x1:1, y1:0.0227273, x2:0, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
      </property>
      <property name="text">
       <string>BO Current and Lifetime</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -128,10 +131,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <bool>false</bool>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="text">
          <string/>
@@ -172,7 +175,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string notr="true">font-weight:bold;</string>
         </property>
         <property name="text">
-         <string>Lifetime (H:m:s)</string>
+         <string>Lifetime [H:m:s]: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -203,10 +206,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <bool>false</bool>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="text">
          <string/>
@@ -246,7 +249,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string notr="true">font-weight:bold;</string>
         </property>
         <property name="text">
-         <string>Current (mA)</string>
+         <string>Current [mA]: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -425,6 +428,9 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="8" column="2" colspan="5">
        <widget class="QLabel" name="label_7">
+        <property name="styleSheet">
+         <string notr="true">font-weight: bold;</string>
+        </property>
         <property name="text">
          <string>Buffer</string>
         </property>
@@ -482,7 +488,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Size</string>
+         <string>Size: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -505,6 +511,9 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
         <property name="autoFillBackground">
          <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">font-weight: bold;</string>
         </property>
         <property name="text">
          <string>Sampling Time [s]</string>
@@ -643,7 +652,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
       <item row="16" column="3">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Auto Reset</string>
+         <string>Auto Reset: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -671,10 +680,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string/>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -711,10 +720,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <set>Qt::ImhNone</set>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -748,10 +757,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string/>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -779,7 +788,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Max Size</string>
+         <string>Max Size: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -856,10 +865,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
             <string/>
            </property>
            <property name="frameShape">
-            <enum>QFrame::Box</enum>
+            <enum>QFrame::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Plain</enum>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -906,14 +915,17 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
       <string>Graphs Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Time Span [s]</string>
+         <string>Time Span [s]: </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="2">
        <widget class="QSpinBox" name="spinBox_2">
         <property name="minimum">
          <number>1</number>
@@ -929,11 +941,14 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
       <item row="1" column="1">
        <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Buffer Size</string>
+         <string>Buffer Size: </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="2">
+      <item row="4" column="1" colspan="2">
        <spacer name="verticalSpacer_6">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -1004,17 +1019,55 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </spacer>
       </item>
+      <item row="2" column="1" colspan="2">
+       <spacer name="verticalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
    <item row="1" column="8">
     <widget class="QGroupBox" name="groupBox">
+     <property name="maximumSize">
+      <size>
+       <width>560</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="title">
       <string>Current Status</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="2" column="1">
+      <item row="2" column="3">
+       <spacer name="horizontalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="2">
        <widget class="SiriusLedState" name="SiriusLedState_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="minimumSize">
          <size>
           <width>40</width>
@@ -1038,17 +1091,75 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="2" column="1">
        <widget class="QLabel" name="label_8">
         <property name="text">
          <string>Stored EBeam?</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="1" column="1" colspan="2">
+       <spacer name="verticalSpacer_13">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="1">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>DCCT Measure </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <widget class="SiriusLedAlert" name="SiriusLedAlert">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${PREFIX}BO-35D:DI-DCCT:ReliableMeas-Mon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1" colspan="2">
        <spacer name="verticalSpacer_9">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -1064,13 +1175,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </spacer>
       </item>
-      <item row="1" column="0" colspan="2">
-       <spacer name="verticalSpacer_13">
+      <item row="3" column="1" colspan="2">
+       <spacer name="horizontalSpacer_7">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -1092,19 +1200,19 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
  </widget>
  <customwidgets>
   <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
    <class>PyDMTimePlot</class>
    <extends>QGraphicsView</extends>
    <header>pydm.widgets.timeplot</header>
   </customwidget>
   <customwidget>
    <class>PyDMEnumComboBox</class>
-   <extends>QFrame</extends>
+   <extends>QComboBox</extends>
    <header>pydm.widgets.enum_combo_box</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
    <class>PyDMPushButton</class>
@@ -1123,6 +1231,11 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
   </customwidget>
   <customwidget>
    <class>SiriusLedState</class>
+   <extends>PyDMLed</extends>
+   <header>siriushla.widgets.led</header>
+  </customwidget>
+  <customwidget>
+   <class>SiriusLedAlert</class>
    <extends>PyDMLed</extends>
    <header>siriushla.widgets.led</header>
   </customwidget>

--- a/pyqt-apps/siriushla/as_ap_currlt/ui_si_ap_currlt.ui
+++ b/pyqt-apps/siriushla/as_ap_currlt/ui_si_ap_currlt.ui
@@ -63,7 +63,7 @@
       <item row="16" column="3">
        <widget class="QLabel" name="label_6">
         <property name="text">
-         <string>Auto Reset</string>
+         <string>Auto Reset: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -103,6 +103,9 @@
       </item>
       <item row="8" column="2" colspan="5">
        <widget class="QLabel" name="label_7">
+        <property name="styleSheet">
+         <string notr="true">font-weight:bold/</string>
+        </property>
         <property name="text">
          <string>Buffer</string>
         </property>
@@ -129,7 +132,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Max Size</string>
+         <string>Max Size: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -189,10 +192,10 @@
          <string/>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -272,10 +275,10 @@
             <string/>
            </property>
            <property name="frameShape">
-            <enum>QFrame::Box</enum>
+            <enum>QFrame::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Plain</enum>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
@@ -319,7 +322,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Size</string>
+         <string>Size: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -425,10 +428,10 @@
          <string/>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -465,10 +468,10 @@
          <set>Qt::ImhNone</set>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -498,6 +501,9 @@
         <property name="autoFillBackground">
          <bool>false</bool>
         </property>
+        <property name="styleSheet">
+         <string notr="true">font-weight:bold/</string>
+        </property>
         <property name="text">
          <string>Sampling Time [s]</string>
         </property>
@@ -526,10 +532,13 @@
      <property name="styleSheet">
       <string notr="true">font-size:24pt;
 font-weight:bold;
-background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
+background-color: qlineargradient(spread:pad, x1:1, y1:0.0227273, x2:0, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
      </property>
      <property name="text">
       <string>SI Current and Lifetime</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>
@@ -551,19 +560,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
       <string>Graphs Settings</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_5">
-      <item row="2" column="2">
-       <widget class="QSpinBox" name="spinBox_2">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>1000000</number>
-        </property>
-        <property name="value">
-         <number>300</number>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <spacer name="horizontalSpacer_9">
         <property name="orientation">
@@ -576,19 +572,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          </size>
         </property>
        </spacer>
-      </item>
-      <item row="1" column="2">
-       <widget class="QSpinBox" name="spinBox">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>1000000</number>
-        </property>
-        <property name="value">
-         <number>6000</number>
-        </property>
-       </widget>
       </item>
       <item row="0" column="1" colspan="2">
        <spacer name="verticalSpacer_10">
@@ -606,7 +589,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </spacer>
       </item>
-      <item row="3" column="1" colspan="2">
+      <item row="4" column="1" colspan="2">
        <spacer name="verticalSpacer_6">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -622,10 +605,49 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </spacer>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>Time Span [s]</string>
+         <string>Time Span [s]: </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="spinBox">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>6000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Buffer Size: </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QSpinBox" name="spinBox_2">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>300</number>
         </property>
        </widget>
       </item>
@@ -642,12 +664,21 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </spacer>
       </item>
-      <item row="1" column="1">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Buffer Size</string>
+      <item row="2" column="1" colspan="2">
+       <spacer name="verticalSpacer_14">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
-       </widget>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -694,7 +725,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string notr="true">font-weight:bold;</string>
         </property>
         <property name="text">
-         <string>Lifetime (H:m:s)</string>
+         <string>Lifetime [H:m:s]: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -725,10 +756,10 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <bool>false</bool>
         </property>
         <property name="frameShape">
-         <enum>QFrame::Box</enum>
+         <enum>QFrame::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Plain</enum>
         </property>
         <property name="text">
          <string/>
@@ -810,7 +841,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string notr="true">font-weight:bold;</string>
         </property>
         <property name="text">
-         <string>Current (mA)</string>
+         <string>Current [mA]: </string>
         </property>
         <property name="alignment">
          <set>Qt::AlignCenter</set>
@@ -832,37 +863,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          </size>
         </property>
        </spacer>
-      </item>
-      <item row="1" column="6">
-       <widget class="QLabel" name="CurrLT">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>200</width>
-          <height>80</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="autoFillBackground">
-         <bool>false</bool>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Box</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
       </item>
       <item row="1" column="0">
        <spacer name="horizontalSpacer">
@@ -1004,6 +1004,37 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
        </widget>
       </item>
+      <item row="1" column="6">
+       <widget class="QLabel" name="CurrLT">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>200</width>
+          <height>80</height>
+         </size>
+        </property>
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -1028,96 +1059,53 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
       <string>Current Settings and Status</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="4" column="1" colspan="2">
-       <spacer name="verticalSpacer_11">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
+      <item row="13" column="2" colspan="3">
+       <widget class="PyDMLabel" name="PyDMLabel_SelectDCCT">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="1" colspan="2">
-       <spacer name="verticalSpacer_13">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="6" column="1" colspan="2">
-       <spacer name="verticalSpacer_12">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="2">
-       <widget class="SiriusLedState" name="SiriusLedState_2">
         <property name="minimumSize">
          <size>
-          <width>40</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
+          <width>0</width>
+          <height>48</height>
          </size>
         </property>
         <property name="toolTip">
          <string/>
         </property>
         <property name="whatsThis">
-         <string>PyDMLed specialization to represent 2 states in dark/light green.</string>
+         <string/>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="inputMethodHints">
+         <set>Qt::ImhNone</set>
+        </property>
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Plain</enum>
+        </property>
+        <property name="text">
+         <string>PyDMLabel</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="precision" stdset="0">
+         <number>0</number>
         </property>
         <property name="channel" stdset="0">
-         <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:StoredEBeam-Mon</string>
+         <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:DCCT-Sts</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
-       <spacer name="verticalSpacer_9">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::MinimumExpanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>10</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="2">
+      <item row="3" column="2" colspan="3">
        <widget class="QWidget" name="widget" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="leftMargin">
@@ -1173,6 +1161,12 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          </item>
          <item>
           <widget class="SiriusLedState" name="SiriusLedState">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
            <property name="minimumSize">
             <size>
              <width>40</width>
@@ -1199,220 +1193,173 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </layout>
        </widget>
       </item>
+      <item row="1" column="8">
+       <spacer name="horizontalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="4">
+       <spacer name="horizontalSpacer_10">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="13" column="1">
+       <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox_SelectDCCT">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string/>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:DCCT-Sel</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="label_8">
         <property name="text">
          <string>Stored EBeam?</string>
         </property>
         <property name="alignment">
-         <set>Qt::AlignCenter</set>
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="2">
-       <widget class="QFrame" name="frame_DCCT">
+      <item row="0" column="1" colspan="4">
+       <spacer name="verticalSpacer_13">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="16" column="3">
+       <widget class="SiriusLedAlert" name="SiriusLedAlert_DCCT13C4">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <layout class="QGridLayout" name="gridLayout_6">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="2" column="0" colspan="2">
-          <spacer name="verticalSpacer_8">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::MinimumExpanding</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>10</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QLabel" name="label_SelectDCCT">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="autoFillBackground">
-            <bool>false</bool>
-           </property>
-           <property name="text">
-            <string>Select DCCT</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_DCCT14C4">
-           <property name="text">
-            <string>DCCT 14C4 Measure</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="SiriusLedAlert" name="SiriusLedAlert_DCCT13C4">
-           <property name="minimumSize">
-            <size>
-             <width>40</width>
-             <height>40</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>40</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${PREFIX}SI-13C4:DI-DCCT:ReliableMeas-Mon</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="PyDMLabel" name="PyDMLabel_SelectDCCT">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>48</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string/>
-           </property>
-           <property name="autoFillBackground">
-            <bool>false</bool>
-           </property>
-           <property name="inputMethodHints">
-            <set>Qt::ImhNone</set>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::Box</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <property name="text">
-            <string>PyDMLabel</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-           <property name="precision" stdset="0">
-            <number>0</number>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:DCCT-Sts</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QLabel" name="label_DCCT13C4">
-           <property name="text">
-            <string>DCCT 13C4 Measure</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="PyDMEnumComboBox" name="PyDMEnumComboBox_SelectDCCT">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string/>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:DCCT-Sel</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="1">
-          <widget class="SiriusLedAlert" name="SiriusLedAlert_DCCT14C4">
-           <property name="minimumSize">
-            <size>
-             <width>40</width>
-             <height>40</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>16777215</width>
-             <height>40</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${PREFIX}SI-14C4:DI-DCCT:ReliableMeas-Mon</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${PREFIX}SI-13C4:DI-DCCT:ReliableMeas-Mon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="17" column="1" colspan="4">
+       <spacer name="verticalSpacer_12">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="4" column="1" colspan="4">
+       <spacer name="verticalSpacer_11">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1" colspan="4">
+       <spacer name="verticalSpacer_9">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="16" column="1">
+       <widget class="QLabel" name="label_DCCT14C4">
+        <property name="text">
+         <string>DCCT 14C4 Measure</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
        </widget>
       </item>
       <item row="3" column="1">
@@ -1421,9 +1368,154 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          <string>DCCT Fault Check</string>
         </property>
         <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="15" column="3">
+       <widget class="SiriusLedAlert" name="SiriusLedAlert_DCCT14C4">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${PREFIX}SI-14C4:DI-DCCT:ReliableMeas-Mon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="SiriusLedState" name="SiriusLedState_2">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>40</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="whatsThis">
+         <string>PyDMLed specialization to represent 2 states in dark/light green.</string>
+        </property>
+        <property name="channel" stdset="0">
+         <string>ca://${PREFIX}SI-Glob:AP-CurrInfo:StoredEBeam-Mon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="1" colspan="4">
+       <widget class="QLabel" name="label_SelectDCCT">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">font-weight:bold/</string>
+        </property>
+        <property name="text">
+         <string>Select DCCT</string>
+        </property>
+        <property name="alignment">
          <set>Qt::AlignCenter</set>
         </property>
        </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer_7">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="15" column="1">
+       <widget class="QLabel" name="label_DCCT13C4">
+        <property name="text">
+         <string>DCCT 13C4 Measure</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="1" colspan="4">
+       <spacer name="verticalSpacer_8">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::MinimumExpanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>10</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -1437,19 +1529,19 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
  </widget>
  <customwidgets>
   <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
    <class>PyDMTimePlot</class>
    <extends>QGraphicsView</extends>
    <header>pydm.widgets.timeplot</header>
   </customwidget>
   <customwidget>
    <class>PyDMEnumComboBox</class>
-   <extends>QFrame</extends>
+   <extends>QComboBox</extends>
    <header>pydm.widgets.enum_combo_box</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
    <class>PyDMPushButton</class>

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -318,54 +318,88 @@ class TLAPControlWindow(SiriusMainWindow):
         corr_details.setLayout(QGridLayout())
         corr_details.layout().setContentsMargins(0, 0, 0, 0)
 
-        led = SiriusLedState(
-            self, 'ca://' + self.prefix + corr + ':PwrState-Sts')
-        led.setObjectName(
-            'SiriusLed_' + name + '_PwrState_Scrn' + str(scrn))
-        led.setFixedSize(40, 40)
-        corr_details.layout().addWidget(led, 1, 1)
+        if corr.split('-')[0] == 'LA':  # Linac PVs
+            led = SiriusLedState(
+                parent=self,
+                init_channel='ca://'+self.prefix+corr+':setpwm')
+            led.setObjectName(
+                'SiriusLed_Linac'+corr.split('-')[-1]+'_setpwm_Scrn'+str(scrn))
+            led.setFixedSize(40, 40)
+            corr_details.layout().addWidget(led, 1, 1)
 
-        pushbutton = QPushButton(corr, self)
-        pushbutton.setObjectName(
-            'pushButton_' + name + 'App_Scrn' + str(scrn))
-        if corr.split('-')[0] == 'LI':
-            pass
-            # TODO
-        elif corr.split('-')[1].split(':')[1] == 'PM':
-            _hlautil.connect_window(pushbutton,
-                                    PulsedMagnetDetailWindow,
-                                    parent=self, maname=corr)
+            label_corr = QLabel(corr, self, alignment=Qt.AlignCenter)
+            label_corr.setObjectName('label_'+name+'App_Scrn'+str(scrn))
+            label_corr.setFixedSize(300, 40)
+            corr_details.layout().addWidget(label_corr, 1, 2)
+
+            pydm_sp_current = PyDMLinEditScrollbar(
+                parent=self, channel='ca://'+self.prefix+corr+':seti')
+            pydm_sp_current.setObjectName(
+                'LeditScroll_Linac'+corr.split('-')[-1]+'_seti_Scrn'+str(scrn))
+            pydm_sp_current.setMaximumWidth(220)
+            pydm_sp_current.layout.setContentsMargins(0, 0, 0, 0)
+            pydm_sp_current.sp_lineedit.setFixedSize(220, 40)
+            pydm_sp_current.sp_lineedit.setAlignment(Qt.AlignCenter)
+            pydm_sp_current.sp_lineedit.setSizePolicy(
+                QSzPlcy.Minimum, QSzPlcy.Minimum)
+            pydm_sp_current.sp_scrollbar.limitsFromPV = True
+            pydm_sp_current.sp_scrollbar.setSizePolicy(
+                QSzPlcy.Minimum, QSzPlcy.Maximum)
+            corr_details.layout().addWidget(pydm_sp_current, 1, 3, 2, 1)
+
+            pydmlabel_current = PyDMLabel(
+                parent=self, init_channel='ca://'+self.prefix+corr+':rdi')
+            pydmlabel_current.unit_changed('A')
+            pydmlabel_current.showUnits = True
+            pydmlabel_current.setObjectName(
+                'PyDMLabel_Linac'+corr.split('-')[-1]+'_rdi_Scrn'+str(scrn))
+            pydmlabel_current.setFixedSize(180, 40)
+            pydmlabel_current.precFromPV = True
+            pydmlabel_current.setAlignment(Qt.AlignCenter)
+            corr_details.layout().addWidget(pydmlabel_current, 1, 4)
+
         else:
-            _hlautil.connect_window(pushbutton,
-                                    PSDetailWindow,
-                                    parent=self, psname=corr)
-        pushbutton.setFixedSize(300, 40)
-        corr_details.layout().addWidget(pushbutton, 1, 2)
+            led = SiriusLedState(
+                parent=self,
+                init_channel='ca://'+self.prefix+corr+':PwrState-Sts')
+            led.setObjectName('SiriusLed_'+name+'_PwrState_Scrn'+str(scrn))
+            led.setFixedSize(40, 40)
+            corr_details.layout().addWidget(led, 1, 1)
 
-        pydm_sp_kick = PyDMLinEditScrollbar(
-            parent=self,
-            channel='ca://' + self.prefix + corr + ':Kick-SP')
-        pydm_sp_kick.setObjectName(
-            'PyDMLineEdit' + name + '_Kick_SP_Scrn' + str(scrn))
-        pydm_sp_kick.setMaximumWidth(220)
-        pydm_sp_kick.layout.setContentsMargins(0, 0, 0, 0)
-        pydm_sp_kick.sp_lineedit.setFixedSize(220, 40)
-        pydm_sp_kick.sp_lineedit.setAlignment(Qt.AlignCenter)
-        pydm_sp_kick.sp_lineedit.setSizePolicy(
-            QSzPlcy.Minimum, QSzPlcy.Minimum)
-        pydm_sp_kick.sp_scrollbar.limitsFromPV = True
-        pydm_sp_kick.sp_scrollbar.setSizePolicy(
-            QSzPlcy.Minimum, QSzPlcy.Maximum)
-        corr_details.layout().addWidget(pydm_sp_kick, 1, 3, 2, 1)
+            pushbutton = QPushButton(corr, self)
+            pushbutton.setObjectName('pushButton_'+name+'App_Scrn'+str(scrn))
+            if corr.split('-')[1].split(':')[1] == 'PM':
+                _hlautil.connect_window(pushbutton, PulsedMagnetDetailWindow,
+                                        parent=self, maname=corr)
+            else:
+                _hlautil.connect_window(pushbutton, PSDetailWindow,
+                                        parent=self, psname=corr)
+            pushbutton.setFixedSize(300, 40)
+            corr_details.layout().addWidget(pushbutton, 1, 2)
 
-        pydmlabel_kick = PyDMLabel(
-            self, 'ca://' + self.prefix + corr + ':Kick-Mon')
-        pydmlabel_kick.setObjectName(
-            'PyDMLabel_' + name + '_Kick_Mon_Scrn' + str(scrn))
-        pydmlabel_kick.setFixedSize(180, 40)
-        pydmlabel_kick.precFromPV = True
-        pydmlabel_kick.setAlignment(Qt.AlignCenter)
-        corr_details.layout().addWidget(pydmlabel_kick, 1, 4)
+            pydm_sp_kick = PyDMLinEditScrollbar(
+                parent=self, channel='ca://'+self.prefix+corr+':Kick-SP')
+            pydm_sp_kick.setObjectName(
+                'PyDMLineEdit' + name + '_Kick_SP_Scrn' + str(scrn))
+            pydm_sp_kick.setMaximumWidth(220)
+            pydm_sp_kick.layout.setContentsMargins(0, 0, 0, 0)
+            pydm_sp_kick.sp_lineedit.setFixedSize(220, 40)
+            pydm_sp_kick.sp_lineedit.setAlignment(Qt.AlignCenter)
+            pydm_sp_kick.sp_lineedit.setSizePolicy(
+                QSzPlcy.Minimum, QSzPlcy.Minimum)
+            pydm_sp_kick.sp_scrollbar.limitsFromPV = True
+            pydm_sp_kick.sp_scrollbar.setSizePolicy(
+                QSzPlcy.Minimum, QSzPlcy.Maximum)
+            corr_details.layout().addWidget(pydm_sp_kick, 1, 3, 2, 1)
+
+            pydmlabel_kick = PyDMLabel(
+                parent=self, init_channel='ca://'+self.prefix+corr+':Kick-Mon')
+            pydmlabel_kick.setObjectName(
+                'PyDMLabel_' + name + '_Kick_Mon_Scrn' + str(scrn))
+            pydmlabel_kick.setFixedSize(180, 40)
+            pydmlabel_kick.precFromPV = True
+            pydmlabel_kick.setAlignment(Qt.AlignCenter)
+            corr_details.layout().addWidget(pydmlabel_kick, 1, 4)
         corr_details.setSizePolicy(QSzPlcy.Minimum, QSzPlcy.Fixed)
         return corr_details
 
@@ -375,7 +409,7 @@ class TLAPControlWindow(SiriusMainWindow):
             UI_FILE = ('ui_tb_ap_control.ui')
             SVG_FILE = ('TB.svg')
             correctors_list = [
-                [['LI-01:MA-CH-7'], 'LI-01:MA-CV-7', 0, 'TB-01:DI-Scrn-1'],
+                [['LA-CN:H1LCPS-10'], 'LA-CN:H1LCPS-9', 0, 'TB-01:DI-Scrn-1'],
                 [['TB-01:MA-CH-1'], 'TB-01:MA-CV-1', 1, 'TB-01:DI-Scrn-2'],
                 [['TB-01:MA-CH-2'], 'TB-01:MA-CV-2', 2, 'TB-02:DI-Scrn-1'],
                 [['TB-02:MA-CH-1'], 'TB-02:MA-CV-1', 3, 'TB-02:DI-Scrn-2'],

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -183,35 +183,6 @@ class TLAPControlWindow(SiriusMainWindow):
             correctors_gridlayout.addWidget(widget_scrncorr, line, 1)
             line += 1
 
-        hlay_buttonsline = QHBoxLayout()
-        hlay_buttonsline.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        pushbutton_scrnsdohoming = QPushButton('All Screens Do Homing', self)
-        pushbutton_scrnsdohoming.clicked.connect(self._allScrnsDoHoming)
-        pushbutton_scrnsdohoming.setMinimumSize(780, 80)
-        hlay_buttonsline.addWidget(pushbutton_scrnsdohoming)
-        hlay_buttonsline.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        pushbutton_chsturnon = QPushButton('All CHs Turn On', self)
-        pushbutton_chsturnon.clicked.connect(self._allCHsTurnOn)
-        pushbutton_chsturnon.setMinimumSize(740, 80)
-        hlay_buttonsline.addWidget(pushbutton_chsturnon)
-        hlay_buttonsline.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        pushbutton_cvsturnon = QPushButton('All CVs Turn On', self)
-        pushbutton_cvsturnon.clicked.connect(self._allCVsTurnOn)
-        pushbutton_cvsturnon.setMinimumSize(740, 80)
-        hlay_buttonsline.addWidget(pushbutton_cvsturnon)
-        hlay_buttonsline.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        buttonsline = QWidget()
-        buttonsline.setObjectName('buttonsline')
-        buttonsline.setLayout(hlay_buttonsline)
-        buttonsline.setMaximumHeight(98)
-        buttonsline.layout().setContentsMargins(0, 9, 0, 9)
-        buttonsline.setStyleSheet('#buttonsline {border-top: 2px solid gray;}')
-        correctors_gridlayout.addWidget(buttonsline, 8, 1)
-
         self.centralwidget.groupBox_allcorrPanel.setLayout(
             correctors_gridlayout)
         self.centralwidget.groupBox_allcorrPanel.setContentsMargins(0, 0, 0, 0)
@@ -232,6 +203,10 @@ class TLAPControlWindow(SiriusMainWindow):
         pydmcombobox_scrntype.currentIndexChanged.connect(
             self.scrnview_widgets_dict[self._currScrn].
             updateCalibrationGridFlag)
+
+        # Create an action menu
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._show_context_menu)
 
     def _allCHsTurnOn(self):
         for ch_group, _, _, _ in self._corr_devicenames_list:
@@ -493,6 +468,20 @@ class TLAPControlWindow(SiriusMainWindow):
             widget=self.scrnview_widgets_dict[self._currScrn],
             propagate=False)
 
+    @Slot(QPoint)
+    def _show_context_menu(self, point):
+        """Show a custom context menu."""
+        turn_CHs_on = QAction("Turn CHs On", self)
+        turn_CHs_on.triggered.connect(self._allCHsTurnOn)
+        turn_CVs_on = QAction("Turn CVs On", self)
+        turn_CVs_on.triggered.connect(self._allCVsTurnOn)
+        do_scrn_homing = QAction("Screens do Homing", self)
+        do_scrn_homing.triggered.connect(self._allScrnsDoHoming)
+        menu = QMenu("Actions", self)
+        menu.addAction(turn_CHs_on)
+        menu.addAction(turn_CVs_on)
+        menu.addAction(do_scrn_homing)
+        menu.popup(self.mapToGlobal(point))
 
 
 class ShowLatticeAndTwiss(SiriusMainWindow):

--- a/pyqt-apps/siriushla/tl_ap_control/ICT_monitor.py
+++ b/pyqt-apps/siriushla/tl_ap_control/ICT_monitor.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python-sirius
+"""HLA TB and TS ICT monitoring Window."""
+
+import sys
+from qtpy.uic import loadUi
+from qtpy.QtCore import Slot
+from pydm.utilities.macro import substitute_in_file as _substitute_in_file
+from siriuspy.envars import vaca_prefix as _vaca_prefix
+from siriushla.sirius_application import SiriusApplication
+from siriushla.widgets import SiriusMainWindow
+from siriushla import util
+
+
+class ICTMonitoring(SiriusMainWindow):
+    """Class to create ICTs History Monitor Window."""
+
+    def __init__(self, tl, parent=None, prefix=None):
+        """Create graphs."""
+        super(ICTMonitoring, self).__init__(parent)
+        tmp_file = _substitute_in_file(
+            '/home/fac_files/lnls-sirius/hla/pyqt-apps/siriushla'
+            '/tl_ap_control/ui_tl_ap_ictmon.ui', {'TL': tl.upper()})
+        self.centralwidget = loadUi(tmp_file)
+        self.setCentralWidget(self.centralwidget)
+        if tl.upper() == 'TB':
+            ICT1_channel = 'ca://' + prefix + 'TB-02:DI-ICT'
+            ICT2_channel = 'ca://' + prefix + 'TB-04:DI-ICT'
+        elif tl.upper() == 'TS':
+            ICT1_channel = 'ca://' + prefix + 'TS-01:DI-ICT'
+            ICT2_channel = 'ca://' + prefix + 'TS-04:DI-ICT'
+        self.centralwidget.PyDMTimePlot_Charge.addYChannel(
+            y_channel=ICT1_channel + ':Charge-Mon',
+            name='Charge ICT1', color='red', lineWidth=2)
+        self.centralwidget.PyDMTimePlot_Charge.addYChannel(
+            y_channel=ICT2_channel + ':Charge-Mon',
+            name='Charge ICT2', color='blue', lineWidth=2)
+        self.centralwidget.PyDMWaveformPlot_ChargeHstr.addChannel(
+            y_channel=ICT1_channel + ':ChargeHstr-Mon',
+            name='Charge History ICT1', color='red', lineWidth=2)
+        self.centralwidget.PyDMWaveformPlot_ChargeHstr.addChannel(
+            y_channel=ICT2_channel + ':ChargeHstr-Mon',
+            name='Charge History ICT2', color='blue', lineWidth=2)
+
+        self.centralwidget.checkBox.stateChanged.connect(
+            self._setICT1CurveVisibility)
+        self.centralwidget.checkBox_2.stateChanged.connect(
+            self._setICT2CurveVisibility)
+
+    @Slot(int)
+    def _setICT1CurveVisibility(self, value):
+        """Set curves visibility."""
+        self.centralwidget.PyDMTimePlot_Charge._curves[0].setVisible(value)
+        self.centralwidget.PyDMWaveformPlot_ChargeHstr._curves[0].setVisible(
+            value)
+
+    @Slot(int)
+    def _setICT2CurveVisibility(self, value):
+        """Set curves visibility."""
+        self.centralwidget.PyDMTimePlot_Charge._curves[1].setVisible(value)
+        self.centralwidget.PyDMWaveformPlot_ChargeHstr._curves[1].setVisible(
+            value)
+
+
+if __name__ == '__main__':
+    """Run Example."""
+    app = SiriusApplication()
+    util.set_style(app)
+    w = ICTMonitoring(tl='TB', prefix=_vaca_prefix)
+    w.show()
+    sys.exit(app.exec_())

--- a/pyqt-apps/siriushla/tl_ap_control/Slit_monitor.py
+++ b/pyqt-apps/siriushla/tl_ap_control/Slit_monitor.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python-sirius
+"""HLA TB and TS ICT monitoring Window."""
+
+import sys
+from qtpy.uic import loadUi
+from qtpy.QtCore import QPoint
+from qtpy.QtWidgets import QWidget, QVBoxLayout
+from pydm.utilities.macro import substitute_in_file as _substitute_in_file
+from siriuspy.envars import vaca_prefix as _vaca_prefix
+from siriushla.sirius_application import SiriusApplication
+from siriushla.widgets import SiriusMainWindow, SiriusConnectionSignal
+from siriushla import util
+
+
+class SlitMonitoring(QWidget):
+    """Class to create Slits Monitor Widget."""
+
+    def __init__(self, slit_orientation, parent=None, prefix=''):
+        """Init."""
+        super(SlitMonitoring, self).__init__(parent)
+        if not prefix:
+            prefix = _vaca_prefix
+        self.slit_orientation = slit_orientation
+        self._slit_center = 0
+        self._slit_width = 0
+
+        tmp_file = _substitute_in_file(
+            '/home/fac_files/lnls-sirius/hla/pyqt-apps/siriushla/tl_ap_control'
+            '/ui_tb_ap_slit'+slit_orientation.lower()+'mon.ui',
+            {'PREFIX': prefix})
+        self.centralwidget = loadUi(tmp_file)
+        self.setLayout(QVBoxLayout())
+        self.layout().setContentsMargins(0, 0, 0, 0)
+        self.layout().addWidget(self.centralwidget)
+
+        slit_prefix = 'ca://'+prefix+'TB-01:DI-Slit'+slit_orientation.upper()
+        self.conn_slitcenter = SiriusConnectionSignal(
+            slit_prefix+':Center-RB')
+        self.conn_slitcenter.new_value_signal[float].connect(self._setSlitPos)
+        self.conn_slitwidth = SiriusConnectionSignal(
+            slit_prefix+':Width-RB')
+        self.conn_slitwidth.new_value_signal[float].connect(self._setSlitPos)
+
+    def _setSlitPos(self, new_value):
+        """Set Slits Widget positions."""
+        if 'Center' in self.sender().address:
+            self._slit_center = new_value  # considering mm
+        elif 'Width' in self.sender().address:
+            self._slit_width = new_value
+
+        rect_width = 110
+        circle_diameter = 100
+        widget_width = 300
+        vacuum_chamber_diameter = 36  # mm
+
+        xc = (circle_diameter*self._slit_center/vacuum_chamber_diameter
+              + widget_width/2)
+        xw = circle_diameter*self._slit_width/vacuum_chamber_diameter
+
+        if self.slit_orientation == 'H':
+            left = round(xc - rect_width - xw/2)
+            right = round(xc + xw/2)
+            self.centralwidget.PyDMDrawingRectangle_SlitHLeft.move(
+                QPoint(left, (widget_width/2 - rect_width)))
+            self.centralwidget.PyDMDrawingRectangle_SlitHRight.move(
+                QPoint(right, (widget_width/2 - rect_width)))
+        elif self.slit_orientation == 'V':
+            up = round(xc - rect_width - xw/2)
+            down = round(xc + xw/2)
+            self.centralwidget.PyDMDrawingRectangle_SlitVUp.move(
+                QPoint((widget_width/2 - rect_width), up))
+            self.centralwidget.PyDMDrawingRectangle_SlitVDown.move(
+                QPoint((widget_width/2 - rect_width), down))
+
+    def channels(self):
+        """Return channels."""
+        return [self.conn_slitcenter, self.conn_slitwidth]
+
+
+if __name__ == '__main__':
+    """Run Example."""
+    app = SiriusApplication()
+    util.set_style(app)
+    w = SlitMonitoring(slit_orientation='H', prefix=_vaca_prefix)
+    window = SiriusMainWindow()
+    window.setCentralWidget(w)
+    window.setWindowTitle('SlitV Monitor')
+    window.show()
+    sys.exit(app.exec_())

--- a/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_control.ui
+++ b/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_control.ui
@@ -88,7 +88,7 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
         </property>
         <property name="minimumSize">
          <size>
-          <width>600</width>
+          <width>910</width>
           <height>0</height>
          </size>
         </property>
@@ -115,7 +115,135 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
           <string>ICTs</string>
          </attribute>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="8" column="3">
+          <item row="10" column="4" colspan="2">
+           <widget class="PyDMLabel" name="PyDMLabel_ICT2">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+            <property name="text">
+             <string>PyDMLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${PREFIX}TB-04:DI-ICT:Charge-Mon</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="1">
+           <widget class="SiriusLedAlert" name="SiriusLedAlert">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${PREFIX}TB-02:DI-ICT:ReliableMeas-Mon</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="4">
+           <widget class="SiriusLedAlert" name="SiriusLedAlert_2">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${PREFIX}TB-04:DI-ICT:ReliableMeas-Mon</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" colspan="5">
+           <widget class="PyDMLabel" name="PyDMLabel_TransportEfficiency">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+            <property name="text">
+             <string>PyDMLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${PREFIX}TB-Glob:AP-TranspEff:Eff-Mon</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="5">
+           <widget class="QLabel" name="label_ICT2">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Charge ICT2</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="2">
+           <widget class="QLabel" name="label_ICT1">
+            <property name="maximumSize">
+             <size>
+              <width>200</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Charge ICT1</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <spacer name="horizontalSpacer_22">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="10" column="6">
+           <spacer name="horizontalSpacer_23">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="10" column="3">
            <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -124,6 +252,47 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
              <size>
               <width>40</width>
               <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="10" column="1" colspan="2">
+           <widget class="PyDMLabel" name="PyDMLabel_ICT1">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+            <property name="text">
+             <string>PyDMLabel</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignCenter</set>
+            </property>
+            <property name="channel" stdset="0">
+             <string>ca://${PREFIX}TB-02:DI-ICT:Charge-Mon</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="3">
+           <spacer name="verticalSpacer_21">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Maximum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
              </size>
             </property>
            </spacer>
@@ -140,112 +309,12 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
              <string notr="true">font-weight:bold;</string>
             </property>
             <property name="text">
-             <string>Transport Efficiency (%)</string>
+             <string>Transport Efficiency [%]</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignCenter</set>
             </property>
            </widget>
-          </item>
-          <item row="8" column="6">
-           <spacer name="horizontalSpacer_23">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="8" column="0">
-           <spacer name="horizontalSpacer_22">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="5" column="1" colspan="5">
-           <widget class="QFrame" name="frame_TransportEfficiency">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>50</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_15">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="leftMargin">
-              <number>4</number>
-             </property>
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="rightMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_TransportEfficiency">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-Glob:AP-TranspEff:Eff-Mon</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="9" column="3">
-           <spacer name="verticalSpacer_22">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
           <item row="0" column="3">
            <spacer name="verticalSpacer_23">
@@ -263,34 +332,8 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
             </property>
            </spacer>
           </item>
-          <item row="7" column="2">
-           <widget class="QLabel" name="label_ICT1">
-            <property name="maximumSize">
-             <size>
-              <width>200</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Charge ICT1</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="5">
-           <widget class="QLabel" name="label_ICT2">
-            <property name="maximumSize">
-             <size>
-              <width>200</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>Charge ICT2</string>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="3">
-           <spacer name="verticalSpacer_21">
+          <item row="11" column="3">
+           <spacer name="verticalSpacer_22">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -304,130 +347,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
              </size>
             </property>
            </spacer>
-          </item>
-          <item row="7" column="1">
-           <widget class="SiriusLedAlert" name="SiriusLedAlert">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-02:DI-ICT:ReliableMeas-Mon</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="1" colspan="2">
-           <widget class="QFrame" name="frame_ICT1">
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_13">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="leftMargin">
-              <number>4</number>
-             </property>
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="rightMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_ICT1">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-02:DI-ICT:Charge-Mon</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="7" column="4">
-           <widget class="SiriusLedAlert" name="SiriusLedAlert_2">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-04:DI-ICT:ReliableMeas-Mon</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="4" colspan="2">
-           <widget class="QFrame" name="frame_ICT2">
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_14">
-             <property name="spacing">
-              <number>4</number>
-             </property>
-             <property name="leftMargin">
-              <number>4</number>
-             </property>
-             <property name="topMargin">
-              <number>4</number>
-             </property>
-             <property name="rightMargin">
-              <number>4</number>
-             </property>
-             <property name="bottomMargin">
-              <number>4</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_ICT2">
-               <property name="maximumSize">
-                <size>
-                 <width>16777215</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-04:DI-ICT:Charge-Mon</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -436,496 +355,9 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
           <string>SlitH</string>
          </attribute>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="0">
-           <spacer name="verticalSpacer_6">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="2" column="1">
-           <widget class="SiriusLedAlert" name="SiriusLedAlert_3">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-            </property>
-            <property name="shape">
-             <enum>QLed::Round</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Status</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0">
-           <spacer name="verticalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="5" column="0">
-           <spacer name="verticalSpacer_8">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_SlitH_Center">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Width 
- (mm)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="PyDMSpinbox" name="PyDMSpinbox_2">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    A QDoubleSpinBox with support for Channels and more from PyDM.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-01:DI-SlitH:Width-SP</string>
-            </property>
-            <property name="showStepExponent" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="QFrame" name="frame_SlitH_Width_SP">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_29">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_SlitH_Width_RB">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-01:DI-SlitH:Width-RB</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_SlitH_Width">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Center 
- (mm)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="PyDMSpinbox" name="PyDMSpinbox">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    A QDoubleSpinBox with support for Channels and more from PyDM.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-01:DI-SlitH:Center-SP</string>
-            </property>
-            <property name="showStepExponent" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QFrame" name="frame_SlitH_Center_SP">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_31">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_SlitH_Center_RB">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-01:DI-SlitH:Center-RB</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="PyDMPushButton" name="PyDMPushButton">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    Basic PushButton to send a fixed value.
-
-    The PyDMPushButton is meant to hold a specific value, and send that value
-    to a channel when it is clicked, much like the MessageButton does in EDM.
-    The PyDMPushButton works in two different modes of operation, first, a
-    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
-    button is clicked a signal containing this value will be sent to the
-    connected channel. This is the default behavior of the button. However, if
-    the :attr:`.relativeChange` is set to True, the fixed value will be added
-    to the current value of the channel. This means that the button will
-    increment a channel by a fixed amount with every click, a consistent
-    relative move
-
-    Parameters
-    ----------
-    parent : QObject, optional
-        Parent of PyDMPushButton
-
-    label : str, optional
-        String to place on button
-
-    icon : QIcon, optional
-        An Icon to display on the PyDMPushButton
-
-    pressValue : int, float, str
-        Value to be sent when the button is clicked
-
-    relative : bool, optional
-        Choice to have the button perform a relative put, instead of always
-        setting to an absolute value
-
-    init_channel : str, optional
-        ID of channel to manipulate
-
-    </string>
-            </property>
-            <property name="text">
-             <string>Do Homing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <spacer name="verticalSpacer_9">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="3" rowspan="7">
-           <widget class="QWidget" name="widget_2" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>300</width>
-              <height>300</height>
-             </size>
-            </property>
-            <widget class="PyDMDrawingCircle" name="PyDMDrawingCircle">
-             <property name="geometry">
-              <rect>
-               <x>0</x>
-               <y>80</y>
-               <width>300</width>
-               <height>140</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a circle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-            </widget>
-            <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitHLeft">
-             <property name="geometry">
-              <rect>
-               <x>40</x>
-               <y>40</y>
-               <width>110</width>
-               <height>220</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-             <property name="brush" stdset="0">
-              <brush brushstyle="Dense3Pattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>153</green>
-                <blue>116</blue>
-               </color>
-              </brush>
-             </property>
-            </widget>
-            <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitHRight">
-             <property name="geometry">
-              <rect>
-               <x>150</x>
-               <y>40</y>
-               <width>110</width>
-               <height>220</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-             <property name="brush" stdset="0">
-              <brush brushstyle="Dense3Pattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>153</green>
-                <blue>116</blue>
-               </color>
-              </brush>
-             </property>
-            </widget>
+          <item row="0" column="0">
+           <widget class="QWidget" name="widget_SlitH" native="true">
+            <layout class="QGridLayout" name="gridLayout_7"/>
            </widget>
           </item>
          </layout>
@@ -935,499 +367,9 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
           <string>SlitV</string>
          </attribute>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="2" column="2">
-           <widget class="PyDMPushButton" name="PyDMPushButton_2">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    Basic PushButton to send a fixed value.
-
-    The PyDMPushButton is meant to hold a specific value, and send that value
-    to a channel when it is clicked, much like the MessageButton does in EDM.
-    The PyDMPushButton works in two different modes of operation, first, a
-    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
-    button is clicked a signal containing this value will be sent to the
-    connected channel. This is the default behavior of the button. However, if
-    the :attr:`.relativeChange` is set to True, the fixed value will be added
-    to the current value of the channel. This means that the button will
-    increment a channel by a fixed amount with every click, a consistent
-    relative move
-
-    Parameters
-    ----------
-    parent : QObject, optional
-        Parent of PyDMPushButton
-
-    label : str, optional
-        String to place on button
-
-    icon : QIcon, optional
-        An Icon to display on the PyDMPushButton
-
-    pressValue : int, float, str
-        Value to be sent when the button is clicked
-
-    relative : bool, optional
-        Choice to have the button perform a relative put, instead of always
-        setting to an absolute value
-
-    init_channel : str, optional
-        ID of channel to manipulate
-
-    </string>
-            </property>
-            <property name="text">
-             <string>Do Homing</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_SlitV_Center">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Center 
- (mm)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="PyDMSpinbox" name="PyDMSpinbox_3">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    A QDoubleSpinBox with support for Channels and more from PyDM.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-            </property>
-            <property name="precision" stdset="0">
-             <number>0</number>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-01:DI-SlitV:Center-SP</string>
-            </property>
-            <property name="showStepExponent" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QFrame" name="frame_SlitV_Center_RB">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_32">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_SlitV_Center_RB">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-01:DI-SlitV:Center-RB</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="6" column="0">
-           <widget class="QLabel" name="label_SlitV_Width">
-            <property name="minimumSize">
-             <size>
-              <width>120</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Width 
- (mm)</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="1">
-           <widget class="PyDMSpinbox" name="PyDMSpinbox_4">
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>
-    A QDoubleSpinBox with support for Channels and more from PyDM.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-            </property>
-            <property name="channel" stdset="0">
-             <string>ca://${PREFIX}TB-01:DI-SlitV:Width-SP</string>
-            </property>
-            <property name="showStepExponent" stdset="0">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="2">
-           <widget class="QFrame" name="frame_SlitV_SlitV_Width_RB">
-            <property name="minimumSize">
-             <size>
-              <width>200</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::Box</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Raised</enum>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_30">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="PyDMLabel" name="PyDMLabel_SlitV_Width_RB">
-               <property name="maximumSize">
-                <size>
-                 <width>150</width>
-                 <height>16777215</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string/>
-               </property>
-               <property name="whatsThis">
-                <string/>
-               </property>
-               <property name="text">
-                <string>PyDMLabel</string>
-               </property>
-               <property name="alignment">
-                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-               </property>
-               <property name="channel" stdset="0">
-                <string>ca://${PREFIX}TB-01:DI-SlitV:Width-RB</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="styleSheet">
-             <string notr="true">font-weight:bold;</string>
-            </property>
-            <property name="text">
-             <string>Status</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="SiriusLedAlert" name="SiriusLedAlert_4">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>40</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string/>
-            </property>
-            <property name="whatsThis">
-             <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-            </property>
-            <property name="shape">
-             <enum>QLed::Round</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <spacer name="verticalSpacer_10">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="3" column="0">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="5" column="0">
-           <spacer name="verticalSpacer_4">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="7" column="0">
-           <spacer name="verticalSpacer_5">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeType">
-             <enum>QSizePolicy::Maximum</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item row="1" column="3" rowspan="7">
-           <widget class="QWidget" name="widget_3" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>300</width>
-              <height>300</height>
-             </size>
-            </property>
-            <widget class="PyDMDrawingCircle" name="PyDMDrawingCircle_2">
-             <property name="geometry">
-              <rect>
-               <x>80</x>
-               <y>0</y>
-               <width>140</width>
-               <height>300</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a circle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-            </widget>
-            <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitVDown">
-             <property name="geometry">
-              <rect>
-               <x>40</x>
-               <y>150</y>
-               <width>220</width>
-               <height>110</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-             <property name="brush" stdset="0">
-              <brush brushstyle="Dense3Pattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>153</green>
-                <blue>116</blue>
-               </color>
-              </brush>
-             </property>
-            </widget>
-            <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitVUp">
-             <property name="geometry">
-              <rect>
-               <x>40</x>
-               <y>40</y>
-               <width>220</width>
-               <height>110</height>
-              </rect>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string/>
-             </property>
-             <property name="whatsThis">
-              <string>
-    A widget with a rectangle drawn in it.
-    This class inherits from PyDMDrawing.
-
-    Parameters
-    ----------
-    parent : QWidget
-        The parent widget for the Label
-    init_channel : str, optional
-        The channel to be used by the widget.
-    </string>
-             </property>
-             <property name="brush" stdset="0">
-              <brush brushstyle="Dense3Pattern">
-               <color alpha="255">
-                <red>119</red>
-                <green>153</green>
-                <blue>116</blue>
-               </color>
-              </brush>
-             </property>
-            </widget>
+          <item row="0" column="0">
+           <widget class="QWidget" name="widget_SlitV" native="true">
+            <layout class="QGridLayout" name="gridLayout_6"/>
            </widget>
           </item>
          </layout>
@@ -1470,8 +412,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
           <height>16777215</height>
          </size>
         </property>
-        <zorder>tabWidget</zorder>
-        <zorder>tabWidget</zorder>
        </widget>
       </item>
      </layout>
@@ -1595,29 +535,9 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMDrawingCircle</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.drawing</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMDrawingRectangle</class>
-   <extends>QWidget</extends>
-   <header>pydm.widgets.drawing</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMPushButton</class>
-   <extends>QPushButton</extends>
-   <header>pydm.widgets.pushbutton</header>
-  </customwidget>
-  <customwidget>
-   <class>PyDMSpinbox</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>pydm.widgets.spinbox</header>
   </customwidget>
   <customwidget>
    <class>PyDMLed</class>

--- a/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_slithmon.ui
+++ b/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_slithmon.ui
@@ -1,0 +1,486 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>815</width>
+    <height>318</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">font-size:20pt;</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <spacer name="verticalSpacer_9">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="3" rowspan="7">
+    <widget class="QWidget" name="widget_2" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>300</height>
+      </size>
+     </property>
+     <widget class="PyDMDrawingCircle" name="PyDMDrawingCircle">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>100</y>
+        <width>300</width>
+        <height>100</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a circle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+     </widget>
+     <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitHLeft">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>40</y>
+        <width>110</width>
+        <height>220</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+      <property name="brush" stdset="0">
+       <brush brushstyle="Dense3Pattern">
+        <color alpha="255">
+         <red>119</red>
+         <green>153</green>
+         <blue>116</blue>
+        </color>
+       </brush>
+      </property>
+     </widget>
+     <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitHRight">
+      <property name="geometry">
+       <rect>
+        <x>150</x>
+        <y>40</y>
+        <width>110</width>
+        <height>220</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+      <property name="brush" stdset="0">
+       <brush brushstyle="Dense3Pattern">
+        <color alpha="255">
+         <red>119</red>
+         <green>153</green>
+         <blue>116</blue>
+        </color>
+       </brush>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Status</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="SiriusLedAlert" name="SiriusLedAlert_3">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+     </property>
+     <property name="shape">
+      <enum>QLed::Round</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="PyDMPushButton" name="PyDMPushButton">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Basic PushButton to send a fixed value.
+
+    The PyDMPushButton is meant to hold a specific value, and send that value
+    to a channel when it is clicked, much like the MessageButton does in EDM.
+    The PyDMPushButton works in two different modes of operation, first, a
+    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
+    button is clicked a signal containing this value will be sent to the
+    connected channel. This is the default behavior of the button. However, if
+    the :attr:`.relativeChange` is set to True, the fixed value will be added
+    to the current value of the channel. This means that the button will
+    increment a channel by a fixed amount with every click, a consistent
+    relative move
+
+    Parameters
+    ----------
+    parent : QObject, optional
+        Parent of PyDMPushButton
+
+    label : str, optional
+        String to place on button
+
+    icon : QIcon, optional
+        An Icon to display on the PyDMPushButton
+
+    pressValue : int, float, str
+        Value to be sent when the button is clicked
+
+    relative : bool, optional
+        Choice to have the button perform a relative put, instead of always
+        setting to an absolute value
+
+    init_channel : str, optional
+        ID of channel to manipulate
+
+    </string>
+     </property>
+     <property name="text">
+      <string>Do Homing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_6">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_SlitH_Width">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Center 
+ [mm]</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="PyDMSpinbox" name="PyDMSpinbox">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QDoubleSpinBox with support for Channels and more from PyDM.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitH:Center-SP</string>
+     </property>
+     <property name="showStepExponent" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_SlitH_Center_RB">
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="text">
+      <string>PyDMLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitH:Center-RB</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer_8">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_SlitH_Center">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Width 
+ [mm]</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="PyDMSpinbox" name="PyDMSpinbox_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QDoubleSpinBox with support for Channels and more from PyDM.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitH:Width-SP</string>
+     </property>
+     <property name="showStepExponent" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_SlitH_Width_RB">
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="text">
+      <string>PyDMLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitH:Width-RB</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer_7">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingCircle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingRectangle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMSpinbox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>pydm.widgets.spinbox</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLed</class>
+   <extends>QLed</extends>
+   <header>siriushla.widgets.led</header>
+  </customwidget>
+  <customwidget>
+   <class>SiriusLedAlert</class>
+   <extends>PyDMLed</extends>
+   <header>siriushla.widgets.led</header>
+  </customwidget>
+  <customwidget>
+   <class>QLed</class>
+   <extends>QFrame</extends>
+   <header>siriushla.widgets.QLed</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_slitvmon.ui
+++ b/pyqt-apps/siriushla/tl_ap_control/ui_tb_ap_slitvmon.ui
@@ -1,0 +1,489 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>815</width>
+    <height>318</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">font-size:20pt;</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <spacer name="verticalSpacer_10">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="3" rowspan="7">
+    <widget class="QWidget" name="widget_3" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>300</width>
+       <height>300</height>
+      </size>
+     </property>
+     <widget class="PyDMDrawingCircle" name="PyDMDrawingCircle_2">
+      <property name="geometry">
+       <rect>
+        <x>100</x>
+        <y>0</y>
+        <width>100</width>
+        <height>300</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a circle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+     </widget>
+     <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitVDown">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>150</y>
+        <width>220</width>
+        <height>110</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+      <property name="brush" stdset="0">
+       <brush brushstyle="Dense3Pattern">
+        <color alpha="255">
+         <red>119</red>
+         <green>153</green>
+         <blue>116</blue>
+        </color>
+       </brush>
+      </property>
+     </widget>
+     <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle_SlitVUp">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>40</y>
+        <width>220</width>
+        <height>110</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="whatsThis">
+       <string>
+    A widget with a rectangle drawn in it.
+    This class inherits from PyDMDrawing.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+      </property>
+      <property name="brush" stdset="0">
+       <brush brushstyle="Dense3Pattern">
+        <color alpha="255">
+         <red>119</red>
+         <green>153</green>
+         <blue>116</blue>
+        </color>
+       </brush>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Status</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="SiriusLedAlert" name="SiriusLedAlert_4">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>40</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+     </property>
+     <property name="shape">
+      <enum>QLed::Round</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="PyDMPushButton" name="PyDMPushButton_2">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    Basic PushButton to send a fixed value.
+
+    The PyDMPushButton is meant to hold a specific value, and send that value
+    to a channel when it is clicked, much like the MessageButton does in EDM.
+    The PyDMPushButton works in two different modes of operation, first, a
+    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
+    button is clicked a signal containing this value will be sent to the
+    connected channel. This is the default behavior of the button. However, if
+    the :attr:`.relativeChange` is set to True, the fixed value will be added
+    to the current value of the channel. This means that the button will
+    increment a channel by a fixed amount with every click, a consistent
+    relative move
+
+    Parameters
+    ----------
+    parent : QObject, optional
+        Parent of PyDMPushButton
+
+    label : str, optional
+        String to place on button
+
+    icon : QIcon, optional
+        An Icon to display on the PyDMPushButton
+
+    pressValue : int, float, str
+        Value to be sent when the button is clicked
+
+    relative : bool, optional
+        Choice to have the button perform a relative put, instead of always
+        setting to an absolute value
+
+    init_channel : str, optional
+        ID of channel to manipulate
+
+    </string>
+     </property>
+     <property name="text">
+      <string>Do Homing</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_SlitV_Center">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Center 
+ [mm]</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="PyDMSpinbox" name="PyDMSpinbox_3">
+     <property name="minimumSize">
+      <size>
+       <width>200</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QDoubleSpinBox with support for Channels and more from PyDM.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="precision" stdset="0">
+      <number>0</number>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitV:Center-SP</string>
+     </property>
+     <property name="showStepExponent" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_SlitV_Center_RB">
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="text">
+      <string>PyDMLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitV:Center-RB</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_SlitV_Width">
+     <property name="minimumSize">
+      <size>
+       <width>120</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font-weight:bold;</string>
+     </property>
+     <property name="text">
+      <string>Width 
+ [mm]</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
+    <widget class="PyDMSpinbox" name="PyDMSpinbox_4">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string>
+    A QDoubleSpinBox with support for Channels and more from PyDM.
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitV:Width-SP</string>
+     </property>
+     <property name="showStepExponent" stdset="0">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="PyDMLabel" name="PyDMLabel_SlitV_Width_RB">
+     <property name="maximumSize">
+      <size>
+       <width>150</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="text">
+      <string>PyDMLabel</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="channel" stdset="0">
+      <string>ca://${PREFIX}TB-01:DI-SlitV:Width-RB</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <spacer name="verticalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Maximum</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingCircle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMDrawingRectangle</class>
+   <extends>QWidget</extends>
+   <header>pydm.widgets.drawing</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMPushButton</class>
+   <extends>QPushButton</extends>
+   <header>pydm.widgets.pushbutton</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMSpinbox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>pydm.widgets.spinbox</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLed</class>
+   <extends>QLed</extends>
+   <header>siriushla.widgets.led</header>
+  </customwidget>
+  <customwidget>
+   <class>SiriusLedAlert</class>
+   <extends>PyDMLed</extends>
+   <header>siriushla.widgets.led</header>
+  </customwidget>
+  <customwidget>
+   <class>QLed</class>
+   <extends>QFrame</extends>
+   <header>siriushla.widgets.QLed</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/pyqt-apps/siriushla/tl_ap_control/ui_tl_ap_ictmon.ui
+++ b/pyqt-apps/siriushla/tl_ap_control/ui_tl_ap_ictmon.ui
@@ -34,10 +34,13 @@
      <property name="styleSheet">
       <string notr="true">font-size:24pt;
 font-weight:bold;
-background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
+background-color: qlineargradient(spread:pad, x1:1, y1:0.0227273, x2:0, y2:0, stop:0 rgba(173, 190, 207, 255), stop:1 rgba(213, 213, 213, 255));</string>
      </property>
      <property name="text">
       <string>${TL} ICTs Monitor</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
      </property>
     </widget>
    </item>

--- a/pyqt-apps/siriushla/tl_ap_control/ui_ts_ap_control.ui
+++ b/pyqt-apps/siriushla/tl_ap_control/ui_ts_ap_control.ui
@@ -134,184 +134,6 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
          </size>
         </property>
         <layout class="QGridLayout" name="gridLayout">
-         <item row="6" column="3">
-          <spacer name="horizontalSpacer_19">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="6" column="1" colspan="2">
-          <widget class="QFrame" name="frame_ICT1_9">
-           <property name="frameShape">
-            <enum>QFrame::Box</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_26">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="PyDMLabel" name="PyDMLabel_ICT1_9">
-              <property name="maximumSize">
-               <size>
-                <width>160</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="whatsThis">
-               <string/>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="channel" stdset="0">
-               <string>ca://${PREFIX}TS-01:DI-ICT:Charge-Mon</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="7" column="3">
-          <spacer name="verticalSpacer_19">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="0" column="3">
-          <spacer name="verticalSpacer_20">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="6" column="6">
-          <spacer name="horizontalSpacer_22">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-         <item row="5" column="1">
-          <widget class="SiriusLedAlert" name="SiriusLedAlert">
-           <property name="toolTip">
-            <string/>
-           </property>
-           <property name="whatsThis">
-            <string>PyDMLed specialization to represent 2 states in red/light green.</string>
-           </property>
-           <property name="channel" stdset="0">
-            <string>ca://${PREFIX}TS-01:DI-ICT:ReliableMeas-Mon</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1" colspan="5">
-          <widget class="QFrame" name="frame_TransportEfficiency_3">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>0</width>
-             <height>50</height>
-            </size>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::Box</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_28">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="PyDMLabel" name="PyDMLabel_TransportEfficiency_3">
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="whatsThis">
-               <string/>
-              </property>
-              <property name="text">
-               <string>PyDMLabel</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignCenter</set>
-              </property>
-              <property name="channel" stdset="0">
-               <string>ca://${PREFIX}TS-Glob:AP-TranspEff:Eff-Mon</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
          <item row="2" column="1" colspan="5">
           <widget class="QLabel" name="label_Efficiency_2">
            <property name="maximumSize">
@@ -324,85 +146,35 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
             <string notr="true">font-weight:bold;</string>
            </property>
            <property name="text">
-            <string>Transport Efficiency</string>
+            <string>Transport Efficiency [%]</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
-         <item row="5" column="2">
-          <widget class="QLabel" name="label_ICT1_3">
+         <item row="3" column="1" colspan="5">
+          <widget class="PyDMLabel" name="PyDMLabel_TransportEfficiency_3">
            <property name="maximumSize">
             <size>
-             <width>200</width>
+             <width>16777215</width>
              <height>16777215</height>
             </size>
            </property>
-           <property name="text">
-            <string>Charge ICT1</string>
+           <property name="toolTip">
+            <string/>
            </property>
-          </widget>
-         </item>
-         <item row="6" column="4" colspan="2">
-          <widget class="QFrame" name="frame_ICT2_3">
-           <property name="frameShape">
-            <enum>QFrame::Box</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_27">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="PyDMLabel" name="PyDMLabel_ICT2_3">
-              <property name="maximumSize">
-               <size>
-                <width>160</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string/>
-              </property>
-              <property name="whatsThis">
-               <string/>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-              </property>
-              <property name="channel" stdset="0">
-               <string>ca://${PREFIX}TS-04:DI-ICT:Charge-Mon</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="5" column="5">
-          <widget class="QLabel" name="label_ICT2_3">
-           <property name="maximumSize">
-            <size>
-             <width>200</width>
-             <height>16777215</height>
-            </size>
+           <property name="whatsThis">
+            <string/>
            </property>
            <property name="text">
-            <string>Charge ICT2</string>
+            <string>PyDMLabel</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${PREFIX}TS-Glob:AP-TranspEff:Eff-Mon</string>
            </property>
           </widget>
          </item>
@@ -419,6 +191,71 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
            </property>
           </widget>
          </item>
+         <item row="5" column="2">
+          <widget class="QLabel" name="label_ICT1_3">
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Charge ICT1</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="SiriusLedAlert" name="SiriusLedAlert">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>PyDMLed specialization to represent 2 states in red/light green.</string>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${PREFIX}TS-01:DI-ICT:ReliableMeas-Mon</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="3">
+          <spacer name="verticalSpacer_19">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="5" column="5">
+          <widget class="QLabel" name="label_ICT2_3">
+           <property name="maximumSize">
+            <size>
+             <width>200</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Charge ICT2</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <spacer name="verticalSpacer_20">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
          <item row="4" column="3">
           <spacer name="verticalSpacer_21">
            <property name="orientation">
@@ -432,8 +269,78 @@ background-color: qlineargradient(spread:pad, x1:0, y1:0.0227273, x2:1, y2:0, st
            </property>
           </spacer>
          </item>
+         <item row="6" column="4" colspan="2">
+          <widget class="PyDMLabel" name="PyDMLabel_ICT2_3">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${PREFIX}TS-04:DI-ICT:Charge-Mon</string>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1" colspan="2">
+          <widget class="PyDMLabel" name="PyDMLabel_ICT1_9">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+           <property name="channel" stdset="0">
+            <string>ca://${PREFIX}TS-01:DI-ICT:Charge-Mon</string>
+           </property>
+          </widget>
+         </item>
          <item row="6" column="0">
           <spacer name="horizontalSpacer_23">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="6" column="3">
+          <spacer name="horizontalSpacer_19">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="6" column="6">
+          <spacer name="horizontalSpacer_22">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>

--- a/pyqt-apps/siriushla/widgets/scrn_view.py
+++ b/pyqt-apps/siriushla/widgets/scrn_view.py
@@ -1,8 +1,8 @@
 """SiriusScrnView widget."""
 
-import numpy as np
 import time
 from threading import Thread
+import numpy as np
 from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QFormLayout, \
                             QSpacerItem, QWidget, QGroupBox, QLabel, \
                             QComboBox, QPushButton, QCheckBox, QMessageBox, \
@@ -332,9 +332,8 @@ class SiriusScrnView(QWidget):
         else:
             self.prefix = prefix
         self.device = device
+        self.scrn_prefix = 'ca://'+self.prefix+self.device
         self._calibrationgrid_flag = False
-        self.setLayout(QGridLayout())
-        self.setStyleSheet("""font-size:20pt;""")
         self._setupUi()
 
     @property
@@ -354,6 +353,8 @@ class SiriusScrnView(QWidget):
                 self.pushbutton_savegrid.setEnabled(False)
 
     def _setupUi(self):
+        self.setLayout(QGridLayout())
+
         self.cameraview_widget = QWidget()
         self.cameraview_widget.setLayout(self._cameraviewLayout())
         self.layout().addWidget(self.cameraview_widget, 1, 1, 1, 3)
@@ -363,11 +364,11 @@ class SiriusScrnView(QWidget):
         self.calibrationgrid_widget = QWidget()
         self.calibrationgrid_widget.setLayout(self._calibrationgridLayout())
         self.calibrationgrid_widget.layout().setAlignment(Qt.AlignHCenter)
-        self.imagesettings_widget = QWidget()
-        self.imagesettings_widget.setLayout(self._imagesettingsLayout())
+        self.enablecam_widget = QWidget()
+        self.enablecam_widget.setLayout(self._enablecamLayout())
         layout_container.addWidget(self.calibrationgrid_widget)
         layout_container.setStretch(1, 2)
-        layout_container.addWidget(self.imagesettings_widget)
+        layout_container.addWidget(self.enablecam_widget)
         layout_container.setStretch(2, 1)
         container.setLayout(layout_container)
         self.layout().addWidget(container, 2, 1, 1, 3)
@@ -404,205 +405,177 @@ class SiriusScrnView(QWidget):
             QSpacerItem(40, 20, QSzPlcy.Fixed, QSzPlcy.Expanding), 7, 2)
 
     def _cameraviewLayout(self):
-        layout = QGridLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
         label = QLabel(self.device, self)
         label.setStyleSheet("""font-weight: bold;""")
         label.setAlignment(Qt.AlignCenter)
-        layout.addWidget(label, 0, 1)
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 1, 1)
         self.image_view = _SiriusImageView(
             parent=self,
-            image_channel='ca://'+self.prefix+self.device+':ImgData-Mon',
-            width_channel='ca://'+self.prefix+self.device+':ImgROIWidth-RB',
-            offsetx_channel='ca://'+self.prefix+self.device +
-                            ':ImgROIOffsetX-RB',
-            offsety_channel='ca://'+self.prefix+self.device +
-                            ':ImgROIOffsetY-RB',
-            maxwidth_channel='ca://'+self.prefix+self.device +
-                            ':ImgMaxWidth-Cte',
-            maxheight_channel='ca://'+self.prefix+self.device +
-                            ':ImgMaxHeight-Cte')
+            image_channel=self.scrn_prefix+':ImgData-Mon',
+            width_channel=self.scrn_prefix+':ImgROIWidth-RB',
+            offsetx_channel=self.scrn_prefix+':ImgROIOffsetX-RB',
+            offsety_channel=self.scrn_prefix+':ImgROIOffsetY-RB',
+            maxwidth_channel=self.scrn_prefix+':ImgMaxWidth-Cte',
+            maxheight_channel=self.scrn_prefix+':ImgMaxHeight-Cte')
         self.image_view.normalizeData = True
         self.image_view.readingOrder = self.image_view.Clike
         self.image_view.maxRedrawRate = 15
         self.image_view.setMinimumSize(920, 736)
         self.image_view.failToSaveGrid.connect(self._showFailToSaveGridMsg)
-        layout.addWidget(self.image_view, 2, 1)
-        return layout
+
+        lay = QGridLayout()
+        lay.setContentsMargins(0, 0, 0, 0)
+        lay.addWidget(label, 0, 1)
+        lay.addItem(QSpacerItem(40, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 1, 1)
+        lay.addWidget(self.image_view, 2, 1)
+        return lay
 
     def _calibrationgridLayout(self):
-        layout = QHBoxLayout()
         self.checkBox_showgrid = QCheckBox('Show grid', self)
         self.checkBox_showgrid.toggled.connect(
             self.image_view.showCalibrationGrid)
-        layout.addWidget(self.checkBox_showgrid)
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
         self.pushbutton_savegrid = QPushButton('Save grid', self)
         self.pushbutton_savegrid.setEnabled(False)
         self.pushbutton_savegrid.setMinimumHeight(40)
         self.pushbutton_savegrid.clicked.connect(self._saveCalibrationGrid)
-        layout.addWidget(self.pushbutton_savegrid)
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        label = QLabel('LED: ', self, alignment=Qt.AlignRight)
-        layout.addWidget(label)
+        label = QLabel('LED: ', self, alignment=Qt.AlignRight | Qt.AlignBottom)
         self.PyDMStateButton_EnblLED = PyDMStateButton(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':EnblLED-Sel')
+            parent=self, init_channel=self.scrn_prefix+':EnblLED-Sel')
         self.PyDMStateButton_EnblLED.shape = 1
         self.PyDMStateButton_EnblLED.setMaximumHeight(40)
         self.PyDMStateButton_EnblLED.setSizePolicy(
             QSzPlcy.Fixed, QSzPlcy.Maximum)
-        layout.addWidget(self.PyDMStateButton_EnblLED)
         self.SiriusLedState_EnblLED = SiriusLedState(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':EnblLED-Sts')
+            parent=self, init_channel=self.scrn_prefix+':EnblLED-Sts')
         self.SiriusLedState_EnblLED.setFixedSize(40, 40)
         self.SiriusLedState_EnblLED.setSizePolicy(
             QSzPlcy.Minimum, QSzPlcy.Maximum)
-        layout.addWidget(self.SiriusLedState_EnblLED)
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-        layout.setAlignment(Qt.AlignVCenter)
-        return layout
 
-    def _imagesettingsLayout(self):
-        layout = QGridLayout()
-        label = QLabel('Zoom: ', self, alignment=Qt.AlignRight)
-        layout.addWidget(label, 1, 1)
-        self.pushButton_zoomOut = QPushButton('-', parent=self)
-        self.pushButton_zoomOut.clicked.connect(self._zoomOut)
-        self.pushButton_zoomOut.setFixedSize(40, 40)
-        layout.addWidget(self.pushButton_zoomOut, 1, 2)
-        self.pushButton_zoomActualSize = QPushButton('100%', parent=self)
-        self.pushButton_zoomActualSize.clicked.connect(
-            self._zoomToActualSize)
-        self.pushButton_zoomActualSize.setFixedSize(80, 40)
-        layout.addWidget(self.pushButton_zoomActualSize, 1, 3)
-        self.pushButton_zoomIn = QPushButton('+', parent=self)
-        self.pushButton_zoomIn.clicked.connect(self._zoomIn)
-        self.pushButton_zoomIn.setFixedSize(40, 40)
-        layout.addWidget(self.pushButton_zoomIn, 1, 4)
-        return layout
+        lay = QHBoxLayout()
+        lay.addWidget(self.checkBox_showgrid)
+        lay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        lay.addWidget(self.pushbutton_savegrid)
+        lay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        lay.addWidget(label)
+        lay.addWidget(self.PyDMStateButton_EnblLED)
+        lay.addWidget(self.SiriusLedState_EnblLED)
+        lay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        lay.setAlignment(Qt.AlignVCenter)
+        return lay
+
+    def _enablecamLayout(self):
+        label = QLabel('CamEnbl: ', self,
+                       alignment=Qt.AlignRight | Qt.AlignBottom)
+        self.PyDMStateButton_CamEnbl = PyDMStateButton(
+            parent=self, init_channel=self.scrn_prefix+':CamEnbl-Sel')
+        self.PyDMStateButton_CamEnbl.shape = 1
+        self.PyDMStateButton_CamEnbl.setFixedHeight(40)
+        self.SiriusLedState_CamEnbl = SiriusLedState(
+            parent=self, init_channel=self.scrn_prefix+':CamEnbl-Sts')
+        self.SiriusLedState_CamEnbl.setFixedHeight(40)
+
+        lay = QHBoxLayout()
+        lay.addWidget(label)
+        lay.addWidget(self.PyDMStateButton_CamEnbl)
+        lay.addWidget(self.SiriusLedState_CamEnbl)
+        return lay
 
     def _camerasettingsLayout(self):
-        layout = QGridLayout()
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 2, 1)
-
-        label = QLabel('Gain', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 3, 1, 1, 2)
+        label_CamGain = QLabel('Gain', self, alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_CamGain = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamGain-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamGain-SP')
         self.PyDMSpinbox_CamGain.setMaximumSize(220, 40)
         self.PyDMSpinbox_CamGain.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_CamGain.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_CamGain, 4, 1)
         self.PyDMLabel_CamGain = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamGain-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamGain-RB')
         self.PyDMLabel_CamGain.setMaximumSize(220, 40)
         self.PyDMLabel_CamGain.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_CamGain, 4, 2)
 
-        label = QLabel('Exposure Time', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 5, 1, 1, 2)
+        label_CamExposureTime = QLabel('Exposure Time', self,
+                                       alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_CamExposureTime = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureTime-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureTime-SP')
         self.PyDMSpinbox_CamExposureTime.setMaximumSize(220, 40)
         self.PyDMSpinbox_CamExposureTime.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_CamExposureTime.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_CamExposureTime, 6, 1)
         self.PyDMLabel_CamExposureTime = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureTime-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureTime-RB')
         self.PyDMLabel_CamExposureTime.setMaximumSize(220, 40)
         self.PyDMLabel_CamExposureTime.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_CamExposureTime, 6, 2)
 
-        label = QLabel('ROI Offset X', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 7, 1, 1, 2)
+        label_ROIOffsetX = QLabel('ROI Offset X', self,
+                                  alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_ROIOffsetX = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetX-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetX-SP')
         self.PyDMSpinbox_ROIOffsetX.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIOffsetX.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIOffsetX.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_ROIOffsetX, 8, 1)
         self.PyDMLabel_ROIOffsetX = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetX-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetX-RB')
         self.PyDMLabel_ROIOffsetX.setMaximumSize(220, 40)
         self.PyDMLabel_ROIOffsetX.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_ROIOffsetX, 8, 2)
 
-        label = QLabel('ROI Offset Y', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 9, 1, 1, 2)
+        label_ROIOffsetY = QLabel('ROI Offset Y', self,
+                                  alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_ROIOffsetY = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetY-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetY-SP')
         self.PyDMSpinbox_ROIOffsetY.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIOffsetY.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIOffsetY.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_ROIOffsetY, 10, 1)
         self.PyDMLabel_ROIOffsetY = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetY-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetY-RB')
         self.PyDMLabel_ROIOffsetY.setMaximumSize(220, 40)
         self.PyDMLabel_ROIOffsetY.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_ROIOffsetY, 10, 2)
 
-        label = QLabel('ROI Width', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 11, 1, 1, 2)
+        label_ROIWidth = QLabel('ROI Width', self, alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_ROIWidth = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIWidth-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIWidth-SP')
         self.PyDMSpinbox_ROIWidth.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIWidth.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIWidth.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_ROIWidth, 12, 1)
         self.PyDMLabel_ROIWidth = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIWidth-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIWidth-RB')
         self.PyDMLabel_ROIWidth.setMaximumSize(220, 40)
         self.PyDMLabel_ROIWidth.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_ROIWidth, 12, 2)
 
-        label = QLabel('ROI Heigth', self, alignment=Qt.AlignHCenter)
-        layout.addWidget(label, 13, 1, 1, 2)
+        label_ROIHeight = QLabel('ROI Heigth', self, alignment=Qt.AlignHCenter)
         self.PyDMSpinbox_ROIHeight = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIHeight-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIHeight-SP')
         self.PyDMSpinbox_ROIHeight.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIHeight.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIHeight.showStepExponent = False
-        layout.addWidget(self.PyDMSpinbox_ROIHeight, 14, 1)
         self.PyDMLabel_ROIHeight = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIHeight-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIHeight-RB')
         self.PyDMLabel_ROIHeight.setMaximumSize(220, 40)
         self.PyDMLabel_ROIHeight.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.PyDMLabel_ROIHeight, 14, 2)
 
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 15, 1)
-
-        return layout
+        lay = QGridLayout()
+        lay.addItem(QSpacerItem(4, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 2, 1)
+        lay.addWidget(label_CamGain, 3, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_CamGain, 4, 1)
+        lay.addWidget(self.PyDMLabel_CamGain, 4, 2)
+        lay.addWidget(label_CamExposureTime, 5, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_CamExposureTime, 6, 1)
+        lay.addWidget(self.PyDMLabel_CamExposureTime, 6, 2)
+        lay.addWidget(label_ROIOffsetX, 7, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_ROIOffsetX, 8, 1)
+        lay.addWidget(self.PyDMLabel_ROIOffsetX, 8, 2)
+        lay.addWidget(label_ROIOffsetY, 9, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_ROIOffsetY, 10, 1)
+        lay.addWidget(self.PyDMLabel_ROIOffsetY, 10, 2)
+        lay.addWidget(label_ROIWidth, 11, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_ROIWidth, 12, 1)
+        lay.addWidget(self.PyDMLabel_ROIWidth, 12, 2)
+        lay.addWidget(label_ROIHeight, 13, 1, 1, 2)
+        lay.addWidget(self.PyDMSpinbox_ROIHeight, 14, 1)
+        lay.addWidget(self.PyDMLabel_ROIHeight, 14, 2)
+        lay.addItem(QSpacerItem(4, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 15, 1)
+        return lay
 
     def _statisticsLayout(self):
-        layout = QGridLayout()
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 1, 2)
-
         # - Method
         label_Method = QLabel('CalcMethod: ', self)
         label_Method.setMaximumHeight(40)
-        layout.addWidget(label_Method, 2, 2)
 
         self.comboBox_Method = QComboBox(self)
         self.comboBox_Method.addItem('DimFei', 0)
@@ -610,127 +583,115 @@ class SiriusScrnView(QWidget):
         self.comboBox_Method.setCurrentIndex(0)
         self.comboBox_Method.currentIndexChanged.connect(
             self._handleShowStatistics)
-        layout.addWidget(self.comboBox_Method, 2, 4)
-
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 3, 2)
 
         # - Centroid
         label_Centroid = QLabel('Centroid', self, alignment=Qt.AlignHCenter)
         label_Centroid.setMaximumHeight(40)
-        layout.addWidget(label_Centroid, 4, 1, 1, 5)
-        label = QLabel('(', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 5, 1)
+        label_i_Center = QLabel('(', self)
+        label_i_Center.setMaximumSize(10, 40)
 
         self.PyDMLabel_CenterXDimFei = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CenterXDimFei-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CenterXDimFei-Mon')
         self.PyDMLabel_CenterXDimFei.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_CenterXDimFei.setMaximumSize(220, 40)
-        layout.addWidget(self.PyDMLabel_CenterXDimFei, 5, 2)
-
         self.PyDMLabel_CenterXNDStats = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CenterXNDStats-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CenterXNDStats-Mon')
         self.PyDMLabel_CenterXNDStats.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_CenterXNDStats.setMaximumSize(220, 40)
         self.PyDMLabel_CenterXNDStats.setVisible(False)
-        layout.addWidget(self.PyDMLabel_CenterXNDStats, 5, 2)
 
-        label = QLabel(',', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 5, 3)
+        label_m_Center = QLabel(',', self)
+        label_m_Center.setMaximumSize(10, 40)
 
         self.PyDMLabel_CenterYDimFei = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CenterYDimFei-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CenterYDimFei-Mon')
         self.PyDMLabel_CenterYDimFei.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_CenterYDimFei.setMaximumSize(220, 40)
-        layout.addWidget(self.PyDMLabel_CenterYDimFei, 5, 4)
-
         self.PyDMLabel_CenterYNDStats = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CenterYNDStats-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CenterYNDStats-Mon')
         self.PyDMLabel_CenterYNDStats.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_CenterYNDStats.setMaximumSize(220, 40)
         self.PyDMLabel_CenterYNDStats.setVisible(False)
-        layout.addWidget(self.PyDMLabel_CenterYNDStats, 5, 4)
 
-        label = QLabel(')', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 5, 5)
+        label_f_Center = QLabel(')', self)
+        label_f_Center.setMaximumSize(10, 40)
 
         # - Sigma
         label_Sigma = QLabel('Sigma', self, alignment=Qt.AlignHCenter)
         label_Sigma.setMaximumHeight(40)
-        layout.addWidget(label_Sigma, 6, 1, 1, 5)
-        label = QLabel('(', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 7, 1)
+        label_i_Sigma = QLabel('(', self)
+        label_i_Sigma.setMaximumSize(10, 40)
 
         self.PyDMLabel_SigmaXDimFei = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':SigmaXDimFei-Mon')
+            parent=self, init_channel=self.scrn_prefix+':SigmaXDimFei-Mon')
         self.PyDMLabel_SigmaXDimFei.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_SigmaXDimFei.setMaximumSize(220, 40)
-        layout.addWidget(self.PyDMLabel_SigmaXDimFei, 7, 2)
-
         self.PyDMLabel_SigmaXNDStats = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':SigmaXNDStats-Mon')
+            parent=self, init_channel=self.scrn_prefix+':SigmaXNDStats-Mon')
         self.PyDMLabel_SigmaXNDStats.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_SigmaXNDStats.setMaximumSize(220, 40)
         self.PyDMLabel_SigmaXNDStats.setVisible(False)
-        layout.addWidget(self.PyDMLabel_SigmaXNDStats, 7, 2)
 
-        label = QLabel(',', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 7, 3)
+        label_m_Sigma = QLabel(',', self)
+        label_m_Sigma.setMaximumSize(10, 40)
         self.PyDMLabel_SigmaYDimFei = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':SigmaYDimFei-Mon')
+            parent=self, init_channel=self.scrn_prefix+':SigmaYDimFei-Mon')
         self.PyDMLabel_SigmaYDimFei.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_SigmaYDimFei.setMaximumSize(220, 40)
-
-        layout.addWidget(self.PyDMLabel_SigmaYDimFei, 7, 4)
         self.PyDMLabel_SigmaYNDStats = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':SigmaYNDStats-Mon')
+            parent=self, init_channel=self.scrn_prefix+':SigmaYNDStats-Mon')
         self.PyDMLabel_SigmaYNDStats.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_SigmaYNDStats.setMaximumSize(220, 40)
         self.PyDMLabel_SigmaYNDStats.setVisible(False)
-        layout.addWidget(self.PyDMLabel_SigmaYNDStats, 7, 4)
 
-        label = QLabel(')', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 7, 5)
+        label_f_Sigma = QLabel(')', self)
+        label_f_Sigma.setMaximumSize(10, 40)
 
         # - Theta
         label_Theta = QLabel('Theta', self, alignment=Qt.AlignHCenter)
         label_Theta.setMaximumHeight(40)
-        layout.addWidget(label_Theta, 8, 1, 1, 5)
-        label = QLabel('(', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 9, 1)
+        label_i_Theta = QLabel('(', self)
+        label_i_Theta.setMaximumSize(10, 40)
+
         self.PyDMLabel_ThetaDimFei = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ThetaDimFei-Mon')
+            parent=self, init_channel=self.scrn_prefix+':ThetaDimFei-Mon')
         self.PyDMLabel_ThetaDimFei.setAlignment(Qt.AlignHCenter)
-        layout.addWidget(self.PyDMLabel_ThetaDimFei, 9, 2, 1, 3)
         self.PyDMLabel_ThetaNDStats = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ThetaNDStats-Mon')
+            parent=self, init_channel=self.scrn_prefix+':ThetaNDStats-Mon')
         self.PyDMLabel_ThetaNDStats.setAlignment(Qt.AlignHCenter)
         self.PyDMLabel_ThetaNDStats.setVisible(False)
-        layout.addWidget(self.PyDMLabel_ThetaNDStats, 9, 2, 1, 3)
-        label = QLabel(')', self)
-        label.setMaximumSize(10, 40)
-        layout.addWidget(label, 9, 5)
 
-        layout.addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum), 10, 2)
-        return layout
+        label_f_Theta = QLabel(')', self)
+        label_f_Theta.setMaximumSize(10, 40)
+
+        lay = QGridLayout()
+        lay.addItem(QSpacerItem(4, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 1, 2)
+        lay.addWidget(label_Method, 2, 2)
+        lay.addWidget(self.comboBox_Method, 2, 4)
+        lay.addItem(QSpacerItem(4, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 3, 2)
+        lay.addWidget(label_Centroid, 4, 1, 1, 5)
+        lay.addWidget(label_i_Center, 5, 1)
+        lay.addWidget(self.PyDMLabel_CenterXDimFei, 5, 2)
+        lay.addWidget(self.PyDMLabel_CenterXNDStats, 5, 2)
+        lay.addWidget(label_m_Center, 5, 3)
+        lay.addWidget(self.PyDMLabel_CenterYDimFei, 5, 4)
+        lay.addWidget(self.PyDMLabel_CenterYNDStats, 5, 4)
+        lay.addWidget(label_f_Center, 5, 5)
+        lay.addWidget(label_Sigma, 6, 1, 1, 5)
+        lay.addWidget(label_i_Sigma, 7, 1)
+        lay.addWidget(self.PyDMLabel_SigmaXDimFei, 7, 2)
+        lay.addWidget(self.PyDMLabel_SigmaXNDStats, 7, 2)
+        lay.addWidget(label_m_Sigma, 7, 3)
+        lay.addWidget(self.PyDMLabel_SigmaYDimFei, 7, 4)
+        lay.addWidget(self.PyDMLabel_SigmaYNDStats, 7, 4)
+        lay.addWidget(label_f_Sigma, 7, 5)
+        lay.addWidget(label_Theta, 8, 1, 1, 5)
+        lay.addWidget(label_i_Theta, 9, 1)
+        lay.addWidget(self.PyDMLabel_ThetaDimFei, 9, 2, 1, 3)
+        lay.addWidget(self.PyDMLabel_ThetaNDStats, 9, 2, 1, 3)
+        lay.addWidget(label_f_Theta, 9, 5)
+        lay.addItem(QSpacerItem(4, 2, QSzPlcy.Expanding, QSzPlcy.Fixed), 10, 2)
+        return lay
 
     def _handleShowStatistics(self, visible):
         self.PyDMLabel_CenterXDimFei.setVisible(not visible)
@@ -779,26 +740,6 @@ class SiriusScrnView(QWidget):
                             'Could not save calibration grid!',
                             QMessageBox.Ok)
 
-    @Slot()
-    def _zoomIn(self):
-        """Zoom ImageView to 0.5x current image scale."""
-        self.image_view.getView().scaleBy((0.5, 0.5))
-
-    @Slot()
-    def _zoomOut(self):
-        """Zoom ImageView to 2x current image scale."""
-        self.image_view.getView().scaleBy((2.0, 2.0))
-
-    @Slot()
-    def _zoomToActualSize(self):
-        """Zoom ImqgeView to actual image size."""
-        if len(self.image_view.image_waveform) == 0:
-            return
-        self.image_view.getView().setRange(
-            xRange=(0, self.image_view.imageWidth),
-            yRange=(0, self.image_view.image_waveform.shape[0] /
-                    self.image_view.imageWidth))
-
 
 class _ScrnSettingsDetails(SiriusMainWindow):
 
@@ -806,455 +747,381 @@ class _ScrnSettingsDetails(SiriusMainWindow):
         super().__init__(parent=parent)
         self.prefix = prefix
         self.device = device
-        self.setWindowTitle('Camera Settings Details')
+        self.scrn_prefix = 'ca://'+self.prefix+self.device
+        self.setWindowTitle('Screen Settings Details')
         self.centralwidget = QWidget(self)
-        self.centralwidget.setLayout(QFormLayout())
-        self.centralwidget.layout().setLabelAlignment(Qt.AlignRight)
         self._setupUi()
         self.setCentralWidget(self.centralwidget)
 
     def _setupUi(self):
-        label = QLabel('Screen General Info')
-        label.setStyleSheet("""font-weight: bold;""")
-        self.centralwidget.layout().addRow(label)
-
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        label_general = QLabel('<h4>Screen General Info</h4>')
 
         label_MtrPrefix = QLabel('Motor Prefix', self)
         self.PyDMLabel_MtrPrefix = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':MtrCtrlPrefix-Cte')
+            parent=self, init_channel=self.scrn_prefix+':MtrCtrlPrefix-Cte')
         self.PyDMLabel_MtrPrefix.setMaximumSize(220, 40)
         self.PyDMLabel_MtrPrefix.setAlignment(Qt.AlignCenter)
-        self.centralwidget.layout().addRow(label_MtrPrefix,
-                                           self.PyDMLabel_MtrPrefix)
 
         label_CamPrefix = QLabel('Camera Prefix', self)
         self.PyDMLabel_CamPrefix = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamPrefix-Cte')
+            parent=self, init_channel=self.scrn_prefix+':CamPrefix-Cte')
         self.PyDMLabel_CamPrefix.setMaximumSize(220, 40)
         self.PyDMLabel_CamPrefix.setAlignment(Qt.AlignCenter)
-        self.centralwidget.layout().addRow(label_CamPrefix,
-                                           self.PyDMLabel_CamPrefix)
 
         label_ImgMaxWidth = QLabel('Image Maximum Width', self)
         self.PyDMLabel_ImgMaxWidth = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgMaxWidth-Cte')
+            parent=self, init_channel=self.scrn_prefix+':ImgMaxWidth-Cte')
         self.PyDMLabel_ImgMaxWidth.setMaximumSize(220, 40)
         self.PyDMLabel_ImgMaxWidth.setAlignment(Qt.AlignCenter)
-        self.centralwidget.layout().addRow(label_ImgMaxWidth,
-                                           self.PyDMLabel_ImgMaxWidth)
 
         label_ImgMaxHeight = QLabel('Image Maximum Height', self)
         self.PyDMLabel_ImgMaxHeight = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgMaxHeight-Cte')
+            parent=self, init_channel=self.scrn_prefix+':ImgMaxHeight-Cte')
         self.PyDMLabel_ImgMaxHeight.setMaximumSize(220, 40)
         self.PyDMLabel_ImgMaxHeight.setAlignment(Qt.AlignCenter)
-        self.centralwidget.layout().addRow(label_ImgMaxHeight,
-                                           self.PyDMLabel_ImgMaxHeight)
 
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-
-        label = QLabel('Camera Acquire Settings')
-        label.setStyleSheet("""font-weight: bold;""")
-        self.centralwidget.layout().addRow(label)
-
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        label_acq = QLabel('<h4>Camera Acquire Settings</h4>')
 
         label_CamEnbl = QLabel('Acquire Enable Status', self)
         self.PyDMStateButton_CamEnbl = PyDMStateButton(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamEnbl-Sel')
+            parent=self, init_channel=self.scrn_prefix+':CamEnbl-Sel')
         self.PyDMStateButton_CamEnbl.setMaximumSize(220, 40)
+        self.PyDMStateButton_CamEnbl.shape = 1
         self.PyDMLabel_CamEnbl = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamEnbl-Sts')
+            parent=self, init_channel=self.scrn_prefix+':CamEnbl-Sts')
         self.PyDMLabel_CamEnbl.setMaximumSize(220, 40)
         self.PyDMLabel_CamEnbl.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMStateButton_CamEnbl)
-        hbox.addWidget(self.PyDMLabel_CamEnbl)
-        self.centralwidget.layout().addRow(label_CamEnbl, hbox)
+        hbox_CamEnbl = QHBoxLayout()
+        hbox_CamEnbl.addWidget(self.PyDMStateButton_CamEnbl)
+        hbox_CamEnbl.addWidget(self.PyDMLabel_CamEnbl)
 
         label_AcqMode = QLabel('Acquire Mode', self)
         self.PyDMEnumComboBox_AcqMode = PyDMEnumComboBox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamAcqMode-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamAcqMode-SP')
         self.PyDMEnumComboBox_AcqMode.setMaximumSize(220, 40)
         self.PyDMLabel_AcqMode = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamAcqMode-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamAcqMode-RB')
         self.PyDMLabel_AcqMode.setMaximumSize(220, 40)
         self.PyDMLabel_AcqMode.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMEnumComboBox_AcqMode)
-        hbox.addWidget(self.PyDMLabel_AcqMode)
-        self.centralwidget.layout().addRow(label_AcqMode, hbox)
+        hbox_AcqMode = QHBoxLayout()
+        hbox_AcqMode.addWidget(self.PyDMEnumComboBox_AcqMode)
+        hbox_AcqMode.addWidget(self.PyDMLabel_AcqMode)
 
         label_AcqPeriod = QLabel('Acquire Period', self)
         self.PyDMSpinbox_AcqPeriod = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamAcqPeriod-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamAcqPeriod-SP')
         self.PyDMSpinbox_AcqPeriod.setMaximumSize(220, 40)
         self.PyDMSpinbox_AcqPeriod.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_AcqPeriod.showStepExponent = False
         self.PyDMLabel_AcqPeriod = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamAcqPeriod-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamAcqPeriod-RB')
         self.PyDMLabel_AcqPeriod.setMaximumSize(220, 40)
         self.PyDMLabel_AcqPeriod.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_AcqPeriod)
-        hbox.addWidget(self.PyDMLabel_AcqPeriod)
-        self.centralwidget.layout().addRow(label_AcqPeriod, hbox)
+        hbox_AcqPeriod = QHBoxLayout()
+        hbox_AcqPeriod.addWidget(self.PyDMSpinbox_AcqPeriod)
+        hbox_AcqPeriod.addWidget(self.PyDMLabel_AcqPeriod)
 
         label_ExpMode = QLabel('Exposure Mode', self)
         self.PyDMEnumComboBox_ExpMode = PyDMEnumComboBox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureMode-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureMode-SP')
         self.PyDMEnumComboBox_ExpMode.setMaximumSize(220, 40)
         self.PyDMLabel_ExpMode = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureMode-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureMode-RB')
         self.PyDMLabel_ExpMode.setMaximumSize(220, 40)
         self.PyDMLabel_ExpMode.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMEnumComboBox_ExpMode)
-        hbox.addWidget(self.PyDMLabel_ExpMode)
-        self.centralwidget.layout().addRow(label_ExpMode, hbox)
+        hbox_ExpMode = QHBoxLayout()
+        hbox_ExpMode.addWidget(self.PyDMEnumComboBox_ExpMode)
+        hbox_ExpMode.addWidget(self.PyDMLabel_ExpMode)
 
         label_ExpTime = QLabel('Exposure Time', self)
         self.PyDMSpinbox_ExpTime = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureTime-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureTime-SP')
         self.PyDMSpinbox_ExpTime.setMaximumSize(220, 40)
         self.PyDMSpinbox_ExpTime.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ExpTime.showStepExponent = False
         self.PyDMLabel_ExpTime = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamExposureTime-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamExposureTime-RB')
         self.PyDMLabel_ExpTime.setMaximumSize(220, 40)
         self.PyDMLabel_ExpTime.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_ExpTime)
-        hbox.addWidget(self.PyDMLabel_ExpTime)
-        self.centralwidget.layout().addRow(label_ExpTime, hbox)
+        hbox_ExpTime = QHBoxLayout()
+        hbox_ExpTime.addWidget(self.PyDMSpinbox_ExpTime)
+        hbox_ExpTime.addWidget(self.PyDMLabel_ExpTime)
 
         label_Gain = QLabel('Gain', self)
         self.PyDMSpinbox_Gain = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamGain-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamGain-SP')
         self.PyDMSpinbox_Gain.setFixedSize(220, 40)
         self.PyDMSpinbox_Gain.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_Gain.showStepExponent = False
         self.PyDMLabel_Gain = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamGain-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamGain-RB')
         self.PyDMLabel_Gain.setFixedSize(220, 40)
         self.PyDMLabel_Gain.setAlignment(Qt.AlignCenter)
         self.PyDMPushButton_AutoGain = PyDMPushButton(
-            parent=self,
-            label='Auto Gain',
-            pressValue=1,
-            init_channel='ca://'+self.prefix+self.device+':CamAutoGain-Cmg')
+            parent=self, label='Auto Gain', pressValue=1,
+            init_channel=self.scrn_prefix+':CamAutoGain-Cmg')
         self.PyDMPushButton_AutoGain.setMaximumSize(220, 40)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_Gain)
-        hbox.addWidget(self.PyDMLabel_Gain)
-        hbox.addWidget(self.PyDMPushButton_AutoGain)
-        self.centralwidget.layout().addRow(label_Gain, hbox)
+        hbox_Gain = QHBoxLayout()
+        hbox_Gain.addWidget(self.PyDMSpinbox_Gain)
+        hbox_Gain.addWidget(self.PyDMLabel_Gain)
+        hbox_Gain.addWidget(self.PyDMPushButton_AutoGain)
 
         label_BlackLevel = QLabel('Black Level', self)
         self.PyDMSpinbox_BlackLevel = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamBlackLevel-SP')
+            parent=self, init_channel=self.scrn_prefix+':CamBlackLevel-SP')
         self.PyDMSpinbox_BlackLevel.setMaximumSize(220, 40)
         self.PyDMSpinbox_BlackLevel.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_BlackLevel.showStepExponent = False
         self.PyDMLabel_BlackLevel = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamBlackLevel-RB')
+            parent=self, init_channel=self.scrn_prefix+':CamBlackLevel-RB')
         self.PyDMLabel_BlackLevel.setMaximumSize(220, 40)
         self.PyDMLabel_BlackLevel.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_BlackLevel)
-        hbox.addWidget(self.PyDMLabel_BlackLevel)
-        self.centralwidget.layout().addRow(label_BlackLevel, hbox)
+        hbox_BlackLevel = QHBoxLayout()
+        hbox_BlackLevel.addWidget(self.PyDMSpinbox_BlackLevel)
+        hbox_BlackLevel.addWidget(self.PyDMLabel_BlackLevel)
 
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-
-        label = QLabel('Camera Region of Interest (ROI) Settings')
-        label.setStyleSheet("""font-weight: bold;""")
-        self.centralwidget.layout().addRow(label)
-
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        label_ROI = QLabel('<h4>Camera Region of Interest (ROI) Settings</h4>')
 
         label_ROIOffsetX = QLabel('Offset X', self)
         self.PyDMSpinbox_ROIOffsetX = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetX-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetX-SP')
         self.PyDMSpinbox_ROIOffsetX.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIOffsetX.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIOffsetX.showStepExponent = False
         self.PyDMLabel_ROIOffsetX = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetX-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetX-RB')
         self.PyDMLabel_ROIOffsetX.setMaximumSize(220, 40)
         self.PyDMLabel_ROIOffsetX.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_ROIOffsetX)
-        hbox.addWidget(self.PyDMLabel_ROIOffsetX)
-        self.centralwidget.layout().addRow(label_ROIOffsetX, hbox)
+        hbox_ROIOffsetX = QHBoxLayout()
+        hbox_ROIOffsetX.addWidget(self.PyDMSpinbox_ROIOffsetX)
+        hbox_ROIOffsetX.addWidget(self.PyDMLabel_ROIOffsetX)
 
         label_ROIOffsetY = QLabel('Offset Y', self)
         self.PyDMSpinbox_ROIOffsetY = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetY-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetY-SP')
         self.PyDMSpinbox_ROIOffsetY.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIOffsetY.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIOffsetY.showStepExponent = False
         self.PyDMLabel_ROIOffsetY = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIOffsetY-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIOffsetY-RB')
         self.PyDMLabel_ROIOffsetY.setMaximumSize(220, 40)
         self.PyDMLabel_ROIOffsetY.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_ROIOffsetY)
-        hbox.addWidget(self.PyDMLabel_ROIOffsetY)
-        self.centralwidget.layout().addRow(label_ROIOffsetY, hbox)
+        hbox_ROIOffsetY = QHBoxLayout()
+        hbox_ROIOffsetY.addWidget(self.PyDMSpinbox_ROIOffsetY)
+        hbox_ROIOffsetY.addWidget(self.PyDMLabel_ROIOffsetY)
 
         label_ROIWidth = QLabel('Width', self)
         self.PyDMSpinbox_ROIWidth = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIWidth-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIWidth-SP')
         self.PyDMSpinbox_ROIWidth.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIWidth.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIWidth.showStepExponent = False
         self.PyDMLabel_ROIWidth = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIWidth-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIWidth-RB')
         self.PyDMLabel_ROIWidth.setMaximumSize(220, 40)
         self.PyDMLabel_ROIWidth.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_ROIWidth)
-        hbox.addWidget(self.PyDMLabel_ROIWidth)
-        self.centralwidget.layout().addRow(label_ROIWidth, hbox)
+        hbox_ROIWidth = QHBoxLayout()
+        hbox_ROIWidth.addWidget(self.PyDMSpinbox_ROIWidth)
+        hbox_ROIWidth.addWidget(self.PyDMLabel_ROIWidth)
 
         label_ROIHeight = QLabel('Heigth', self)
         self.PyDMSpinbox_ROIHeight = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIHeight-SP')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIHeight-SP')
         self.PyDMSpinbox_ROIHeight.setMaximumSize(220, 40)
         self.PyDMSpinbox_ROIHeight.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_ROIHeight.showStepExponent = False
         self.PyDMLabel_ROIHeight = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':ImgROIHeight-RB')
+            parent=self, init_channel=self.scrn_prefix+':ImgROIHeight-RB')
         self.PyDMLabel_ROIHeight.setMaximumSize(220, 40)
         self.PyDMLabel_ROIHeight.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_ROIHeight)
-        hbox.addWidget(self.PyDMLabel_ROIHeight)
-        self.centralwidget.layout().addRow(label_ROIHeight, hbox)
+        hbox_ROIHeight = QHBoxLayout()
+        hbox_ROIHeight.addWidget(self.PyDMSpinbox_ROIHeight)
+        hbox_ROIHeight.addWidget(self.PyDMLabel_ROIHeight)
 
         label_AutoCenterX = QLabel('Auto Center X', self)
         self.PyDMStateButton_AutoCenterX = PyDMStateButton(
             parent=self,
-            init_channel='ca://'+self.prefix+self.device +
-                         ':ImgROIAutoCenterX-Sel')
+            init_channel=self.scrn_prefix + ':ImgROIAutoCenterX-Sel')
         self.PyDMStateButton_AutoCenterX.setMaximumSize(220, 40)
+        self.PyDMStateButton_AutoCenterX.shape = 1
         self.PyDMLabel_AutoCenterX = PyDMLabel(
             parent=self,
-            init_channel='ca://'+self.prefix+self.device +
-                         ':ImgROIAutoCenterX-Sts')
+            init_channel=self.scrn_prefix + ':ImgROIAutoCenterX-Sts')
         self.PyDMLabel_AutoCenterX.setMaximumSize(220, 40)
         self.PyDMLabel_AutoCenterX.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMStateButton_AutoCenterX)
-        hbox.addWidget(self.PyDMLabel_AutoCenterX)
-        self.centralwidget.layout().addRow(label_AutoCenterX, hbox)
+        hbox_AutoCenterX = QHBoxLayout()
+        hbox_AutoCenterX.addWidget(self.PyDMStateButton_AutoCenterX)
+        hbox_AutoCenterX.addWidget(self.PyDMLabel_AutoCenterX)
 
         label_AutoCenterY = QLabel('Auto Center Y', self)
         self.PyDMStateButton_AutoCenterY = PyDMStateButton(
             parent=self,
-            init_channel='ca://'+self.prefix+self.device +
-                         ':ImgROIAutoCenterY-Sel')
+            init_channel=self.scrn_prefix + ':ImgROIAutoCenterY-Sel')
         self.PyDMStateButton_AutoCenterY.setMaximumSize(220, 40)
+        self.PyDMStateButton_AutoCenterY.shape = 1
         self.PyDMLabel_AutoCenterY = PyDMLabel(
             parent=self,
-            init_channel='ca://'+self.prefix+self.device +
-                         ':ImgROIAutoCenterY-Sts')
+            init_channel=self.scrn_prefix + ':ImgROIAutoCenterY-Sts')
         self.PyDMLabel_AutoCenterY.setMaximumSize(220, 40)
         self.PyDMLabel_AutoCenterY.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMStateButton_AutoCenterY)
-        hbox.addWidget(self.PyDMLabel_AutoCenterY)
-        self.centralwidget.layout().addRow(label_AutoCenterY, hbox)
+        hbox_AutoCenterY = QHBoxLayout()
+        hbox_AutoCenterY.addWidget(self.PyDMStateButton_AutoCenterY)
+        hbox_AutoCenterY.addWidget(self.PyDMLabel_AutoCenterY)
 
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-
-        label = QLabel('Camera Errors Monitoring')
-        label.setStyleSheet("""font-weight: bold;""")
-        self.centralwidget.layout().addRow(label)
-
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        label_err = QLabel('<h4>Camera Errors Monitoring</h4>')
 
         label_AcceptedErr = QLabel('Positioning Error Tolerance', self)
         self.PyDMSpinbox_AcceptedErr = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':AcceptedErr-SP')
+            parent=self, init_channel=self.scrn_prefix+':AcceptedErr-SP')
         self.PyDMSpinbox_AcceptedErr.setMaximumSize(220, 40)
         self.PyDMSpinbox_AcceptedErr.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_AcceptedErr.showStepExponent = False
         self.PyDMLabel_AcceptedErr = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':AcceptedErr-RB')
+            parent=self, init_channel=self.scrn_prefix+':AcceptedErr-RB')
         self.PyDMLabel_AcceptedErr.setMaximumSize(220, 40)
         self.PyDMLabel_AcceptedErr.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_AcceptedErr)
-        hbox.addWidget(self.PyDMLabel_AcceptedErr)
-        self.centralwidget.layout().addRow(label_AcceptedErr, hbox)
+        hbox_AcceptedErr = QHBoxLayout()
+        hbox_AcceptedErr.addWidget(self.PyDMSpinbox_AcceptedErr)
+        hbox_AcceptedErr.addWidget(self.PyDMLabel_AcceptedErr)
 
         label_CamTemp = QLabel('Temperature', self)
         self.PyDMLabel_CamTemp = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamTemp-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CamTemp-Mon')
         self.PyDMLabel_CamTemp.setAlignment(Qt.AlignCenter)
         self.PyDMLabel_CamTemp.setMaximumSize(220, 40)
         self.PyDMLabel_CamTempState = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CamTempState-Mon')
+            parent=self, init_channel=self.scrn_prefix+':CamTempState-Mon')
         self.PyDMLabel_CamTempState.setMaximumSize(220, 40)
         self.PyDMLabel_CamTempState.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMLabel_CamTemp)
-        hbox.addWidget(self.PyDMLabel_CamTempState)
-        self.centralwidget.layout().addRow(label_CamTemp, hbox)
+        hbox_CamTemp = QHBoxLayout()
+        hbox_CamTemp.addWidget(self.PyDMLabel_CamTemp)
+        hbox_CamTemp.addWidget(self.PyDMLabel_CamTempState)
 
         label_LastErr = QLabel('Last Error', self)
         self.PyDMLabel_LastErr = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':LastErr-Mon')
+            parent=self, init_channel=self.scrn_prefix+':LastErr-Mon')
         self.PyDMLabel_LastErr.setAlignment(Qt.AlignCenter)
         self.PyDMLabel_LastErr.setMinimumSize(440, 40)
         self.PyDMPushButton_LastErr = PyDMPushButton(
-            parent=self,
-            label='Clear Last Error',
-            pressValue=1,
-            init_channel='ca://'+self.prefix+self.device+':ClearLastErr-Cmd')
+            parent=self, label='Clear Last Error', pressValue=1,
+            init_channel=self.scrn_prefix+':ClearLastErr-Cmd')
         self.PyDMPushButton_LastErr.setMaximumSize(220, 40)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMLabel_LastErr)
-        hbox.addWidget(self.PyDMPushButton_LastErr)
-        self.centralwidget.layout().addRow(label_LastErr, hbox)
+        hbox_LastErr = QHBoxLayout()
+        hbox_LastErr.addWidget(self.PyDMLabel_LastErr)
+        hbox_LastErr.addWidget(self.PyDMPushButton_LastErr)
 
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
-
-        label = QLabel('Detailed Screen Control')
-        label.setStyleSheet("""font-weight: bold;""")
-        self.centralwidget.layout().addRow(label)
-
-        self.centralwidget.layout().addItem(
-            QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        label_details = QLabel('<h4>Detailed Screen Control</h4>')
 
         label_FluorScrnPos = QLabel('Fluorescent Screen Position', self)
         self.PyDMSpinbox_FluorScrnPos = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':FluorScrnPos-SP')
+            parent=self, init_channel=self.scrn_prefix+':FluorScrnPos-SP')
         self.PyDMSpinbox_FluorScrnPos.setMaximumSize(220, 40)
         self.PyDMSpinbox_FluorScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_FluorScrnPos.showStepExponent = False
         self.PyDMLabel_FluorScrnPos = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':FluorScrnPos-RB')
+            parent=self, init_channel=self.scrn_prefix+':FluorScrnPos-RB')
         self.PyDMLabel_FluorScrnPos.setMaximumSize(220, 40)
         self.PyDMLabel_FluorScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMPushButton_FluorScrnPos = PyDMPushButton(
-            parent=self,
-            label='Get Position',
-            pressValue=1,
-            init_channel='ca://'+self.prefix+self.device +
-                         ':GetFluorScrnPos-Cmd')
+            parent=self, label='Get Position', pressValue=1,
+            init_channel=self.scrn_prefix + ':GetFluorScrnPos-Cmd')
         self.PyDMPushButton_FluorScrnPos.setMaximumSize(220, 40)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_FluorScrnPos)
-        hbox.addWidget(self.PyDMLabel_FluorScrnPos)
-        hbox.addWidget(self.PyDMPushButton_FluorScrnPos)
-        self.centralwidget.layout().addRow(label_FluorScrnPos, hbox)
+        hbox_FluorScrnPos = QHBoxLayout()
+        hbox_FluorScrnPos.addWidget(self.PyDMSpinbox_FluorScrnPos)
+        hbox_FluorScrnPos.addWidget(self.PyDMLabel_FluorScrnPos)
+        hbox_FluorScrnPos.addWidget(self.PyDMPushButton_FluorScrnPos)
 
         label_CalScrnPos = QLabel('Calibration Screen Position', self)
         self.PyDMSpinbox_CalScrnPos = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CalScrnPos-SP')
+            parent=self, init_channel=self.scrn_prefix+':CalScrnPos-SP')
         self.PyDMSpinbox_CalScrnPos.setMaximumSize(220, 40)
         self.PyDMSpinbox_CalScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_CalScrnPos.showStepExponent = False
         self.PyDMLabel_CalScrnPos = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':CalScrnPos-RB')
+            parent=self, init_channel=self.scrn_prefix+':CalScrnPos-RB')
         self.PyDMLabel_CalScrnPos.setMaximumSize(220, 40)
         self.PyDMLabel_CalScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMPushButton_CalScrnPos = PyDMPushButton(
-            parent=self,
-            label='Get Position',
-            pressValue=1,
-            init_channel='ca://'+self.prefix+self.device+':GetCalScrnPos-Cmd')
+            parent=self, label='Get Position', pressValue=1,
+            init_channel=self.scrn_prefix+':GetCalScrnPos-Cmd')
         self.PyDMPushButton_CalScrnPos.setMaximumSize(220, 40)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_CalScrnPos)
-        hbox.addWidget(self.PyDMLabel_CalScrnPos)
-        hbox.addWidget(self.PyDMPushButton_CalScrnPos)
-        self.centralwidget.layout().addRow(label_CalScrnPos, hbox)
+        hbox_CalScrnPos = QHBoxLayout()
+        hbox_CalScrnPos.addWidget(self.PyDMSpinbox_CalScrnPos)
+        hbox_CalScrnPos.addWidget(self.PyDMLabel_CalScrnPos)
+        hbox_CalScrnPos.addWidget(self.PyDMPushButton_CalScrnPos)
 
         label_NoneScrnPos = QLabel('Receded Screen Position', self)
         self.PyDMSpinbox_NoneScrnPos = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':NoneScrnPos-SP')
+            parent=self, init_channel=self.scrn_prefix+':NoneScrnPos-SP')
         self.PyDMSpinbox_NoneScrnPos.setMaximumSize(220, 40)
         self.PyDMSpinbox_NoneScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_NoneScrnPos.showStepExponent = False
         self.PyDMLabel_NoneScrnPos = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':NoneScrnPos-RB')
+            parent=self, init_channel=self.scrn_prefix+':NoneScrnPos-RB')
         self.PyDMLabel_NoneScrnPos.setMaximumSize(220, 40)
         self.PyDMLabel_NoneScrnPos.setAlignment(Qt.AlignCenter)
         self.PyDMPushButton_NoneScrnPos = PyDMPushButton(
-            parent=self,
-            label='Get Position',
-            pressValue=1,
-            init_channel='ca://'+self.prefix+self.device+':GetNoneScrnPos-Cmd')
+            parent=self, label='Get Position', pressValue=1,
+            init_channel=self.scrn_prefix+':GetNoneScrnPos-Cmd')
         self.PyDMPushButton_NoneScrnPos.setMaximumSize(220, 40)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_NoneScrnPos)
-        hbox.addWidget(self.PyDMLabel_NoneScrnPos)
-        hbox.addWidget(self.PyDMPushButton_NoneScrnPos)
-        self.centralwidget.layout().addRow(label_NoneScrnPos, hbox)
+        hbox_NoneScrnPos = QHBoxLayout()
+        hbox_NoneScrnPos.addWidget(self.PyDMSpinbox_NoneScrnPos)
+        hbox_NoneScrnPos.addWidget(self.PyDMLabel_NoneScrnPos)
+        hbox_NoneScrnPos.addWidget(self.PyDMPushButton_NoneScrnPos)
 
         label_LedPwrLvl = QLabel('LED Brightness Intensity', self)
         self.PyDMSpinbox_LedPwrLvl = PyDMSpinbox(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':LEDPwrLvl-SP')
+            parent=self, init_channel=self.scrn_prefix+':LEDPwrLvl-SP')
         self.PyDMSpinbox_LedPwrLvl.setMaximumSize(220, 40)
         self.PyDMSpinbox_LedPwrLvl.setAlignment(Qt.AlignCenter)
         self.PyDMSpinbox_LedPwrLvl.showStepExponent = False
         self.PyDMLabel_LedPwrLvl = PyDMLabel(
-            parent=self,
-            init_channel='ca://'+self.prefix+self.device+':LEDPwrLvl-RB')
+            parent=self, init_channel=self.scrn_prefix+':LEDPwrLvl-RB')
         self.PyDMLabel_LedPwrLvl.setMaximumSize(220, 40)
         self.PyDMLabel_LedPwrLvl.setAlignment(Qt.AlignCenter)
-        hbox = QHBoxLayout()
-        hbox.addWidget(self.PyDMSpinbox_LedPwrLvl)
-        hbox.addWidget(self.PyDMLabel_LedPwrLvl)
-        self.centralwidget.layout().addRow(label_LedPwrLvl, hbox)
+        hbox_LedPwrLvl = QHBoxLayout()
+        hbox_LedPwrLvl.addWidget(self.PyDMSpinbox_LedPwrLvl)
+        hbox_LedPwrLvl.addWidget(self.PyDMLabel_LedPwrLvl)
+
+        flay = QFormLayout()
+        flay.addRow(label_general)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_MtrPrefix, self.PyDMLabel_MtrPrefix)
+        flay.addRow(label_CamPrefix, self.PyDMLabel_CamPrefix)
+        flay.addRow(label_ImgMaxWidth, self.PyDMLabel_ImgMaxWidth)
+        flay.addRow(label_ImgMaxHeight, self.PyDMLabel_ImgMaxHeight)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_acq)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_CamEnbl, hbox_CamEnbl)
+        flay.addRow(label_AcqMode, hbox_AcqMode)
+        flay.addRow(label_AcqPeriod, hbox_AcqPeriod)
+        flay.addRow(label_ExpMode, hbox_ExpMode)
+        flay.addRow(label_ExpTime, hbox_ExpTime)
+        flay.addRow(label_Gain, hbox_Gain)
+        flay.addRow(label_BlackLevel, hbox_BlackLevel)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_ROI)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_ROIOffsetX, hbox_ROIOffsetX)
+        flay.addRow(label_ROIOffsetY, hbox_ROIOffsetY)
+        flay.addRow(label_ROIWidth, hbox_ROIWidth)
+        flay.addRow(label_ROIHeight, hbox_ROIHeight)
+        flay.addRow(label_AutoCenterX, hbox_AutoCenterX)
+        flay.addRow(label_AutoCenterY, hbox_AutoCenterY)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_err)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_AcceptedErr, hbox_AcceptedErr)
+        flay.addRow(label_CamTemp, hbox_CamTemp)
+        flay.addRow(label_LastErr, hbox_LastErr)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_details)
+        flay.addItem(QSpacerItem(40, 20, QSzPlcy.Expanding, QSzPlcy.Minimum))
+        flay.addRow(label_FluorScrnPos, hbox_FluorScrnPos)
+        flay.addRow(label_CalScrnPos, hbox_CalScrnPos)
+        flay.addRow(label_NoneScrnPos, hbox_NoneScrnPos)
+        flay.addRow(label_LedPwrLvl, hbox_LedPwrLvl)
+        self.centralwidget.setLayout(flay)
+        flay.setLabelAlignment(Qt.AlignRight)
+

--- a/pyqt-apps/siriushla/widgets/scrn_view.py
+++ b/pyqt-apps/siriushla/widgets/scrn_view.py
@@ -1,5 +1,6 @@
 """SiriusScrnView widget."""
 
+import sys
 import time
 from threading import Thread
 import numpy as np
@@ -12,9 +13,10 @@ from pydm.widgets import PyDMImageView, PyDMLabel, PyDMSpinbox, \
                             PyDMPushButton, PyDMEnumComboBox
 from pydm.widgets.channel import PyDMChannel
 from siriuspy.envars import vaca_prefix as _vaca_prefix
+from siriushla import util
+from siriushla.sirius_application import SiriusApplication
 from siriushla.widgets import PyDMStateButton, SiriusLedState
 from siriushla.widgets.windows import SiriusMainWindow
-from siriushla import util
 
 
 class _SiriusImageView(PyDMImageView):
@@ -1125,3 +1127,33 @@ class _ScrnSettingsDetails(SiriusMainWindow):
         self.centralwidget.setLayout(flay)
         flay.setLabelAlignment(Qt.AlignRight)
 
+
+if __name__ == '__main__':
+    """Run test."""
+    app = SiriusApplication()
+    util.set_style(app)
+
+    centralwidget = QWidget()
+    scrn_view = SiriusScrnView(prefix=_vaca_prefix, device='TB-01:DI-Scrn-1')
+    cb_scrntype = PyDMEnumComboBox(
+        parent=centralwidget,
+        init_channel='ca://'+_vaca_prefix+'TB-01:DI-Scrn-1:ScrnType-Sel')
+    cb_scrntype.currentIndexChanged.connect(
+        scrn_view.updateCalibrationGridFlag)
+
+    lay = QGridLayout()
+    lay.addWidget(QLabel('<h3>SiriusScrnView Test</h3>', centralwidget,
+                         alignment=Qt.AlignCenter), 0, 0, 1, 2)
+    lay.addItem(QSpacerItem(20, 20, QSzPlcy.Fixed, QSzPlcy.Fixed), 1, 0)
+    lay.addWidget(QLabel('Select Screen Type: ', centralwidget,
+                         alignment=Qt.AlignRight), 2, 0)
+    lay.addWidget(cb_scrntype, 2, 1)
+    lay.addItem(QSpacerItem(20, 40, QSzPlcy.Fixed, QSzPlcy.Fixed), 3, 0)
+    lay.addWidget(scrn_view, 4, 0, 1, 2)
+    centralwidget.setLayout(lay)
+
+    window = SiriusMainWindow()
+    window.setWindowTitle('SiriusScrnView Test')
+    window.setCentralWidget(centralwidget)
+    window.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
The PR commits:
- change TL Control HLA to separate some widgets code to perform tests with DIG devices: Slits and ICTs. It also fix PVs related to Linac correctors;
- include cleanup in CurrInfo HLA appearance and add ReliableMeas-Mon PV monitoring;
- cleanup ScrnView code, change layout to replace zoom buttons with CamEnbl-Sel PV control and add a test to make it easier to perform tests with DIG devices.