### PR TITLE
Improve Windows

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-as-ap-configdb.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-configdb.py
@@ -4,16 +4,11 @@
 import sys
 
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.clientconfigdb import ConfigDBClient
+from siriushla.as_ap_configdb import ConfigurationManager
 
-try:
-    from siriuspy.clientconfigdb import ConfigDBClient
-    from siriushla.as_ap_configdb import ConfigurationManager
-    app = SiriusApplication()
-    model = ConfigDBClient()
-    app.open_window(ConfigurationManager, parent=None, model=model)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+
+app = SiriusApplication()
+model = ConfigDBClient()
+app.open_window(ConfigurationManager, parent=None, model=model)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-energybutton.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-energybutton.py
@@ -3,15 +3,9 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_energybutton import EnergySetterWindow
 
-try:
-    from siriushla.as_ap_energybutton import EnergySetterWindow
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(EnergySetterWindow, parent=None)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(EnergySetterWindow, parent=None)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-injection.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-injection.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_injection import InjectionController, InjectionWindow
 
-try:
-    from siriushla.as_ap_injection import InjectionController, InjectionWindow
 
-    app = SiriusApplication(None, sys.argv)
-    ctlr = InjectionController()
-    app.open_window(InjectionWindow, parent=None, controller=ctlr)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+ctlr = InjectionController()
+app.open_window(InjectionWindow, parent=None, controller=ctlr)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-launcher.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-launcher.py
@@ -4,22 +4,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_launcher import MainOperation
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_launcher import MainOperation
 
