### PR TITLE
Enhancements

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-as-di-scrn.py
+++ b/pyqt-apps/scripts/sirius-hla-as-di-scrn.py
@@ -7,24 +7,33 @@ import sys
 import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
 from siriuspy.envars import vaca_prefix
+from siriuspy.namesys import SiriusPVName as PVName
 from siriushla.widgets.windows import create_window_from_widget
-from siriushla.as_di_scrns import SelectScrns
+from siriushla.as_di_scrns import SelectScrns, IndividualScrn
 
 
 parser = _argparse.ArgumentParser(
     description="Run Interface of Specified Screen.")
-parser.add_argument('sec', type=str, help='Select a section.')
+parser.add_argument('scrn_sel', type=str, help='Select a section.')
 parser.add_argument(
     '-p', "--prefix", type=str, default=vaca_prefix,
     help="Define the prefix for the PVs in the window.")
 args = parser.parse_args()
 
-sec = args.sec
-prefix = args.prefix
-
 os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '200000000'
 app = SiriusApplication()
-MyWindow = create_window_from_widget(
-    SelectScrns, title='Select a Screen', is_main=True)
-app.open_window(MyWindow, parent=None, prefix=prefix, sec=sec)
+
+scrn_sel = PVName(args.scrn_sel)
+prefix = args.prefix
+
+if scrn_sel.dev == 'Scrn':
+    window = create_window_from_widget(
+        IndividualScrn, title='Screen View: '+scrn_sel, is_main=True)
+    kwargs = dict(prefix=prefix, scrn=scrn_sel)
+else:
+    window = create_window_from_widget(
+        SelectScrns, title='Select a Screen', is_main=True)
+    kwargs = dict(prefix=prefix, sec=scrn_sel)
+
+app.open_window(window, parent=None, **kwargs)
 sys.exit(app.exec_())

--- a/pyqt-apps/siriushla/as_ap_launcher/menu.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/menu.py
@@ -5,18 +5,16 @@
 from epics import PV as _PV
 
 from qtpy.QtWidgets import QVBoxLayout, QMessageBox, QMenuBar, \
-    QMenu, QHBoxLayout, QWidget, QPushButton, QAction, QGroupBox
+    QMenu, QHBoxLayout, QWidget, QPushButton, QAction, QGroupBox, \
+    QInputDialog
 
-from siriuspy.envars import vaca_prefix as _vaca_prefix
+from siriuspy.envars import vaca_prefix as _prefix
 from siriuspy.clientconfigdb import ConfigDBClient
 
 from siriushla import util
 from siriushla.widgets.dialog import ReportDialog, ProgressDialog
 from siriushla.misc.epics.wrapper import PyEpicsWrapper
 from siriushla.misc.epics.task import EpicsChecker, EpicsSetter
-
-
-_STANDBY_FILAPS_CURRENT = 0.7
 
 
 def get_pushbutton(name, parent):
@@ -346,11 +344,28 @@ def get_object(ismenubar=True, parent=None):
 
             ans = QMessageBox.question(
                 self, 'Are you Sure?',
-                "Do you really want to apply the Configuration'" +
+                "Do you really want to apply the Configuration '" +
                 config_name + "' to the machine?",
                 QMessageBox.Yes, QMessageBox.Cancel)
             if ans != QMessageBox.Yes:
                 return
+
+            if config_name == 'standby':
+                current, ok = QInputDialog.getDouble(
+                    self, 'Enter value: ',
+                    'Enter FilaPS standby current [A]\n'
+                    'or cancel to not set it: ',
+                    value=0.7, min=0.0, max=1.5, decimals=3)
+                if ok:
+                    fila_pv = _PV(_prefix+'LI-01:EG-FilaPS:currentoutsoft',
+                                  connection_timeout=0.05)
+                    fila_pv.get()  # force connection
+                    if fila_pv.connected:
+                        fila_pv.put(current)
+                    else:
+                        QMessageBox.warning(
+                            self, 'Message',
+                            'Could not connect to LI-01:EG-FilaPS!')
 
             server_global = ConfigDBClient(config_type='global_config')
             try:
@@ -391,17 +406,6 @@ def get_object(ismenubar=True, parent=None):
             ret = dlg.exec_()
             if ret == dlg.Rejected:
                 return
