### PR TITLE
Fix setter

### DIFF
--- a/pyqt-apps/siriushla/as_ap_configdb/pvsconfigs/load_and_apply.py
+++ b/pyqt-apps/siriushla/as_ap_configdb/pvsconfigs/load_and_apply.py
@@ -147,7 +147,7 @@ class LoadAndApplyConfig2MachineWindow(SiriusMainWindow):
             self._tree_msg.setText(
                 'Configuration has {} items'.format(len(pvs)))
             self._tree.check_all()
-            self._tree.expand_all()
+            self._tree.collapseAll()
             self._filter_pvs(self._filter_le.text())
         except KeyError:
             self._tree_msg.setText('Configuration has no field pvs')

--- a/pyqt-apps/siriushla/as_di_scrns/base.py
+++ b/pyqt-apps/siriushla/as_di_scrns/base.py
@@ -443,7 +443,7 @@ class SiriusImageView(PyDMImageView):
 
     def mousePressEvent(self, ev):
         pos = ev.pos()
-        pos_scene = self.view.mapSceneToView(pos)
+        pos_scene = self.view.vb.mapSceneToView(pos)
         txt = '{0}, {1}'.format(round(pos_scene.x()),
                                 round(pos_scene.y()))
         QToolTip.showText(

--- a/pyqt-apps/siriushla/misc/epics/task/setter.py
+++ b/pyqt-apps/siriushla/misc/epics/task/setter.py
@@ -11,8 +11,13 @@ class EpicsSetter(EpicsTask):
         if not self._quit_task:
             for i in range(len(self._pvs)):
                 self.currentItem.emit(self._pvs[i].pvname)
-                self._pvs[i].put(self._values[i])
-                time.sleep(self._delays[i])
+                try:
+                    self._pvs[i].put(self._values[i])
+                    time.sleep(self._delays[i])
+                except Exception:
+                    print(
+                        'PV ', self._pvs[i].pvname, 
+                        ' not set wit value: ', self._values[i])
                 self.itemDone.emit()
                 if self._quit_task:
                     break

--- a/pyqt-apps/siriushla/misc/epics/task/setter.py
+++ b/pyqt-apps/siriushla/misc/epics/task/setter.py
@@ -1,5 +1,6 @@
 """Epics Setter."""
 import time
+import logging as _log
 from .task import EpicsTask
 
 
@@ -14,10 +15,9 @@ class EpicsSetter(EpicsTask):
                 try:
                     self._pvs[i].put(self._values[i])
                     time.sleep(self._delays[i])
-                except Exception:
-                    print(
-                        'PV ', self._pvs[i].pvname, 
-                        ' not set wit value: ', self._values[i])
+                except TypeError:
+                    _log.warning('PV {} not set with value: {}'.format(
+                        self._pvs[i].pvname, self._values[i]))
                 self.itemDone.emit()
                 if self._quit_task:
                     break

--- a/pyqt-apps/siriushla/misc/epics/wrapper/pyepics.py
+++ b/pyqt-apps/siriushla/misc/epics/wrapper/pyepics.py
@@ -56,9 +56,12 @@ class PyEpicsWrapper:
 
         if pvv is None:
             return False
-        elif isinstance(pvv, _np.ndarray) or isinstance(value, _np.ndarray):
-            if len(pvv) != len(value):
-                return False
+        elif self._isarray(pvv) or self._isarray(value):
+            try:
+                if len(pvv) != len(value):
+                    return False
+            except TypeError:
+                return False  # one of them is not an array
             return _np.allclose(pvv, value, rtol=1e-06, atol=0.0)
         elif isinstance(pvv, float) or isinstance(value, float):
             return isclose(pvv, value, rel_tol=1e-06, abs_tol=0.0)
@@ -70,3 +73,6 @@ class PyEpicsWrapper:
         """Return PV value."""
         if self.connected(self._pv):
             return self._pv.get(timeout=50e-3)
+
+    def _isarray(self, value):
+        return isinstance(value, (_np.ndarray, list, tuple))

--- a/pyqt-apps/siriushla/sirius_application.py
+++ b/pyqt-apps/siriushla/sirius_application.py
@@ -4,11 +4,20 @@ import os
 import time
 import traceback
 import subprocess as sub
+import logging as _log
 from io import StringIO
-from pydm import PyDMApplication, data_plugins
 from qtpy.QtWidgets import QMessageBox
+from pydm import PyDMApplication, data_plugins
 
 from .util import get_window_id, set_style
+
+
+# Configure Logging
+fmt = '%(levelname)7s | %(asctime)s | ' +\
+      '%(module)15s.%(funcName)-20s[%(lineno)4d] ::: %(message)s'
+_log.basicConfig(
+    format=fmt, datefmt='%F %T', level=_log.INFO,
+    filename='/tmp/sirius-hla.log', filemode='a')
 
 
 # Set QT_SCALE_FACTOR


### PR DESCRIPTION
 - Configure logging in import of `sirius_application`.
 - Fix bug in `EpicsSetter` which was causing crashing of `load_and_apply` window.
 - Collapse all PVs when loading a new configuration in `load_and_apply` window.
 - Fix array checking in `PyEpics` wrapper.
 - Fix `mousePressEvent` in `SiriusImageView` of `as_di_scrns` package.