### PR TITLE
Improve SOFB and timing windows

### DIFF
--- a/pyqt-apps/siriushla/as_ap_sofb/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/main.py
@@ -79,7 +79,7 @@ class MainWindow(SiriusMainWindow):
         wid.setObjectName('doc_OrbReg')
         wid.setStyleSheet("#doc_OrbReg{min-width:20em; min-height:14em;}")
 
-        wid_cont = OrbitRegisters(self, self.prefix, self.acc, 5)
+        wid_cont = OrbitRegisters(self, self.prefix, self.acc, 7)
         wid.setWidget(wid_cont)
         self.orb_regtr = wid_cont
         return wid

--- a/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
@@ -158,7 +158,7 @@ class OrbitRegister(QWidget):
         lbl.setSizePolicy(sz_pol)
         lbl.setMouseTracking(True)
         lbl.setAcceptDrops(True)
-        lbl.setTextInteractionFlags(Qt.TextSelectableByMouse)
+        lbl.setTextInteractionFlags(Qt.TextEditorInteraction)
         self.new_string_signal.connect(lbl.setText)
 
         menu = QMenu(btn)

--- a/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
@@ -191,6 +191,9 @@ class OrbitRegister(QWidget):
         act = menu2.addAction('RespMat')
         act.setIcon(qta.icon('mdi.matrix'))
         act.triggered.connect(self._open_matrix_sel)
+        act = menu.addAction('&Edit Orbit')
+        act.setIcon(qta.icon('mdi.table-edit'))
+        act.triggered.connect(self._edit_orbit)
         act = menu.addAction('&Clear')
         act.setIcon(qta.icon('mdi.delete-empty'))
         act.triggered.connect(self._reset_orbit)
@@ -262,6 +265,74 @@ class OrbitRegister(QWidget):
             orby = orbs[len(orbs)//2:] * kick
             self._update_and_emit(
                 'RespMat: {0:s}'.format(corrnames[idx]), orbx, orby)
+
+    def _edit_orbit(self):
+        orbx = self.orbx
+        orby = self.orby
+
+        wid = QDialog(self)
+        wid.setObjectName(self._csorb.acc+'App')
+        wid.setLayout(QVBoxLayout())
+
+        hbl = QHBoxLayout()
+        wid.layout().addItem(hbl)
+        hbl.addWidget(QLabel('X = ', wid))
+        multx = QLineEdit(wid)
+        multx.setValidator(QDoubleValidator())
+        multx.setText('1.0')
+        # multx.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
+        multx.setAlignment(Qt.AlignCenter)
+        multx.setStyleSheet('max-width:5em;')
+        hbl.addWidget(multx)
+        hbl.addWidget(QLabel('*X   +   ', wid))
+        addx = QLineEdit(wid)
+        addx.setValidator(QDoubleValidator())
+        addx.setText('0.0')
+        addx.setAlignment(Qt.AlignCenter)
+        addx.setStyleSheet('max-width:5em;')
+        hbl.addWidget(addx)
+        hbl.addWidget(QLabel(' [um]', wid))
+
+        hbl = QHBoxLayout()
+        wid.layout().addItem(hbl)
+        hbl.addWidget(QLabel('Y = ', wid))
+        multy = QLineEdit(wid)
+        multy.setValidator(QDoubleValidator())
+        multy.setText('1.0')
+        # multy.setAlignment(Qt.AlignVCenter | Qt.AlignRight)
+        multy.setAlignment(Qt.AlignCenter)
+        multy.setStyleSheet('max-width:5em;')
+        hbl.addWidget(multy)
+        hbl.addWidget(QLabel('*Y   +   ', wid))
+        addy = QLineEdit(wid)
+        addy.setValidator(QDoubleValidator())
+        addy.setText('0.0')
+        addy.setAlignment(Qt.AlignCenter)
+        addy.setStyleSheet('max-width:5em;')
+        hbl.addWidget(addy)
+        hbl.addWidget(QLabel(' [um]', wid))
+
+        hlay = QHBoxLayout()
+        cancel = QPushButton('Cancel', wid)
+        confirm = QPushButton('Ok', wid)
+        cancel.clicked.connect(wid.reject)
+        confirm.clicked.connect(wid.accept)
+        hlay.addStretch()
+        hlay.addWidget(cancel)
+        hlay.addStretch()
+        hlay.addWidget(confirm)
+        hlay.addStretch()
+        wid.layout().addItem(hlay)
+        res = wid.exec_()
+
+        if res == QDialog.Accepted:
+            mltx = float(multx.text())
+            mlty = float(multy.text())
+            plusx = float(addx.text())
+            plusy = float(addy.text())
+            orbx = mltx * orbx + plusx
+            orby = mlty * orby + plusy
+            self._update_and_emit('Orbit Edited', orbx, orby)
 
     def _save_orbit_to_file(self, _):
         header = '# ' + _datetime.now().strftime('%Y/%m/%d-%H:%M:%S') + '\n'

--- a/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
@@ -5,8 +5,9 @@ from datetime import datetime as _datetime
 import numpy as _np
 from qtpy.QtWidgets import QMenu, QFileDialog, QWidget, QMessageBox, \
     QScrollArea, QLabel, QPushButton, QSizePolicy, QGridLayout, QVBoxLayout, \
-    QHBoxLayout
+    QHBoxLayout, QDialog, QComboBox, QLineEdit
 from qtpy.QtCore import Signal, Qt
+from qtpy.QtGui import QDoubleValidator
 import qtawesome as qta
 
 from siriuspy.csdevice.orbitcorr import SOFBFactory
@@ -39,6 +40,7 @@ class OrbitRegisters(QWidget):
             'off': [
                 SiriusConnectionSignal(pre + 'OfflineOrbX-SP'),
                 SiriusConnectionSignal(pre + 'OfflineOrbY-SP')],
+            'mat': SiriusConnectionSignal(pre + 'RespMat-RB'),
             }
         self.setupui()
 