-
-            if config_name == 'standby':
-                fila_pv = _PV(_vaca_prefix + 'LI-01:EG-FilaPS:currentoutsoft',
-                              connection_timeout=0.05)
-                fila_pv.get()  # force connection
-                if fila_pv.connected:
-                    fila_pv.put(_STANDBY_FILAPS_CURRENT)
-                else:
-                    QMessageBox.warning(
-                        self, 'Message',
-                        'Could not connect to LI-01:EG-FilaPS!')
 
             # Show report dialog informing user results
             self._report = ReportDialog(failed, self)

--- a/pyqt-apps/siriushla/as_di_bpms/main.py
+++ b/pyqt-apps/siriushla/as_di_bpms/main.py
@@ -33,10 +33,9 @@ class BPMSummary(BaseWidget):
         hbl.addStretch()
         pbt = QPushButton(self.bpm)
         pbt.setStyleSheet('min-width:8em;')
-        Window = create_window_from_widget(
-            BPMMain, title=self.bpm, is_main=True)
-        util.connect_window(
-            pbt, Window, parent=None, prefix=self.prefix, bpm=self.bpm)
+        util.connect_newprocess(
+            pbt, ['sirius-hla-as-di-bpm.py', '-p', self.prefix, self.bpm],
+            parent=self)
         hbl.addWidget(pbt)
         hbl.addSpacing(10)
         hbl.addStretch()

--- a/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
+++ b/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
@@ -5,7 +5,6 @@ from qtpy.QtWidgets import QWidget, QLabel, QPushButton, \
 from qtpy.QtCore import Qt
 from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriushla import util
-from siriushla.as_di_scrns import IndividualScrn
 
 
 class ScrnSummary(QWidget):
@@ -23,8 +22,9 @@ class ScrnSummary(QWidget):
         hlay.addStretch()
         pbt = QPushButton(self._scrn)
         pbt.setStyleSheet("""min-width:10em;""")
-        util.connect_window(pbt, IndividualScrn, parent=None,
-                            prefix=self._prefix, scrn=self._scrn)
+        util.connect_newprocess(
+            pbt, ['sirius-hla-as-di-scrn.py', '-p', self._prefix, self._scrn],
+            parent=self)
         hlay.addWidget(pbt)
         hlay.addStretch()
 

--- a/pyqt-apps/siriushla/as_di_scrns/main.py
+++ b/pyqt-apps/siriushla/as_di_scrns/main.py
@@ -18,7 +18,7 @@ from siriuspy.envars import vaca_prefix as _vaca_prefix
 from siriuspy.namesys import SiriusPVName
 
 from siriushla import util
-from siriushla.widgets import PyDMLed, SiriusConnectionSignal, SiriusMainWindow
+from siriushla.widgets import PyDMLed, SiriusConnectionSignal
 from siriushla.as_di_scrns.base import \
     SiriusImageView as _SiriusImageView, \
     create_propty_layout as _create_propty_layout, \
@@ -553,7 +553,7 @@ class SiriusScrnView(QWidget):
                             QMessageBox.Ok)
 
 
-class IndividualScrn(SiriusMainWindow):
+class IndividualScrn(QWidget):
     """Individual Screen."""
 
     def __init__(self, parent=None, prefix=_vaca_prefix, scrn=''):
@@ -565,23 +565,22 @@ class IndividualScrn(SiriusMainWindow):
         self._setupUi()
 
     def _setupUi(self):
-        cw = QWidget()
         self.scrn_view = SiriusScrnView(prefix=self._prefix, device=self._scrn)
         self.cb_scrntype = PyDMEnumComboBox(
-            parent=cw, init_channel=self._prefix+self._scrn+':ScrnType-Sel')
+            parent=self, init_channel=self._prefix+self._scrn+':ScrnType-Sel')
         self.l_scrntype = PyDMLabel(
-            parent=cw, init_channel=self._prefix+self._scrn+':ScrnType-Sts')
+            parent=self, init_channel=self._prefix+self._scrn+':ScrnType-Sts')
         self.led_scrntype = PyDMLed(
-            parent=cw, init_channel=self._prefix+self._scrn+':ScrnType-Sts',
+            parent=self, init_channel=self._prefix+self._scrn+':ScrnType-Sts',
             color_list=[PyDMLed.LightGreen, PyDMLed.Red, PyDMLed.Red,
                         PyDMLed.Yellow])
         self.led_scrntype.shape = 2
 
         lay = QGridLayout()
         lay.addWidget(QLabel('<h3>Screen View</h3>',
-                             cw, alignment=Qt.AlignCenter), 0, 0, 1, 4)
+                             self, alignment=Qt.AlignCenter), 0, 0, 1, 4)
         lay.addItem(QSpacerItem(20, 20, QSzPlcy.Fixed, QSzPlcy.Fixed), 1, 0)
