### PR TITLE
Update scrnview

### DIFF
--- a/pyqt-apps/siriushla/as_di_scrns/base.py
+++ b/pyqt-apps/siriushla/as_di_scrns/base.py
@@ -36,8 +36,8 @@ class SiriusImageView(PyDMImageView):
         self._calibration_grid_image = None
         self._calibration_grid_maxdata = None
         self._calibration_grid_width = None
-        self._calibration_grid_filterfactor = 0.5
-        self._calibration_grid_removeborder = 0
+        self._calibration_grid_filterfactor = 0.25
+        self._calibration_grid_removeborder = 150
         self._image_roi_offsetx = 0
         self._offsetxchannel = None
         self._image_roi_offsety = 0

--- a/pyqt-apps/siriushla/as_di_scrns/base.py
+++ b/pyqt-apps/siriushla/as_di_scrns/base.py
@@ -107,6 +107,7 @@ class SiriusImageView(PyDMImageView):
         self._calibration_grid_width = int(data[0])
         self._calibration_grid_maxdata = data[1:].max()
         self._update_calibration_grid_image()
+        self.needs_redraw = True
 
     @property
     def calibration_grid_filterfactor(self):

--- a/pyqt-apps/siriushla/as_di_scrns/base.py
+++ b/pyqt-apps/siriushla/as_di_scrns/base.py
@@ -96,6 +96,19 @@ class SiriusImageView(PyDMImageView):
         self.needs_redraw = True
 
     @property
+    def calibrationGrid(self):
+        """Return Numpy array containing original grid."""
+        return _dcopy(self._calibration_grid_orig)
+
+    @calibrationGrid.setter
+    def calibrationGrid(self, data):
+        """Receive a list 'data' which elements are: [width, new_grid:]."""
+        self._calibration_grid_orig = data[1:]
+        self._calibration_grid_width = int(data[0])
+        self._calibration_grid_maxdata = data[1:].max()
+        self._update_calibration_grid_image()
+
+    @property
     def calibration_grid_filterfactor(self):
         """Factor used to filter calibration grid.
 

--- a/pyqt-apps/siriushla/as_di_scrns/base.py
+++ b/pyqt-apps/siriushla/as_di_scrns/base.py
@@ -139,6 +139,7 @@ class SiriusImageView(PyDMImageView):
             self._calibration_grid_filterfactor = value
             if self._calibration_grid_image is not None:
                 self._update_calibration_grid_image()
+                self.needs_redraw = True
 
     def set_calibration_grid_border2remove(self, value):
         """Set factor used to remove border of the calibration grid.
@@ -152,6 +153,7 @@ class SiriusImageView(PyDMImageView):
         self._calibration_grid_removeborder = value
         if self._calibration_grid_image is not None:
             self._update_calibration_grid_image()
+            self.needs_redraw = True
 
     def process_image(self, image):
         """Reimplement process_image method to add grid to image."""

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -517,10 +517,10 @@ class SiriusScrnView(QWidget):
         else:
             path = os.path.join(
                 home, 'Desktop', 'screens-iocs', 'default')
-            fn = path + '/' + self.device
+            fn = path + '/' + self.device + '.npy'
 
         try:
-            data = np.load(fn+'.npy')
+            data = np.load(fn)
             self.image_view.calibrationGrid = data
         except Exception:
             if not default:

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -415,20 +415,24 @@ class SiriusScrnView(QWidget):
         roi_offsetx = float(self.ch_ImgROIOffsetX.value)
         roi_offsety = float(self.ch_ImgROIOffsetY.value)
 
-        # Disable camera acquisition and wait for disabling
-        self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(0)
-        state = self.SiriusLedState_CamEnbl.state
-        while state == 1:
-            time.sleep(0.1)
+        cond = roi_h != float(self.image_view.image_maxheight) or \
+            roi_w != float(self.image_view.image_maxwidth) or \
+            roi_offsetx != 0 or roi_offsety != 0
+        if cond:
+            # Disable camera acquisition and wait for disabling
+            self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(0)
             state = self.SiriusLedState_CamEnbl.state
