### PR TITLE
WID.BUG: fix bug introduced in cf8b90ac4.

### DIFF
--- a/pyqt-apps/siriushla/widgets/spinbox.py
+++ b/pyqt-apps/siriushla/widgets/spinbox.py
@@ -67,6 +67,7 @@ class SiriusSpinbox(PyDMSpinbox):
             The new precision value
         """
         TextFormatter.precision_changed(self, new_precision)
+        self.setDecimals(self.precision)
         self.update_limits()
 
     @Property(bool)


### PR DESCRIPTION
need to call `setDecimals` since `PyDMSpinbox.precision_changed` is not being called anymore.