-        lay.addWidget(QLabel('Select Screen Type: ', cw,
+        lay.addWidget(QLabel('Select Screen Type: ', self,
                              alignment=Qt.AlignRight), 2, 0)
         lay.addWidget(self.cb_scrntype, 2, 1)
         lay.addWidget(self.l_scrntype, 2, 2)
@@ -589,10 +588,7 @@ class IndividualScrn(SiriusMainWindow):
 
         lay.addItem(QSpacerItem(20, 40, QSzPlcy.Fixed, QSzPlcy.Fixed), 4, 0)
         lay.addWidget(self.scrn_view, 5, 0, 1, 4)
-        cw.setLayout(lay)
-
-        self.setWindowTitle('Screen View: '+self._scrn)
-        self.setCentralWidget(cw)
+        self.setLayout(lay)
 
 
 if __name__ == '__main__':

--- a/pyqt-apps/siriushla/as_pm_control/PulsedMagnetDetailWidget.py
+++ b/pyqt-apps/siriushla/as_pm_control/PulsedMagnetDetailWidget.py
@@ -49,7 +49,6 @@ class PulsedMagnetDetailWidget(QWidget):
         self._intlk5_mon_pv = self._prefixed_maname + ":Intlk5-Mon"
         self._intlk6_mon_pv = self._prefixed_maname + ":Intlk6-Mon"
         self._intlk7_mon_pv = self._prefixed_maname + ":Intlk7-Mon"
-        self._intlk8_mon_pv = self._prefixed_maname + ":Intlk8-Mon"
         self._intlk1label_cte_pv = self._prefixed_maname + ":Intlk1Label-Cte"
         self._intlk2label_cte_pv = self._prefixed_maname + ":Intlk2Label-Cte"
         self._intlk3label_cte_pv = self._prefixed_maname + ":Intlk3Label-Cte"
@@ -57,7 +56,9 @@ class PulsedMagnetDetailWidget(QWidget):
         self._intlk5label_cte_pv = self._prefixed_maname + ":Intlk5Label-Cte"
         self._intlk6label_cte_pv = self._prefixed_maname + ":Intlk6Label-Cte"
         self._intlk7label_cte_pv = self._prefixed_maname + ":Intlk7Label-Cte"
-        self._intlk8label_cte_pv = self._prefixed_maname + ":Intlk8Label-Cte"
+        if 'Sept' not in self._maname:
+            self._intlk8_mon_pv = self._prefixed_maname + ":Intlk8-Mon"
+            self._intlk8label_cte_pv = self._prefixed_maname+":Intlk8Label-Cte"
         self._ctrlmode_pv = self._prefixed_maname + ":CtrlMode-Mon"
         self._prefixed_trigger_name = \
             self._prefixed_maname.replace('PM-', 'TI-')
@@ -105,7 +106,8 @@ class PulsedMagnetDetailWidget(QWidget):
     def _interlock_layout(self):
         interlock_layout = QGridLayout()
 
-        for i in range(8):
+        intlk_cnt = 8 if 'Sept' not in self._maname else 7
+        for i in range(intlk_cnt):
             label = PyDMLabel(
                 self, getattr(self, '_intlk' + str(i+1) + 'label_cte_pv'))
             led = PyDMLed(

--- a/pyqt-apps/siriushla/tl_ap_control/__init__.py
+++ b/pyqt-apps/siriushla/tl_ap_control/__init__.py
@@ -1,5 +1,3 @@
-from siriushla.tl_ap_control.HLTLControl import TLAPControlWindow
-from siriushla.tl_ap_control.ICT_monitor import ICTMonitoring
-from siriushla.tl_ap_control.Slit_monitor import SlitMonitoring, SlitsView
-
-__all__ = ('HLTLControl', 'ICT_monitor', 'Slit_monitor')
+from .HLTLControl import TLAPControlWindow
+from .ICT_monitor import ICTMonitoring
+from .Slit_monitor import SlitMonitoring, SlitsView


### PR DESCRIPTION
This PR:
- Removes last Intlk bit of Septums windows;
- Adds control of last TB correctors and septum to TB Main;
- Moves feature of showing a loading dialog from launcher menu to siriushla/util.py;
- Fixes problem with Screens and BPMs summary windows of do not create a new window when previously a summary window was opened and closed and a child device window was left opened;
- Changes Standby button in launcher to set LI-01:EG-FilaPS:currentoutsoft PV to standby value.