+            while state == 1:
+                time.sleep(0.1)
+                state = self.SiriusLedState_CamEnbl.state
 
-        # Change ROI to get entire image
-        self.ch_ImgROIHeight.send_value_signal[float].emit(
-            float(self.image_view.image_maxheight))
-        self.ch_ImgROIWidth.send_value_signal[float].emit(
-            float(self.image_view.image_maxwidth))
-        self.ch_ImgROIOffsetX.send_value_signal[float].emit(0)
-        self.ch_ImgROIOffsetY.send_value_signal[float].emit(0)
+            # Change ROI to get entire image
+            self.ch_ImgROIHeight.send_value_signal[float].emit(
+                float(self.image_view.image_maxheight))
+            self.ch_ImgROIWidth.send_value_signal[float].emit(
+                float(self.image_view.image_maxwidth))
+            self.ch_ImgROIOffsetX.send_value_signal[float].emit(0)
+            self.ch_ImgROIOffsetY.send_value_signal[float].emit(0)
 
         # Enable led and wait for status
         self.PyDMStateButton_EnblLED.send_value_signal[int].emit(1)
@@ -444,21 +448,22 @@ class SiriusScrnView(QWidget):
         # Save grid
         self.image_view.saveCalibrationGrid()
 
-        # Disable camera acquisition and wait for disabling
-        self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(0)
-        state = self.SiriusLedState_CamEnbl.state
-        while state == 1:
-            time.sleep(0.1)
+        if cond:
+            # Disable camera acquisition and wait for disabling
+            self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(0)
             state = self.SiriusLedState_CamEnbl.state
+            while state == 1:
+                time.sleep(0.1)
+                state = self.SiriusLedState_CamEnbl.state
 
-        # Change ROI to original size
-        self.ch_ImgROIHeight.send_value_signal[float].emit(roi_h)
-        self.ch_ImgROIWidth.send_value_signal[float].emit(roi_w)
-        self.ch_ImgROIOffsetX.send_value_signal[float].emit(roi_offsetx)
-        self.ch_ImgROIOffsetY.send_value_signal[float].emit(roi_offsety)
+            # Change ROI to original size
+            self.ch_ImgROIHeight.send_value_signal[float].emit(roi_h)
+            self.ch_ImgROIWidth.send_value_signal[float].emit(roi_w)
+            self.ch_ImgROIOffsetX.send_value_signal[float].emit(roi_offsetx)
+            self.ch_ImgROIOffsetY.send_value_signal[float].emit(roi_offsety)
 
-        # Enable camera acquisition
-        self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(1)
+            # Enable camera acquisition
+            self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(1)
 
         # Enable showing saved grid
         time.sleep(0.1)

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -464,7 +464,7 @@ class SiriusScrnView(QWidget):
         folder_month = datetime.now().strftime('%Y-%m')
         folder_day = datetime.now().strftime('%Y-%m-%d')
         path = os.path.join(
-            home, 'Desktop', 'screen-iocs', folder_month, folder_day)
+            home, 'Desktop', 'screens-iocs', folder_month, folder_day)
         if not os.path.exists(path):
             os.makedirs(path)
         fn, _ = QFileDialog.getSaveFileName(
@@ -476,7 +476,7 @@ class SiriusScrnView(QWidget):
             fn += '.txt'
 
         path_default = os.path.join(
-            home, 'Desktop', 'screen-iocs', 'default')
+            home, 'Desktop', 'screens-iocs', 'default')
         if not os.path.exists(path_default):
             os.makedirs(path_default)
         fn_default = path_default + '/' + self.device + '.txt'