@@ -186,6 +188,9 @@ class OrbitRegister(QWidget):
         act = menu2.addAction('&OfflineOrb')
         act.setIcon(qta.icon('mdi.signal-off'))
         act.triggered.connect(_part(self._register_orbit, 'off'))
+        act = menu2.addAction('RespMat')
+        act.setIcon(qta.icon('mdi.matrix'))
+        act.triggered.connect(self._open_matrix_sel)
         act = menu.addAction('&Clear')
         act.setIcon(qta.icon('mdi.delete-empty'))
         act.triggered.connect(self._reset_orbit)
@@ -211,6 +216,52 @@ class OrbitRegister(QWidget):
             return
         self._update_and_emit(
             'Orbit Registered.', pvx.getvalue(), pvy.getvalue())
+
+    def _open_matrix_sel(self):
+        wid = QDialog(self)
+        wid.setObjectName(self._csorb.acc+'App')
+        wid.setLayout(QVBoxLayout())
+
+        cbbox = QComboBox(wid)
+        corrnames = self._csorb.CH_NAMES + self._csorb.CV_NAMES
+        if self._csorb.acc == 'SI':
+            corrnames.append('RF')
+        cbbox.addItems(corrnames)
+        wid.layout().addWidget(QLabel('Choose the corrector:', wid))
+        wid.layout().addWidget(cbbox)
+
+        ledit = QLineEdit(wid)
+        ledit.setValidator(QDoubleValidator())
+        ledit.setText('1.0')
+        wid.layout().addWidget(QLabel('Choose the Kick [urad]:', wid))
+        wid.layout().addWidget(ledit)
+
+        hlay = QHBoxLayout()
+        cancel = QPushButton('Cancel', wid)
+        confirm = QPushButton('Ok', wid)
+        cancel.clicked.connect(wid.reject)
+        confirm.clicked.connect(wid.accept)
+        hlay.addStretch()
+        hlay.addWidget(cancel)
+        hlay.addStretch()
+        hlay.addWidget(confirm)
+        hlay.addStretch()
+        wid.layout().addItem(hlay)
+        res = wid.exec_()
+
+        if res == QDialog.Accepted:
+            idx = cbbox.currentIndex()
+            kick = float(ledit.text())
+            pvm = self._orbits.get('mat')
+            if pvm is None or not pvm.connected:
+                self._update_and_emit(
+                    'Error: PV {0:s} not connected.'.format(pvm.pvname))
+            val = pvm.getvalue()
+            orbs = val.reshape(-1, self._csorb.NR_CORRS)[:, idx]
+            orbx = orbs[:len(orbs)//2] * kick
+            orby = orbs[len(orbs)//2:] * kick
+            self._update_and_emit(
+                'RespMat: {0:s}'.format(corrnames[idx]), orbx, orby)
 
     def _save_orbit_to_file(self, _):
         header = '# ' + _datetime.now().strftime('%Y/%m/%d-%H:%M:%S') + '\n'

--- a/pyqt-apps/siriushla/as_ti_control/summary.py
+++ b/pyqt-apps/siriushla/as_ti_control/summary.py
@@ -47,32 +47,31 @@ class Button(QWidget):
             clss, title=self.prefix.device_name, icon=icon)
         connect_window(but, Window, None, prefix=self.prefix + ':')
 
-        prop1 = 'Network'
-        pp1 = 'Net'
-        prop2 = 'LinkStatus'
-        pp2 = 'Link'
+        props = ['DevEnbl', 'Network', 'LinkStatus', 'IntlkStatus']
+        suffs = ['-Sts', '-Mon', '-Mon', '-Mon']
+        chng = [True, True, True, False]
         if self.prefix.dev == 'EVG':
-            prop2 = 'RFStatus'
-            pp2 = 'RFSts'
+            props[2] = 'RFStatus'
+            props[3] = 'ACStatus'
+            chng[3] = True
         elif self.prefix.dev == 'AMCFPGAEVR':
-            prop1 = 'RefClkLocked'
-            pp1 = 'Lckd'
-        pv1 = self.prefix.substitute(propty=prop1+'-Mon')
-        pv2 = self.prefix.substitute(propty=prop2+'-Mon')
-        lbl1 = QLabel(pp1, self)
-        lbl2 = QLabel(pp2, self)
-        led1 = SiriusLedAlert(self, init_channel=pv1)
-        led1.onColor, led1.offColor = led1.offColor, led1.onColor
-        led2 = SiriusLedAlert(self, init_channel=pv2)
-        led2.onColor, led2.offColor = led2.offColor, led2.onColor
+            props[1] = 'RefClkLocked'
+            props = props[:-1]
+        elif self.prefix.dev == 'Fout':
+            props = props[:-1]
 
         lay = QGridLayout(self)
-        lay.addWidget(lbl0, 0, 0, 1, 5, Qt.AlignCenter)
-        lay.addWidget(but, 1, 0, 1, 5)
-        lay.addWidget(lbl1, 2, 0)
-        lay.addWidget(led1, 2, 1)
-        lay.addWidget(lbl2, 2, 3)
-        lay.addWidget(led2, 2, 4)
+        lay.addWidget(lbl0, 0, 0, 1, len(props), Qt.AlignCenter)
+        lay.addWidget(but, 1, 0, 1, len(props))
+
+        for i, prop in enumerate(props):
+            pvn = self.prefix.substitute(propty=prop+suffs[i])
+            led = SiriusLedAlert(self)
+            led.channel = pvn
+            led.setToolTip(prop)
+            if chng[i]:
+                led.onColor, led.offColor = led.offColor, led.onColor
+            lay.addWidget(led, 2, i)
 
 
 class Summary(QWidget):


### PR DESCRIPTION
SOFB:
- Increase the number of registers to 7;
- Add option to modify registers orbits adding a scale and an offset to it.
- Make register text editable.
- Add option to load a chosen line from the respmat to a register.

Timing:
- Improve timing summary window to show more info about devices.