-    parser = _argparse.ArgumentParser(
-        description="Run Operation Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
-    app = SiriusApplication()
-    app.open_window(MainOperation, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+parser = _argparse.ArgumentParser(
+    description="Run Operation Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
+
+app = SiriusApplication()
+app.open_window(MainOperation, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-magoffconv.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-magoffconv.py
@@ -5,18 +5,11 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_magoffconv import MagOffConvApp
 
-try:
-    from siriushla.as_ap_magoffconv import MagOffConvApp
 
-    parser = _argparse.ArgumentParser(description="Run Offline Converter App.")
-    args = parser.parse_args()
-
-    app = SiriusApplication()
-    app.open_window(MagOffConvApp)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+parser = _argparse.ArgumentParser(description="Run Offline Converter App.")
+args = parser.parse_args()
+app = SiriusApplication()
+app.open_window(MagOffConvApp)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs-load.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs-load.py
@@ -3,19 +3,13 @@
 """Lauch PVs configuration manager."""
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.clientconfigdb import ConfigDBClient
+from siriushla.as_ap_configdb.pvsconfigs import \
+    LoadAndApplyConfig2MachineWindow
 
-try:
-    from siriuspy.clientconfigdb import ConfigDBClient
-    from siriushla.as_ap_configdb.pvsconfigs import \
-        LoadAndApplyConfig2MachineWindow
 
-    app = SiriusApplication()
-    client = ConfigDBClient()
-    app.open_window(
-        LoadAndApplyConfig2MachineWindow, parent=None, client=client)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+client = ConfigDBClient()
+app.open_window(
+    LoadAndApplyConfig2MachineWindow, parent=None, client=client)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs-save.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs-save.py
@@ -3,18 +3,11 @@
 """Lauch PVs configuration manager."""
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.clientconfigdb import ConfigDBClient
+from siriushla.as_ap_configdb.pvsconfigs import ReadAndSaveConfig2ServerWindow
 
-try:
-    from siriuspy.clientconfigdb import ConfigDBClient
-    from siriushla.as_ap_configdb.pvsconfigs import \
-        ReadAndSaveConfig2ServerWindow
 
-    app = SiriusApplication()
-    client = ConfigDBClient()
-    app.open_window(ReadAndSaveConfig2ServerWindow, parent=None, client=client)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+client = ConfigDBClient()
+app.open_window(ReadAndSaveConfig2ServerWindow, parent=None, client=client)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ap-pvsconfigs.py
@@ -3,15 +3,9 @@
 """Lauch PVs configuration manager."""
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_configdb.pvsconfigs import PVsConfigManager
 
-try:
-    from siriushla.as_ap_configdb.pvsconfigs import PVsConfigManager
 
-    app = SiriusApplication()
-    app.open_window(PVsConfigManager)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PVsConfigManager)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-di-bpm.py
+++ b/pyqt-apps/scripts/sirius-hla-as-di-bpm.py
@@ -5,60 +5,54 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriuspy.namesys import SiriusPVName as _PVName
+from siriuspy.search import BPMSearch
+from siriushla.widgets.windows import create_window_from_widget
+from siriushla.as_di_bpms import SelectBPMs, BPMMain, SinglePassSummary, \
+    MultiTurnSummary
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriuspy.namesys import SiriusPVName as _PVName
-    from siriuspy.search import BPMSearch
-    from siriushla.widgets.windows import create_window_from_widget
-    from siriushla.as_di_bpms import SelectBPMs, BPMMain, SinglePassSummary, \
-        MultiTurnSummary
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface of Specified BPM.")
-    parser.add_argument(
-        'bpm_sel', type=str, help='Select a section or a BPM name.')
-    parser.add_argument(
-        '-s', '--subsection', type=str, default='all',
-        help='Subdivide take the nth subgroup of the bpms.',
-        choices=('all', '1', '2', '3', '4', '5'))
-    parser.add_argument(
-        '-w', '--window', type=str, default='Summary',
-        help="type of window to open (default= 'Summary').",
-        choices=('SPass', 'MTurn', 'Summary'))
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Interface of Specified BPM.")
+parser.add_argument(
+    'bpm_sel', type=str, help='Select a section or a BPM name.')
+parser.add_argument(
+    '-s', '--subsection', type=str, default='all',
+    help='Subdivide take the nth subgroup of the bpms.',
+    choices=('all', '1', '2', '3', '4', '5'))
+parser.add_argument(
+    '-w', '--window', type=str, default='Summary',
+    help="type of window to open (default= 'Summary').",
+    choices=('SPass', 'MTurn', 'Summary'))
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    pv = _PVName(args.bpm_sel)
-    if pv.dev == 'BPM':
-        window = create_window_from_widget(
-            BPMMain, title=args.bpm_sel, is_main=True)
-        kwargs = dict(prefix=args.prefix, bpm=pv)
+app = SiriusApplication()
+pv = _PVName(args.bpm_sel)
+if pv.dev == 'BPM':
+    window = create_window_from_widget(
+        BPMMain, title=args.bpm_sel, is_main=True)
+    kwargs = dict(prefix=args.prefix, bpm=pv)
+else:
+    bpms_names = BPMSearch.get_names(filters={'sec': args.bpm_sel.upper()})
+    if args.window == 'Summary':
+        clas = SelectBPMs
+    elif args.window == 'SPass':
+        clas = SinglePassSummary
     else:
-        bpms_names = BPMSearch.get_names(filters={'sec': args.bpm_sel.upper()})
-        if args.window == 'Summary':
-            clas = SelectBPMs
-        elif args.window == 'SPass':
-            clas = SinglePassSummary
-        else:
-            clas = MultiTurnSummary
-        slc = slice(None, None)
-        if args.subsection != 'all':
-            sub = int(args.subsection)
-            siz = len(bpms_names)//5
-            slc = slice(siz*(sub-1), siz*sub)
-        bpms_names = bpms_names[slc]
-        window = create_window_from_widget(
-            clas, title=args.bpm_sel.upper() + ' BPM List', is_main=True)
-        kwargs = dict(prefix=args.prefix, bpm_list=bpms_names)
+        clas = MultiTurnSummary
+    slc = slice(None, None)
+    if args.subsection != 'all':
+        sub = int(args.subsection)
+        siz = len(bpms_names)//5
+        slc = slice(siz*(sub-1), siz*sub)
+    bpms_names = bpms_names[slc]
+    window = create_window_from_widget(
+        clas, title=args.bpm_sel.upper() + ' BPM List', is_main=True)
+    kwargs = dict(prefix=args.prefix, bpm_list=bpms_names)
 
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-di-scrn.py
+++ b/pyqt-apps/scripts/sirius-hla-as-di-scrn.py
@@ -6,30 +6,25 @@ import os
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.widgets.windows import create_window_from_widget
+from siriushla.as_di_scrns import SelectScrns
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.widgets.windows import create_window_from_widget
-    from siriushla.as_di_scrns import SelectScrns
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface of Specified Screen.")
-    parser.add_argument('sec', type=str, help='Select a section.')
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Interface of Specified Screen.")
+parser.add_argument('sec', type=str, help='Select a section.')
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    sec = args.sec
-    prefix = args.prefix
+sec = args.sec
+prefix = args.prefix
 
-    os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
-    app = SiriusApplication()
-    MyWindow = create_window_from_widget(
-        SelectScrns, title='Select a Screen', is_main=True)
-    app.open_window(MyWindow, parent=None, prefix=prefix, sec=sec)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
+app = SiriusApplication()
+MyWindow = create_window_from_widget(
+    SelectScrns, title='Select a Screen', is_main=True)
+app.open_window(MyWindow, parent=None, prefix=prefix, sec=sec)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-pm-detail.py
+++ b/pyqt-apps/scripts/sirius-hla-as-pm-detail.py
@@ -5,20 +5,14 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_pm_control import PulsedMagnetDetailWindow
 
-try:
-    from siriushla.as_pm_control import PulsedMagnetDetailWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Pulsed Magnet Detailed Control Interface.")
-    parser.add_argument("pmname", type=str, help="PM name.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Pulsed Magnet Detailed Control Interface.")
+parser.add_argument("pmname", type=str, help="PM name.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(PulsedMagnetDetailWindow, parent=None, maname=args.pmname)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PulsedMagnetDetailWindow, parent=None, maname=args.pmname)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ps-cycle.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-cycle.py
@@ -4,15 +4,9 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_cycle.cycle_window import CycleWindow
 
-try:
-    from siriushla.as_ps_cycle.cycle_window import CycleWindow
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(CycleWindow)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(CycleWindow)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ps-detail.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-detail.py
@@ -5,20 +5,14 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSDetailWindow
 
-try:
-    from siriushla.as_ps_control import PSDetailWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Power Supply Detailed Control Interface.")
-    parser.add_argument("psname", type=str, help="PS name.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Power Supply Detailed Control Interface.")
+parser.add_argument("psname", type=str, help="PS name.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(PSDetailWindow, parent=None, psname=args.psname)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PSDetailWindow, parent=None, psname=args.psname)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ps-diag.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-diag.py
@@ -5,23 +5,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ps_diag import PSDiag
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ps_diag import PSDiag
 
-    parser = _argparse.ArgumentParser(
-        description="Run Power Supply Diagnosis Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Power Supply Diagnosis Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(PSDiag, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PSDiag, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ps-monitor.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-monitor.py
@@ -5,22 +5,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ps_diag import PSMonitor
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ps_diag import PSMonitor
 
-    parser = _argparse.ArgumentParser(
-        description="Run Power Supply Monitor Interface.")
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Power Supply Monitor Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(PSMonitor, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PSMonitor, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ps-test.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-test.py
@@ -4,15 +4,9 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_test.ps_test_window import PSTestWindow
 
-try:
-    from siriushla.as_ps_test.ps_test_window import PSTestWindow
 
-    app = SiriusApplication()
-    app.open_window(PSTestWindow)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(PSTestWindow)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-as-ti-control.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ti-control.py
@@ -5,21 +5,16 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ti_control import TimingMain
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ti_control import TimingMain
 
-    parser = _argparse.ArgumentParser(description="Run Timing HLA Interface.")
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run Timing HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(TimingMain, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(TimingMain, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ap-chromcorr.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ap-chromcorr.py
@@ -4,24 +4,19 @@
 import sys as _sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Booster Chromaticity Correction HLA Interface.")
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Booster Chromaticity Correction HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(
-        OpticsCorrWindow, parent=None, acc='bo',
-        opticsparam='chrom', prefix=args.prefix)
-    _sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    OpticsCorrWindow, parent=None, acc='bo',
+    opticsparam='chrom', prefix=args.prefix)
+_sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ap-currlt.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ap-currlt.py
@@ -5,22 +5,17 @@
 import sys as sys
 import argparse as argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_currlt.HLCurrentLifetime import CurrLTWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_currlt.HLCurrentLifetime import CurrLTWindow
 
-    parser = argparse.ArgumentParser(
-                        description="Run Current and Lifetime HLA Interface.")
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run Current and Lifetime HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(CurrLTWindow, parent=None, prefix=args.prefix, acc='bo')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(CurrLTWindow, parent=None, prefix=args.prefix, acc='bo')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ap-ramp.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ap-ramp.py
@@ -5,23 +5,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.bo_ap_ramp.main_window import RampMain
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.bo_ap_ramp.main_window import RampMain
 
-    parser = _argparse.ArgumentParser(
-        description="Run Booster Ramp HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Booster Ramp HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(RampMain, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(RampMain, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ap-sofb.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ap-sofb.py
@@ -5,21 +5,16 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_sofb import MainWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_sofb import MainWindow
 
-    parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
-    parser.add_argument('-p', "--prefix", type=str, default=vaca_prefix,
-                        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='BO')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='BO')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ap-tunecorr.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ap-tunecorr.py
@@ -4,25 +4,19 @@
 import sys as _sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Booster Tune Correction HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Booster Tune Correction HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(
-        OpticsCorrWindow, parent=None, acc='bo', opticsparam='tune',
-        prefix=args.prefix)
-    _sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    OpticsCorrWindow, parent=None, acc='bo', opticsparam='tune',
+    prefix=args.prefix)
+_sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ma-control.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ma-control.py
@@ -5,28 +5,21 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run BO PS Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run BO PS Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
+app = SiriusApplication()
+device = args.device
+if device:
+    wclass = PSControlWindow
+    kwargs = dict(section='BO', discipline='MA', device=device)
+else:
+    wclass = PSTabControlWindow
+    kwargs = dict(section='BO', discipline='MA')
 
-    app = SiriusApplication()
-    if device:
-        wclass = PSControlWindow
-        kwargs = dict(section='BO', discipline='MA', device=device)
-    else:
-        wclass = PSTabControlWindow
-        kwargs = dict(section='BO', discipline='MA')
-
-    app.open_window(wclass, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app.open_window(wclass, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-offconfig.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-offconfig.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_configdb.normconfigs import ConfigManagerWindow
 
-try:
-    from siriushla.as_ap_configdb.normconfigs import ConfigManagerWindow
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(
-        ConfigManagerWindow, parent=None, config_type='bo_normalized')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(
+    ConfigManagerWindow, parent=None, config_type='bo_normalized')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-pm-control.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-pm-control.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-try:
-    from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-    app = SiriusApplication()
-    app.open_window(
-        PulsedMagnetControlWindow, parent=None, is_main=False, section='BO')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    PulsedMagnetControlWindow, parent=None, is_main=False, section='BO')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-bo-ps-control.py
+++ b/pyqt-apps/scripts/sirius-hla-bo-ps-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run BO PS Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run BO PS Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='BO', discipline='PS', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='BO', discipline='PS')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='BO', discipline='PS', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='BO', discipline='PS')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-li-ap-emittance.py
+++ b/pyqt-apps/scripts/sirius-hla-li-ap-emittance.py
@@ -5,26 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_measure import EmittanceMeasure
+from siriushla.widgets.windows import create_window_from_widget
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_measure import EmittanceMeasure
-    from siriushla.widgets.windows import create_window_from_widget
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface of emittance measurement in Linac.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Interface of emittance measurement in Linac.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    MyWindow = create_window_from_widget(
-        EmittanceMeasure, title='Linac Emittance Measure', is_main=True)
-    app.open_window(MyWindow, parent=None, place='LI')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+MyWindow = create_window_from_widget(
+    EmittanceMeasure, title='Linac Emittance Measure', is_main=True)
+app.open_window(MyWindow, parent=None, place='LI')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-li-ap-energy.py
+++ b/pyqt-apps/scripts/sirius-hla-li-ap-energy.py
@@ -5,26 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_measure import EnergyMeasure
+from siriushla.widgets.windows import create_window_from_widget
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_measure import EnergyMeasure
-    from siriushla.widgets.windows import create_window_from_widget
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface of energy measurement in LI.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Interface of energy measurement in LI.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    MyWindow = create_window_from_widget(
-        EnergyMeasure, title='Linac Energy Measure', is_main=True)
-    app.open_window(MyWindow)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+MyWindow = create_window_from_widget(
+    EnergyMeasure, title='Linac Energy Measure', is_main=True)
+app.open_window(MyWindow)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ap-chromcorr.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ap-chromcorr.py
@@ -4,25 +4,19 @@
 import sys as _sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Storage Ring Chromaticity Correction HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Storage Ring Chromaticity Correction HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(
-        OpticsCorrWindow, parent=None, acc='si', opticsparam='chrom',
-        prefix=args.prefix)
-    _sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    OpticsCorrWindow, parent=None, acc='si', opticsparam='chrom',
+    prefix=args.prefix)
+_sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ap-currlt.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ap-currlt.py
@@ -5,23 +5,17 @@
 import sys as sys
 import argparse as argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_currlt.HLCurrentLifetime import CurrLTWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_currlt.HLCurrentLifetime import CurrLTWindow
 
-    parser = argparse.ArgumentParser(
-                        description="Run Current and Lifetime HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run Current and Lifetime HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(CurrLTWindow, parent=None, prefix=args.prefix, acc='si')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(CurrLTWindow, parent=None, prefix=args.prefix, acc='si')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ap-sofb.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ap-sofb.py
@@ -5,22 +5,16 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_sofb import MainWindow
+from siriuspy.envars import vaca_prefix
 
-try:
-    from siriushla.as_ap_sofb import MainWindow
-    from siriuspy.envars import vaca_prefix
 
-    parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(MainWindow, parent=None, prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(MainWindow, parent=None, prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ap-tunecorr.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ap-tunecorr.py
@@ -4,25 +4,19 @@
 import sys as _sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_opticscorr.HLOpticsCorr import OpticsCorrWindow
 
-    parser = _argparse.ArgumentParser(
-        description="Run Storage Ring Tune Correction HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Storage Ring Tune Correction HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(
-        OpticsCorrWindow, parent=None, acc='si', opticsparam='tune',
-        prefix=args.prefix)
-    _sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    OpticsCorrWindow, parent=None, acc='si', opticsparam='tune',
+    prefix=args.prefix)
+_sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ma-control.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ma-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run SI MA Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SI MA Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        wclass = PSControlWindow
-        kwargs = dict(section='SI', discipline='MA', device=device)
-    else:
-        wclass = PSTabControlWindow
-        kwargs = dict(section='SI', discipline='MA')
-    app.open_window(wclass, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    wclass = PSControlWindow
+    kwargs = dict(section='SI', discipline='MA', device=device)
+else:
+    wclass = PSTabControlWindow
+    kwargs = dict(section='SI', discipline='MA')
+app.open_window(wclass, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-offconfig.py
+++ b/pyqt-apps/scripts/sirius-hla-si-offconfig.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_configdb.normconfigs import ConfigManagerWindow
 
-try:
-    from siriushla.as_ap_configdb.normconfigs import ConfigManagerWindow
 
-    app = SiriusApplication(None, sys.argv)
-    app.open_window(
-        ConfigManagerWindow, parent=None, config_type='si_strength_pvs')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication(None, sys.argv)
+app.open_window(
+    ConfigManagerWindow, parent=None, config_type='si_strength_pvs')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-pm-control.py
+++ b/pyqt-apps/scripts/sirius-hla-si-pm-control.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-try:
-    from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-    app = SiriusApplication()
-    app.open_window(
-        PulsedMagnetControlWindow, parent=None, is_main=False, section='SI')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    PulsedMagnetControlWindow, parent=None, is_main=False, section='SI')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-si-ps-control.py
+++ b/pyqt-apps/scripts/sirius-hla-si-ps-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run SI PS Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SI PS Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='SI', discipline='PS', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='SI', discipline='PS')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='SI', discipline='PS', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='SI', discipline='PS')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ap-control.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ap-control.py
@@ -6,25 +6,19 @@ import os
 import sys
 import argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.tl_ap_control.HLTLControl import TLAPControlWindow
+from siriuspy.envars import vaca_prefix as _vaca_prefix
 
-try:
-    from siriushla.tl_ap_control.HLTLControl import TLAPControlWindow
-    from siriuspy.envars import vaca_prefix as _vaca_prefix
 
-    parser = argparse.ArgumentParser(
-        description="Run TB Control HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=_vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run TB Control HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=_vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
-    app = SiriusApplication()
-    app.open_window(
-        TLAPControlWindow, parent=None, prefix=args.prefix, tl='tb')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
+app = SiriusApplication()
+app.open_window(
+    TLAPControlWindow, parent=None, prefix=args.prefix, tl='tb')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ap-emittance.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ap-emittance.py
@@ -5,25 +5,19 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ap_measure import EmittanceMeasure
+from siriushla.widgets.windows import create_window_from_widget
 
-try:
-    from siriushla.as_ap_measure import EmittanceMeasure
-    from siriushla.widgets.windows import create_window_from_widget
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface of emittance measurement in TB.")
-    parser.add_argument(
-        '-p', "--place", type=str, default='TB-QF2A',
-        help="Define which quadrupole to use.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run Interface of emittance measurement in TB.")
+parser.add_argument(
+    '-p', "--place", type=str, default='TB-QF2A',
+    help="Define which quadrupole to use.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    MyWindow = create_window_from_widget(
-        EmittanceMeasure, title='TB Emittance Measure', is_main=True)
-    app.open_window(MyWindow, parent=None, place=args.place)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+MyWindow = create_window_from_widget(
+    EmittanceMeasure, title='TB Emittance Measure', is_main=True)
+app.open_window(MyWindow, parent=None, place=args.place)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ap-posang.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ap-posang.py
@@ -5,23 +5,17 @@
 import sys as sys
 import argparse as argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_posang.HLPosAng import ASAPPosAngCorr
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_posang.HLPosAng import ASAPPosAngCorr
 
-    parser = argparse.ArgumentParser(
-                        description="Run TB PosAng HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run TB PosAng HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(ASAPPosAngCorr, parent=None, prefix=args.prefix, tl='tb')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(ASAPPosAngCorr, parent=None, prefix=args.prefix, tl='tb')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ap-sofb.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ap-sofb.py
@@ -5,22 +5,16 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_sofb import MainWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_sofb import MainWindow
 
-    parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='TB')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='TB')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-di-icts.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-di-icts.py
@@ -5,23 +5,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.tl_ap_control import ICTMonitoring
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.tl_ap_control import ICTMonitoring
 
-    parser = _argparse.ArgumentParser(
-        description="Run interface of ICTs monitoring of specified TL")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run interface of ICTs monitoring of specified TL")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(ICTMonitoring, parent=None, tl='TB', prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(ICTMonitoring, parent=None, tl='TB', prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-di-slits.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-di-slits.py
@@ -5,26 +5,21 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.tl_ap_control import SlitsView
+from siriushla.widgets.windows import create_window_from_widget
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.tl_ap_control import SlitsView
-    from siriushla.widgets.windows import create_window_from_widget
 
-    parser = _argparse.ArgumentParser(
-        description="Run Interface to control TB Slits widgets.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
-    prefix = args.prefix
-    app = SiriusApplication()
-    window = create_window_from_widget(
-        SlitsView, title='Slits View', is_main=True)
-    app.open_window(window, parent=None, prefix=prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+parser = _argparse.ArgumentParser(
+    description="Run Interface to control TB Slits widgets.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
+
+app = SiriusApplication()
+prefix = args.prefix
+window = create_window_from_widget(
+    SlitsView, title='Slits View', is_main=True)
+app.open_window(window, parent=None, prefix=prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ma-control.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ma-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run TB MA Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run TB MA Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='TB', discipline='MA', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='TB', discipline='MA')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='TB', discipline='MA', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='TB', discipline='MA')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-pm-control.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-pm-control.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-try:
-    from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-    app = SiriusApplication()
-    app.open_window(
-        PulsedMagnetControlWindow, parent=None, is_main=False, section='TB')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    PulsedMagnetControlWindow, parent=None, is_main=False, section='TB')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-tb-ps-control.py
+++ b/pyqt-apps/scripts/sirius-hla-tb-ps-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run TB PS Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run TB PS Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='TB', discipline='PS', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='TB', discipline='PS')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='TB', discipline='PS', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='TB', discipline='PS')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-ap-control.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-ap-control.py
@@ -6,25 +6,19 @@ import os
 import sys
 import argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.tl_ap_control.HLTLControl import TLAPControlWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.tl_ap_control.HLTLControl import TLAPControlWindow
 
-    parser = argparse.ArgumentParser(
-                        description="Run TS Control HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run TS Control HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
-    app = SiriusApplication()
-    app.open_window(
-        TLAPControlWindow, parent=None, prefix=args.prefix, tl='ts')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
+app = SiriusApplication()
+app.open_window(
+    TLAPControlWindow, parent=None, prefix=args.prefix, tl='ts')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-ap-posang.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-ap-posang.py
@@ -5,23 +5,17 @@
 import sys as sys
 import argparse as argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix as _vaca_prefix
+from siriushla.as_ap_posang.HLPosAng import ASAPPosAngCorr
 
-try:
-    from siriuspy.envars import vaca_prefix as _vaca_prefix
-    from siriushla.as_ap_posang.HLPosAng import ASAPPosAngCorr
 
-    parser = argparse.ArgumentParser(
-                        description="Run TS PosAng HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=_vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = argparse.ArgumentParser(
+    description="Run TS PosAng HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=_vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(ASAPPosAngCorr, parent=None, prefix=args.prefix, tl='ts')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(ASAPPosAngCorr, parent=None, prefix=args.prefix, tl='ts')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-ap-sofb.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-ap-sofb.py
@@ -5,22 +5,16 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.as_ap_sofb import MainWindow
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.as_ap_sofb import MainWindow
 
-    parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run SOFB HLA Interface.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='TS')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(MainWindow, parent=None, prefix=args.prefix, acc='TS')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-di-icts.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-di-icts.py
@@ -5,23 +5,17 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriuspy.envars import vaca_prefix
+from siriushla.tl_ap_control import ICTMonitoring
 
-try:
-    from siriuspy.envars import vaca_prefix
-    from siriushla.tl_ap_control import ICTMonitoring
 
-    parser = _argparse.ArgumentParser(
-        description="Run interface of ICTs monitoring of specified TL.")
-    parser.add_argument(
-        '-p', "--prefix", type=str, default=vaca_prefix,
-        help="Define the prefix for the PVs in the window.")
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(
+    description="Run interface of ICTs monitoring of specified TL.")
+parser.add_argument(
+    '-p', "--prefix", type=str, default=vaca_prefix,
+    help="Define the prefix for the PVs in the window.")
+args = parser.parse_args()
 
-    app = SiriusApplication()
-    app.open_window(ICTMonitoring, parent=None, tl='TS', prefix=args.prefix)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(ICTMonitoring, parent=None, tl='TS', prefix=args.prefix)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-ma-control.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-ma-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run TS MA Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run TS MA Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='TS', discipline='MA', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='TS', discipline='MA')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='TS', discipline='MA', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='TS', discipline='MA')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-pm-control.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-pm-control.py
@@ -4,16 +4,10 @@
 
 import sys
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-try:
-    from siriushla.as_pm_control import PulsedMagnetControlWindow
 
-    app = SiriusApplication()
-    app.open_window(
-        PulsedMagnetControlWindow, parent=None, is_main=False, section='TS')
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+app.open_window(
+    PulsedMagnetControlWindow, parent=None, is_main=False, section='TS')
+sys.exit(app.exec_())

--- a/pyqt-apps/scripts/sirius-hla-ts-ps-control.py
+++ b/pyqt-apps/scripts/sirius-hla-ts-ps-control.py
@@ -5,27 +5,20 @@
 import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
+from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-try:
-    from siriushla.as_ps_control import PSTabControlWindow, PSControlWindow
 
-    parser = _argparse.ArgumentParser(description="Run TS PS Interface.")
-    parser.add_argument('-dev', "--device", type=str, default='')
-    args = parser.parse_args()
+parser = _argparse.ArgumentParser(description="Run TS PS Interface.")
+parser.add_argument('-dev', "--device", type=str, default='')
+args = parser.parse_args()
 
-    device = args.device
-
-    app = SiriusApplication()
-    if device:
-        window = PSControlWindow
-        kwargs = dict(section='TS', discipline='PS', device=device)
-    else:
-        window = PSTabControlWindow
-        kwargs = dict(section='TS', discipline='PS')
-    app.open_window(window, parent=None, **kwargs)
-    sys.exit(app.exec_())
-except:
-    app = SiriusApplication.instance()
-    if app is None:
-        app = SiriusApplication(None, sys.argv)
-    app.disclaimer()
+app = SiriusApplication()
+device = args.device
+if device:
+    window = PSControlWindow
+    kwargs = dict(section='TS', discipline='PS', device=device)
+else:
+    window = PSTabControlWindow
+    kwargs = dict(section='TS', discipline='PS')
+app.open_window(window, parent=None, **kwargs)
+sys.exit(app.exec_())

--- a/pyqt-apps/siriushla/as_ap_launcher/main.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/main.py
@@ -57,8 +57,8 @@ class MainOperation(SiriusMainWindow):
         # EVG control
         timing = QGroupBox('EVG Control')
 
-        evg_continuous_label = QLabel('<h4>Continuous</h4>', self,
-                                      alignment=Qt.AlignCenter)
+        evg_continuous_label = QLabel(
+            '<h4>Continuous</h4>', self, alignment=Qt.AlignCenter)
         evg_continuous_sel = PyDMStateButton(
             parent=self,
             init_channel=self._prefix+get_evg_name()+':ContinuousEvt-Sel')
@@ -66,8 +66,8 @@ class MainOperation(SiriusMainWindow):
             parent=self,
             init_channel=self._prefix+get_evg_name()+':ContinuousEvt-Sts')
 
-        evg_injection_label = QLabel('<h4>Injection</h4>', self,
-                                     alignment=Qt.AlignCenter)
+        evg_injection_label = QLabel(
+            '<h4>Injection</h4>', self, alignment=Qt.AlignCenter)
         evg_injection_sel = PyDMStateButton(
             parent=self,
             init_channel=self._prefix+get_evg_name()+':InjectionEvt-Sel')

--- a/pyqt-apps/siriushla/as_ti_control/hl_trigger.py
+++ b/pyqt-apps/siriushla/as_ti_control/hl_trigger.py
@@ -243,6 +243,8 @@ class LLTriggers(QWidget):
                 out_list.add(name)
         if amc_list:
             props = set(AFCOUTList()._ALL_PROPS)
+            props.discard('widthraw')
+            props.discard('delayraw')
             props.add('device')
             amc_wid = LLTriggerList(name='AMCs', parent=self, props=props,
                                     prefix=prefix, obj_names=amc_list)
@@ -251,6 +253,8 @@ class LLTriggers(QWidget):
             vl.addWidget(amc_wid)
         if otp_list:
             props = set(OTPList()._ALL_PROPS)
+            props.discard('width')
+            props.discard('delay')
             props.add('device')
             otp_wid = LLTriggerList(name='OTPs', parent=self, props=props,
                                     prefix=prefix, obj_names=otp_list)
@@ -259,8 +263,11 @@ class LLTriggers(QWidget):
             vl.addWidget(otp_wid)
         if out_list:
             props = set(OTPList()._ALL_PROPS)
-            for prop in OUTList()._ALL_PROPS:
-                props.add(prop)
+            props.update(OUTList()._ALL_PROPS)
+            props.discard('width')
+            props.discard('delay')
+            props.discard('fine_delay')
+            props.discard('rf_delay')
             props.add('device')
             out_wid = LLTriggerList(name='OUTs', parent=self, props=props,
                                     prefix=prefix, obj_names=out_list)

--- a/pyqt-apps/siriushla/misc/epics/wrapper/pyepics.py
+++ b/pyqt-apps/siriushla/misc/epics/wrapper/pyepics.py
@@ -57,11 +57,11 @@ class PyEpicsWrapper:
         if pvv is None:
             return False
         elif isinstance(pvv, _np.ndarray) or isinstance(value, _np.ndarray):
-            if _np.allclose(pvv, value, rtol=1e-06, atol=0.0):
-                return True
+            if len(pvv) != len(value):
+                return False
+            return _np.allclose(pvv, value, rtol=1e-06, atol=0.0)
         elif isinstance(pvv, float) or isinstance(value, float):
-            if isclose(pvv, value, rel_tol=1e-06, abs_tol=0.0):
-                return True
+            return isclose(pvv, value, rel_tol=1e-06, abs_tol=0.0)
         elif pvv == value:
             return True
         return False


### PR DESCRIPTION
The solution implemented in #163 for showing exceptions that happened in our windows was not general enough, because it only handled exceptions which killed the application. 
The solution implemented in this PR is better because it handles all python exceptions that happens during the application execution.
Just like in #163, a `QMessageBox` is raised with the error information and writes the same message in a file named `/tmp/sirius-hla.log`.