@@ -492,14 +492,14 @@ class SiriusScrnView(QWidget):
         if not default:
             folder_month = datetime.now().strftime('%Y-%m')
             path = os.path.join(
-                home, 'Desktop', 'screen-iocs', folder_month)
+                home, 'Desktop', 'screens-iocs', folder_month)
             fn, _ = QFileDialog.getOpenFileName(
                 self, 'Load Grid...', path, '*.txt')
             if not fn:
                 return
         else:
             path = os.path.join(
-                home, 'Desktop', 'screen-iocs', 'default')
+                home, 'Desktop', 'screens-iocs', 'default')
             fn = path + '/' + self.device + '.txt'
 
         try:

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -430,6 +430,11 @@ class SiriusScrnView(QWidget):
         self.ch_ImgROIOffsetX.send_value_signal[float].emit(0)
         self.ch_ImgROIOffsetY.send_value_signal[float].emit(0)
 
+        # Enable led and wait for status
+        self.PyDMStateButton_EnblLED.send_value_signal[int].emit(1)
+        while not self.SiriusLedState_EnblLED.state:
+            time.sleep(0.1)
+
         # Enable camera acquisition and wait for receiveing first frame
         self._receivedData = False
         self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(1)

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -15,9 +15,7 @@ from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy.namesys import SiriusPVName
 
 from siriushla import util
-from siriushla.widgets import PyDMLed
-from siriushla.widgets.signal_channel import SiriusConnectionSignal
-from siriushla.widgets.windows import SiriusMainWindow
+from siriushla.widgets import PyDMLed, SiriusConnectionSignal, SiriusMainWindow
 from siriushla.as_di_scrns.base import \
     SiriusImageView as _SiriusImageView, \
     create_propty_layout as _create_propty_layout, \
@@ -42,11 +40,21 @@ class SiriusScrnView(QWidget):
         self.device = device
         self.scrn_prefix = self.prefix+self.device
         self._receivedData = False
+
         self.screen_type_conn = SiriusConnectionSignal(
             self.scrn_prefix+':ScrnType-Sts')
         self.screen_type_conn.new_value_signal.connect(
             self.updateCalibrationGridFlag)
         self._calibrationgrid_flag = self.screen_type_conn.getvalue()
+        self.ch_ImgROIHeight = SiriusConnectionSignal(
+            self.scrn_prefix+':ImgROIHeight-RB')
+        self.ch_ImgROIWidth = SiriusConnectionSignal(
+            self.scrn_prefix+':ImgROIWidth-RB')
+        self.ch_ImgROIOffsetX = SiriusConnectionSignal(
+            self.scrn_prefix+':ImgROIOffsetX-RB')
+        self.ch_ImgROIOffsetY = SiriusConnectionSignal(
+            self.scrn_prefix+':ImgROIOffsetY-RB')
+
         self._setupUi()
 
     @property
@@ -388,10 +396,10 @@ class SiriusScrnView(QWidget):
         Thread(target=self._saveCalibrationGrid_thread, daemon=True).start()
 
     def _saveCalibrationGrid_thread(self):
-        roi_h = float(self.PyDMLabel_ImgROIHeight.text())
-        roi_w = float(self.PyDMLabel_ImgROIWidth.text())
-        roi_offsetx = float(self.PyDMLabel_ImgROIOffsetX.text())
-        roi_offsety = float(self.PyDMLabel_ImgROIOffsetY.text())
+        roi_h = float(self.ch_ImgROIHeight.value)
+        roi_w = float(self.ch_ImgROIWidth.value)
+        roi_offsetx = float(self.ch_ImgROIOffsetX.value)
+        roi_offsety = float(self.ch_ImgROIOffsetY.value)
 
         # Disable camera acquisition and wait for disabling
         self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(0)
@@ -401,12 +409,12 @@ class SiriusScrnView(QWidget):
             state = self.SiriusLedState_CamEnbl.state
 
         # Change ROI to get entire image
