### PR TITLE
Launch.MNT: add delays between PU setpoints in InjSys buttons

### DIFF
--- a/pyqt-apps/siriushla/as_ap_launcher/standby_widgets.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/standby_widgets.py
@@ -180,6 +180,7 @@ class InjSysStandbyButton(PyDMWritableWidget, QPushButton):
             plugin = pydm.data_plugins.plugin_for_address(addr)
             conn = plugin.connections[addr]
             conn.put_value(val)
+            _time.sleep(0.1)
 
         if self._pressvalue == 0:
             self._booster_handler.turn_off()


### PR DESCRIPTION
Guys, this is a temporary solution needed to avoid a bug in the low level control of PU