### PR TITLE
FIX: fix led status detail dialogs and PSStatusDialog

### DIFF
--- a/pyqt-apps/siriushla/as_ap_launcher/standby_widgets.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/standby_widgets.py
@@ -190,20 +190,20 @@ class InjSysStandbyStatusLed(PyDMLedMultiChannel):
     def mouseDoubleClickEvent(self, ev):
         pv_groups, texts = list(), list()
         pvs_err, pvs_und = set(), set()
-        for k, v in self._address2status.items():
-            if not v:
-                pvs_err.add(k)
-        if pvs_err:
-            pv_groups.append(pvs_err)
-            texts.append(
-                'The following PVs have value\n'
-                'equivalent to off status!')
         for k, v in self._address2conn.items():
             if not v:
                 pvs_und.add(k)
         if pvs_und:
             pv_groups.append(pvs_und)
             texts.append('There are disconnected PVs!')
+        for k, v in self._address2status.items():
+            if not v and k not in pvs_und:
+                pvs_err.add(k)
+        if pvs_err:
+            pv_groups.append(pvs_err)
+            texts.append(
+                'The following PVs have value\n'
+                'equivalent to off status!')
 
         if pv_groups:
             msg = MultiChannelStatusDialog(

--- a/pyqt-apps/siriushla/widgets/dialog/ps_status_dialog.py
+++ b/pyqt-apps/siriushla/widgets/dialog/ps_status_dialog.py
@@ -1,20 +1,18 @@
 """List with power supplies cycling status."""
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QListView, QApplication, QDialog, QVBoxLayout, \
+
+from qtpy.QtWidgets import QListWidget, QApplication, QDialog, QVBoxLayout, \
     QLabel, QPushButton
-from qtpy.QtGui import QStandardItemModel, QStandardItem
 
 from siriushla.as_ps_control.PSDetailWindow import PSDetailWindow
 
 
-class PSList(QListView):
+class PSList(QListWidget):
     """PS List."""
 
     def __init__(self, pwrsupplies=set(), parent=None):
         """Constructor."""
         super().__init__(parent)
         self._pwrsupplies = pwrsupplies
-        self._model = None
         self._setup_ui()
         self.doubleClicked.connect(self._open_detail)
 
@@ -29,13 +27,8 @@ class PSList(QListView):
         self._setup_ui()
 
     def _setup_ui(self):
-        self._model = QStandardItemModel(self)
-        for ps in self._pwrsupplies:
-            text = QStandardItem()
-            text.setData(ps, Qt.DisplayRole)
-            self._model.appendRow(text)
-
-        self.setModel(self._model)
+        self.clear()
+        self.addItems(self._pwrsupplies)
 
     def _open_detail(self, index):
         app = QApplication.instance()

--- a/pyqt-apps/siriushla/widgets/led.py
+++ b/pyqt-apps/siriushla/widgets/led.py
@@ -1,5 +1,6 @@
-from qtpy.QtGui import QStandardItemModel, QStandardItem
-from qtpy.QtWidgets import QListView, QVBoxLayout, QLabel, QPushButton, \
+"""Led widgets."""
+
+from qtpy.QtWidgets import QListWidget, QVBoxLayout, QLabel, QPushButton, \
     QGridLayout, QCheckBox
 from qtpy.QtCore import Qt
 from copy import deepcopy as _dcopy
@@ -359,20 +360,21 @@ class PyDMLedMultiChannel(QLed, PyDMWidget):
     def mouseDoubleClickEvent(self, ev):
         pv_groups, texts = list(), list()
         pvs_err, pvs_und = set(), set()
-        for k, v in self._address2status.items():
-            if not v:
-                pvs_err.add(k)
-        if pvs_err:
-            pv_groups.append(pvs_err)
-            texts.append(
-                'There are PVs with values different\n'
-                'from the desired ones!')
         for k, v in self._address2conn.items():
             if not v:
                 pvs_und.add(k)
         if pvs_und:
             pv_groups.append(pvs_und)
             texts.append('There are disconnected PVs!')
+
+        for k, v in self._address2status.items():
+            if not v and k not in pvs_und:
+                pvs_err.add(k)
+        if pvs_err:
+            pv_groups.append(pvs_err)
+            texts.append(
+                'There are PVs with values different\n'
+                'from the desired ones!')
 
         if pv_groups:
             msg = MultiChannelStatusDialog(
@@ -513,7 +515,7 @@ class MultiChannelStatusDialog(SiriusDialog):
         lay.addWidget(self._ok_bt)
 
 
-class _PVList(QListView):
+class _PVList(QListWidget):
     """PV List."""
 
     clicked_item_data = Signal(str)
@@ -521,12 +523,7 @@ class _PVList(QListView):
     def __init__(self, pvs=set(), parent=None):
         """Constructor."""
         super().__init__(parent)
-        self._model = QStandardItemModel(self)
-        for pv in pvs:
-            text = QStandardItem()
-            text.setData(pv, Qt.DisplayRole)
-            self._model.appendRow(text)
-        self.setModel(self._model)
+        self.addItems(pvs)
         self.doubleClicked.connect(self.emit_item_data)
 
     def emit_item_data(self, index):


### PR DESCRIPTION
Hi guys, this PR fixes:
- a weird behavior of status dialog lists (I replaced the use of QListView with QListWidget), which added blank lines in status lists
- a bug due to which disconnected PVs were also added to the list of PVs with different values than desired 