-        self.PyDMSpinbox_ImgROIHeight.send_value_signal[float].emit(
+        self.ch_ImgROIHeight.send_value_signal[float].emit(
             float(self.image_view.image_maxheight))
-        self.PyDMSpinbox_ImgROIWidth.send_value_signal[float].emit(
+        self.ch_ImgROIWidth.send_value_signal[float].emit(
             float(self.image_view.image_maxwidth))
-        self.PyDMSpinbox_ImgROIOffsetX.send_value_signal[float].emit(0)
-        self.PyDMSpinbox_ImgROIOffsetY.send_value_signal[float].emit(0)
+        self.ch_ImgROIOffsetX.send_value_signal[float].emit(0)
+        self.ch_ImgROIOffsetY.send_value_signal[float].emit(0)
 
         # Enable camera acquisition and wait for receiveing first frame
         self._receivedData = False
@@ -425,12 +433,10 @@ class SiriusScrnView(QWidget):
             state = self.SiriusLedState_CamEnbl.state
 
         # Change ROI to original size
-        self.PyDMSpinbox_ImgROIHeight.send_value_signal[float].emit(roi_h)
-        self.PyDMSpinbox_ImgROIWidth.send_value_signal[float].emit(roi_w)
-        self.PyDMSpinbox_ImgROIOffsetX.send_value_signal[float].emit(
-            roi_offsetx)
-        self.PyDMSpinbox_ImgROIOffsetY.send_value_signal[float].emit(
-            roi_offsety)
+        self.ch_ImgROIHeight.send_value_signal[float].emit(roi_h)
+        self.ch_ImgROIWidth.send_value_signal[float].emit(roi_w)
+        self.ch_ImgROIOffsetX.send_value_signal[float].emit(roi_offsetx)
+        self.ch_ImgROIOffsetY.send_value_signal[float].emit(roi_offsety)
 
         # Enable camera acquisition
         self.PyDMStateButton_CamEnbl.send_value_signal[int].emit(1)

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -406,7 +406,8 @@ class SiriusScrnView(QWidget):
         self.PyDMLabel_SigmaYNDStats.setVisible(visible)
 
     def _saveCalibrationGrid(self):
-        Thread(target=self._saveCalibrationGrid_thread, daemon=True).start()
+        t = Thread(target=self._saveCalibrationGrid_thread, daemon=True)
+        t.start()
 
     def _saveCalibrationGrid_thread(self):
         roi_h = float(self.ch_ImgROIHeight.value)
@@ -469,23 +470,21 @@ class SiriusScrnView(QWidget):
             os.makedirs(path)
         fn, _ = QFileDialog.getSaveFileName(
             self, 'Save Grid As...', path + '/' + self.device +
-            datetime.now().strftime('_%Y-%m-%d_%Hh%Mmin'), '*.txt')
+            datetime.now().strftime('_%Y-%m-%d_%Hh%Mmin'), '*.npy')
         if not fn:
             return False
-        if not fn.endswith('.txt'):
-            fn += '.txt'
 
         path_default = os.path.join(
             home, 'Desktop', 'screens-iocs', 'default')
         if not os.path.exists(path_default):
             os.makedirs(path_default)
-        fn_default = path_default + '/' + self.device + '.txt'
+        fn_default = path_default + '/' + self.device
 
         grid = self.image_view.calibrationGrid
         width = self.image_view.imageWidth
         data = np.append(width, grid)
-        np.savetxt(fn, data)
-        np.savetxt(fn_default, data)
+        np.save(fn, data)
+        np.save(fn_default, data)
 
     def _loadCalibrationGrid(self, default=False):
         home = os.path.expanduser('~')
@@ -494,16 +493,16 @@ class SiriusScrnView(QWidget):
             path = os.path.join(
                 home, 'Desktop', 'screens-iocs', folder_month)
             fn, _ = QFileDialog.getOpenFileName(
-                self, 'Load Grid...', path, '*.txt')
+                self, 'Load Grid...', path, '*.npy')
             if not fn:
                 return
         else:
             path = os.path.join(
                 home, 'Desktop', 'screens-iocs', 'default')
-            fn = path + '/' + self.device + '.txt'
+            fn = path + '/' + self.device
 
         try:
-            data = np.loadtxt(fn)
+            data = np.load(fn+'.npy')
             self.image_view.calibrationGrid = data
         except Exception:
             if not default:

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -522,11 +522,12 @@ class SiriusScrnView(QWidget):
         try:
             data = np.load(fn)
             self.image_view.calibrationGrid = data
-        except Exception:
+        except Exception as e:
             if not default:
                 QMessageBox.critical(
                     self, 'Error',
-                    'Could not load calibration grid from file '+fn,
+                    'Could not load calibration grid from file '+fn+'. ' +
+                    '\nError message: '+str(e),
                     QMessageBox.Ok)
             return
 

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -279,11 +279,11 @@ class SiriusScrnView(QWidget):
         lay.setFormAlignment(Qt.AlignCenter)
         lay.addRow(QLabel('<h4>Camera Acquisition</h4>', self))
         lay.addRow(label_CamEnbl, hbox_CamEnbl)
-        lay.addRow(label_Reset, hbox_Reset)
         lay.addRow(label_CamAcqPeriod, hbox_CamAcqPeriod)
         lay.addRow(label_CamExposureTime, hbox_CamExposureTime)
         lay.addRow(label_CamGain, hbox_CamGain)
         lay.addRow('', hbox_AutoCamGain)
+        lay.addRow(label_Reset, hbox_Reset)
         lay.addRow('', self.pb_moreSettings)
         return lay
 

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -506,6 +506,11 @@ class SiriusScrnView(QWidget):
             data = np.loadtxt(fn)
             self.image_view.calibrationGrid = data
         except Exception:
+            if not default:
+                QMessageBox.critical(
+                    self, 'Error',
+                    'Could not load calibration grid from file '+fn,
+                    QMessageBox.Ok)
             return
 
         # Enable showing saved grid

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -506,6 +506,14 @@ class SiriusScrnView(QWidget):
                 self, 'Load Grid...', path, '*.npy')
             if not fn:
                 return
+            if self.device not in fn:
+                ans = QMessageBox.question(
+                    self, 'Warning',
+                    'The name of the selected file does not contain the name' +
+                    ' of this screen. Are you sure you\'re loading this grid?',
+                    QMessageBox.Yes, QMessageBox.Cancel)
+                if ans == QMessageBox.Cancel:
+                    return
         else:
             path = os.path.join(
                 home, 'Desktop', 'screens-iocs', 'default')

--- a/pyqt-apps/siriushla/as_ps_diag/main.py
+++ b/pyqt-apps/siriushla/as_ps_diag/main.py
@@ -91,11 +91,11 @@ class PSDiag(SiriusMainWindow):
 
                     f = 'LA-.*:'+ps
                     conn_led = MyLedMultiConnection(
-                        filter=f, parent=panel, channels=conn_chs)
+                        filters=f, parent=panel, channels=conn_chs)
                     ps_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=ps_ch2vals)
+                        filters=f, parent=panel, channels2values=ps_ch2vals)
                     intlk_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=intlk_ch2vals)
+                        filters=f, parent=panel, channels2values=intlk_ch2vals)
 
                     suf = ps.strip('.*')+'_led'
                     conn_led.setObjectName('conn' + suf)
@@ -138,20 +138,20 @@ class PSDiag(SiriusMainWindow):
                         asps2labels[ps], panel,
                         alignment=Qt.AlignRight | Qt.AlignVCenter)
                     psconn_led = MyLedMultiConnection(
-                        filter=f, parent=panel, channels=psconn_chs)
+                        filters=f, parent=panel, channels=psconn_chs)
                     maconn_led = MyLedMultiConnection(
-                        filter=f.replace('PS', 'MA'),
+                        filters=f.replace('PS', 'MA'),
                         parent=panel, channels=maconn_chs)
                     ps_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=ps_ch2vals)
+                        filters=f, parent=panel, channels2values=ps_ch2vals)
                     intlk_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=intlk_ch2vals)
+                        filters=f, parent=panel, channels2values=intlk_ch2vals)
                     opm_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=opm_ch2vals)
+                        filters=f, parent=panel, channels2values=opm_ch2vals)
                     opm_led.setOnColor(PyDMLed.LightGreen)
                     opm_led.setOffColor(PyDMLed.Yellow)
                     diff_led = MyLedMultiChannel(
-                        filter=f, parent=panel, channels2values=diff_ch2vlas)
+                        filters=f, parent=panel, channels2values=diff_ch2vlas)
 
                     suf = ps.strip('.*')+'_led'
                     psconn_led.setObjectName('psconn' + suf)
@@ -530,9 +530,9 @@ def create_led_class(type='multichannel'):
 
         filterlog = Signal(str)
 
-        def __init__(self, filt, **kwargs):
+        def __init__(self, filters, **kwargs):
             super().__init__(**kwargs)
-            self.filter = filt
+            self.filter = filters
 
         def mouseDoubleClickEvent(self, ev):
             self.filterlog.emit(self.filter)

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -451,7 +451,10 @@ class TLAPControlWindow(SiriusMainWindow):
     def _openReference(self):
         """Load and show reference image."""
         home = _os.path.expanduser('~')
-        path = _os.path.join(home, 'sirius-hlas', self._tl + '_ap_control')
+        folder_month = _datetime.now().strftime('%Y-%m')
+        folder_day = _datetime.now().strftime('%Y-%m-%d')
+        path = _os.path.join(
+            home, 'Desktop', 'screen-iocs', folder_month, folder_day)
         fn, _ = QFileDialog.getOpenFileName(
             self, 'Open Reference...', path,
             'Images (*.png *.xpm *.jpg);;All Files (*)')
@@ -462,7 +465,10 @@ class TLAPControlWindow(SiriusMainWindow):
     def _saveReference(self):
         """Save reference image."""
         home = _os.path.expanduser('~')
-        path = _os.path.join(home, 'sirius-hlas', self._tl + '_ap_control')
+        folder_month = _datetime.now().strftime('%Y-%m')
+        folder_day = _datetime.now().strftime('%Y-%m-%d')
+        path = _os.path.join(
+            home, 'Desktop', 'screen-iocs', folder_month, folder_day)
         if not _os.path.exists(path):
             _os.makedirs(path)
         fn, _ = QFileDialog.getSaveFileName(

--- a/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
+++ b/pyqt-apps/siriushla/tl_ap_control/HLTLControl.py
@@ -19,7 +19,7 @@ from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 # import pymodels as _pymodels
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriushla import util as _hlautil
-from siriushla.widgets import SiriusLedAlert, SiriusLedState, \
+from siriushla.widgets import PyDMLed, SiriusLedAlert, SiriusLedState, \
     SiriusMainWindow, PyDMLinEditScrollbar
 # from siriushla.widgets import SiriusFigureCanvas
 from siriushla.as_di_scrns import SiriusScrnView
@@ -287,8 +287,10 @@ class TLAPControlWindow(SiriusMainWindow):
         pydmlabel_scrntype.setAlignment(Qt.AlignCenter)
         scrn_details.layout().addWidget(pydmlabel_scrntype, 1, 4)
 
-        led_scrntype = SiriusLedAlert(
-            parent=self, init_channel=self.prefix+scrn_device+':ScrnType-Sts')
+        led_scrntype = PyDMLed(
+            parent=self, init_channel=self.prefix+scrn_device+':ScrnType-Sts',
+            color_list=[PyDMLed.LightGreen, PyDMLed.Red, PyDMLed.Red,
+                        PyDMLed.Yellow])
         led_scrntype.shape = 2
         led_scrntype.setObjectName('Led_ScrnType_Sts_Scrn' + str(scrn_idx))
         led_scrntype.setStyleSheet("""min-width:5.8em; max-width:5.8em;""")


### PR DESCRIPTION
This PR implements the feature of saving and loading screens calibration grids from local files.
The ScrnView load automatically default grid files on window start. 
The files are saved in paths like: 
* in daily registers: /home/$user/Desktop/screens-iocs/$year-$month/$year-$month-$day/$screenname_$timestamp.txt
* in a default path: /home/$user/Desktop/screens-iocs/default/$screenname.txt

This PR also:
* fix a bug left in save grid feature of ScrnView;
* fix a bug left in PSDiag;
* fix paths to save and load references of TLMain HLAs;
* change colors of leds that show ScrnType-Sts in TLMain HLAs.