### PR TITLE
Fix Orbit Interlock control window

### DIFF
--- a/pyqt-apps/siriushla/as_ap_radmon/main.py
+++ b/pyqt-apps/siriushla/as_ap_radmon/main.py
@@ -173,6 +173,7 @@ class RadTotDoseMonitor(QWidget):
             frame.add_widget(lb)
 
             desc = QLabel(pvn + ' ' + local, self, alignment=Qt.AlignCenter)
+            desc.setSizePolicy(QSzPol.Preferred, QSzPol.Maximum)
             desc.setStyleSheet(
                 'QLabel{background-color:black; color:white;font-size:26pt;}')
             self._desc_labels[pvn] = desc

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -378,7 +378,7 @@ class SOFBControl(BaseWidget):
         wid = self.create_pair(gpbx, 'LoopFreq')
         fbl.addRow(lbl, wid)
 
-        lbl = QLabel('Max. Orb. Distortion', gpbx)
+        lbl = QLabel('Max. Orb. Distortion [um]', gpbx)
         wid = self.create_pair(gpbx, 'LoopMaxOrbDistortion')
         fbl.addRow(lbl, wid)
 

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -93,7 +93,7 @@ SEC_2_CHANNELS = {
             'Circ FlwRt': 'RA-TLBO:RF-Circulator:FlwRt-Mon',
             'Load FlwRt': 'RA-TLBO:RF-Load:FlwRt-Mon',
             'Circ Intlk': 'RA-TLBO:RF-Circulator:IntlkOp-Mon',
-            'Circ Limits': (18.0, 25.0),
+            'Circ Limits': (19.0, 23.0),
         },
         'SSA': {
             'Name': 'SSA',

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -52,7 +52,8 @@ class BaseObject(BaseOrbitIntlk):
                 prefix=self._prefix, propty=propty)
             if pvname in self._pvs:
                 continue
-            new_pvs[pvname] = _PV(pvname, connection_timeout=0.01)
+            new_pvs[pvname] = _PV(
+                pvname, auto_monitor=False, connection_timeout=0.01)
         self._pvs.update(new_pvs)
 
     def _get_values(self, propty):

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -1,6 +1,7 @@
 """Base Object."""
 
 import numpy as _np
+from epics.ca import ChannelAccessException
 from siriuspy.epics import PV as _PV
 from siriuspy.envars import VACA_PREFIX
 from siriuspy.namesys import SiriusPVName
@@ -66,7 +67,10 @@ class BaseObject(BaseOrbitIntlk):
         for psn in self.BPM_NAMES:
             pvname = SiriusPVName(psn).substitute(
                 prefix=self._prefix, propty=propty)
-            val = self._pvs[pvname].get()
+            try:
+                val = self._pvs[pvname].get()
+            except ChannelAccessException:
+                val = None
             if val is None:
                 val = 0
             elif propty.startswith('Intlk') and propty.endswith('-Mon'):

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -1,5 +1,6 @@
 """Base Object."""
 
+import numpy as _np
 from siriuspy.epics import PV as _PV
 from siriuspy.envars import VACA_PREFIX
 from siriuspy.namesys import SiriusPVName
@@ -31,7 +32,16 @@ class BaseObject(BaseOrbitIntlk):
         Returns:
             si_orbit: si orbit configuration value from ConfigDB
         """
-        return self._client.get_config_value(configname)
+        try:
+            configvalue = self._client.get_config_value(configname)
+            value = dict()
+            value['x'] = _np.array(configvalue['x']) * self.CONV_UM2NM
+            value['y'] = _np.array(configvalue['y']) * self.CONV_UM2NM
+        except:
+            value = dict()
+            value['x'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
+            value['y'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
+        return value
 
     # --- pv handler methods ---
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -408,11 +408,11 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
         idxsel, namesel = list(), list()
         for idx, wid in enumerate(self._bpm_sel.widgets):
             name = self.BPM_NAMES[idx]
-            led = wid.findChild(QLed)
-            if led.isSelected():
+            check = wid.findChild(QCheckBox)
+            if check.isChecked():
                 idxsel.append(idx)
                 namesel.append(name)
-                led.setSelected(False)
+                check.setChecked(False)
         if not namesel:
             return
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -118,6 +118,7 @@ class RefOrbComboBox(QComboBox):
             'Zero', 'ref_orb', 'bba_orb', 'other...']
         for item in self._choose_reforb:
             self.addItem(item)
+        self.setCurrentText('ref_orb')
         self.activated.connect(self._add_reforb_entry)
 
     @Slot(int)
@@ -263,7 +264,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
             self._create_pvs('Sum-Mon')
             self._summon = _np.zeros(len(self.BPM_NAMES), dtype=float)
         else:
-            self._set_ref_orb('Zero')
+            self._set_ref_orb('ref_orb')
 
         self.prefix = prefix
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -79,17 +79,18 @@ class FamBPMIntlkEnblStateLed(PyDMLedMultiChannel):
                 state = 1
         self.setState(state)
 
-    def mouseDoubleClickEvent(self, ev):
+    def mouseDoubleClickEvent(self, _):
+        """Reimplement mouseDoubleClick."""
         pv_groups, texts = list(), list()
         pvs_err, pvs_und = set(), set()
-        for k, v in self._address2conn.items():
-            if not v:
+        for k, val in self._address2conn.items():
+            if not val:
                 pvs_und.add(k)
         if pvs_und:
             pv_groups.append(pvs_und)
             texts.append('There are disconnected PVs!')
-        for k, v in self._address2status.items():
-            if not v and k not in pvs_und:
+        for k, val in self._address2status.items():
+            if not val and k not in pvs_und:
                 pvs_err.add(k)
         if pvs_err:
             pv_groups.append(pvs_err)

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -10,7 +10,6 @@ from qtpy.QtWidgets import QPushButton, QComboBox, QSizePolicy as QSzPlcy, \
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName
-from siriuspy.clientconfigdb import ConfigDBClient
 
 from ..widgets import SiriusConnectionSignal as _ConnSignal, \
     PyDMLedMultiChannel, PyDMLed, SiriusLedState, QLed, SelectionMatrixWidget
@@ -259,10 +258,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
             self._create_pvs('Sum-Mon')
             self._summon = _np.zeros(len(self.BPM_NAMES))
         else:
-            self._reforb = dict()
-            self._reforb['x'] = _np.zeros(len(self.BPM_NAMES))
-            self._reforb['y'] = _np.zeros(len(self.BPM_NAMES))
-            self._client = ConfigDBClient(config_type='si_orbit')
+            self._set_ref_orb('Zero')
 
         self.prefix = prefix
 
@@ -397,13 +393,14 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
         lay.addWidget(groupsel, 1, 1)
 
     def _set_ref_orb(self, text):
+        self._reforb = dict()
         if text.lower() == 'zero':
-            self._reforb['x'] = _np.zeros(len(self.BPM_NAMES))
-            self._reforb['y'] = _np.zeros(len(self.BPM_NAMES))
+            self._reforb['x'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
+            self._reforb['y'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
         else:
             data = self.get_ref_orb(text)
-            self._reforb['x'] = _np.array(data['x']) * self.CONV_UM2NM
-            self._reforb['y'] = _np.array(data['y']) * self.CONV_UM2NM
+            self._reforb['x'] = data['x']
+            self._reforb['y'] = data['y']
 
     def _get_new_sum(self):
         self._summon = _np.array(self._get_values('Sum-Mon'))

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -261,7 +261,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
 
         if 'sum' in self.metric:
             self._create_pvs('Sum-Mon')
-            self._summon = _np.zeros(len(self.BPM_NAMES))
+            self._summon = _np.zeros(len(self.BPM_NAMES), dtype=float)
         else:
             self._set_ref_orb('Zero')
 
@@ -427,7 +427,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
                 if not self._checks[lsp].isChecked():
                     continue
                 lval = self._spins[lsp].value()
-                plan = 'x' if 'x' in lsp.lower() else 'y'
+                plan = 'y' if 'y' in lsp.lower() else 'x'
                 metric = self.calc_intlk_metric(
                     self._reforb[plan], metric=self.metric)
                 allvals = _np.round(_np.array(metric) + lval)

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -398,7 +398,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
             self._reforb['y'] = data['y']
 
     def _get_new_sum(self):
-        self._summon = _np.array(self._get_values('Sum-Mon'))
+        self._summon = _np.array(self._get_values('Sum-Mon'), dtype=float)
         text = 'Read at ' + _time.strftime(
             '%d/%m/%Y %H:%M:%S\n', _time.localtime(_time.time()))
         self._label_getsts.setText(text)

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -165,21 +165,22 @@ class _BPMSelectionWidget(BaseObject, SelectionMatrixWidget):
         sz_polc = QSzPlcy(QSzPlcy.Fixed, QSzPlcy.Fixed)
         for idx, name in enumerate(self.BPM_NAMES):
             wid = QWidget(self.parent())
-            led = SiriusLedState(self)
-            led.setParent(wid)
-            led.setSizePolicy(sz_polc)
             tooltip = '{0}; Pos = {1:5.1f} m'.format(
                 self.BPM_NICKNAMES[idx], self.BPM_POS[idx])
-            led.setToolTip(tooltip)
             if self.propty:
+                item = SiriusLedState(self)
+                item.setParent(wid)
+                item.setSizePolicy(sz_polc)
+                item.setToolTip(tooltip)
                 pvname = SiriusPVName.from_sp2rb(
                     name.substitute(prefix=self.prefix, propty=self.propty))
-                led.channel = pvname
+                item.channel = pvname
             else:
-                led.state = 1
+                item = QCheckBox(self)
+                item.setSizePolicy(sz_polc)
             hbl = QHBoxLayout(wid)
             hbl.setContentsMargins(0, 0, 0, 0)
-            hbl.addWidget(led)
+            hbl.addWidget(item)
             widgets.append(wid)
         return widgets
 
@@ -382,8 +383,8 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
         groupsel.setStyleSheet(
             '#groupsel{min-width: 27em; max-width: 27em;}')
         self._bpm_sel = _BPMSelectionWidget(
-            self, show_toggle_all_true=False,
-            toggle_all_false_text='Select All', prefix=self.prefix)
+            self, show_toggle_all_false=False,
+            toggle_all_true_text='Select All', prefix=self.prefix)
         lay_groupsel = QGridLayout(groupsel)
         lay_groupsel.addWidget(self._bpm_sel)
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -669,14 +669,14 @@ class _UpdateGraphThread(BaseObject, QThread):
                 vals -= self._reforb
                 vals = _np.array(self.calc_intlk_metric(
                     vals, metric=self.metric), dtype=float)
+                vals = vals * self.CONV_NM2M
             else:
                 # sum case
                 _av = self.CONV_POLY_MONIT1_2_MONIT[0, :]
                 _bv = self.CONV_POLY_MONIT1_2_MONIT[1, :]
                 vals = _np.array(self._get_values(self.meas_data), dtype=float)
                 vals = (vals - _bv)/_av
-
-            y_data_meas = list(vals * self.CONV_NM2M)
+            y_data_meas = list(vals)
 
             self.dataChanged.emit(['meas', symbols_meas, y_data_meas])
 
@@ -695,9 +695,11 @@ class _UpdateGraphThread(BaseObject, QThread):
 
             # data min
             vals = _np.array(self._get_values(self.min_data), dtype=float)
-            ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
-            vals -= ref
-            y_data_min = list(vals * self.CONV_NM2M)
+            if self.metric in ['trans', 'ang']:
+                ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
+                vals -= ref
+                vals = vals * self.CONV_NM2M
+            y_data_min = list(vals)
 
             self.dataChanged.emit(['min', symbols_min, y_data_min])
 
@@ -716,9 +718,11 @@ class _UpdateGraphThread(BaseObject, QThread):
 
             # data max
             vals = _np.array(self._get_values(self.max_data), dtype=float)
-            ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
-            vals -= ref
-            y_data_max = list(vals * self.CONV_NM2M)
+            if self.metric in ['trans', 'ang']:
+                ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
+                vals -= ref
+                vals = vals * self.CONV_NM2M
+            y_data_max = list(vals)
 
             self.dataChanged.emit(['max', symbols_max, y_data_max])
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -553,7 +553,6 @@ class _BaseGraphWidget(BaseObject, QWidget):
         elif self._plan:
             data = self.get_ref_orb(text)
             self._reforb = _np.array(data[self._plan], dtype=float)
-        self._reforb *= self.CONV_UM2NM
         self.refOrbChanged.emit(self._reforb)
 
     def _setupUi(self):

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -573,8 +573,19 @@ class _BaseGraphWidget(BaseObject, QWidget):
 
     def closeEvent(self, ev):
         self._thread.exit_task()
+        self._wait_thread()
         self._thread.deleteLater()
         super().closeEvent(ev)
+
+    def _wait_thread(self):
+        init = _time.time()
+        try:
+            while self._thread.isRunning():
+                _time.sleep(0.1)
+                if _time.time() - init > 10:
+                    raise Exception('Thread will not leave')
+        except RuntimeError:
+            pass
 
 
 class _UpdateGraphThread(BaseObject, QThread):

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -571,11 +571,12 @@ class _BaseGraphWidget(BaseObject, QWidget):
         setattr(self.graph, 'symbols_'+curve, symb)
         setattr(self.graph, 'y_data_'+curve, data)
 
-    def closeEvent(self, ev):
+    def closeEvent(self, event):
+        """Finish thread on close."""
         self._thread.exit_task()
         self._wait_thread()
         self._thread.deleteLater()
-        super().closeEvent(ev)
+        super().closeEvent(event)
 
     def _wait_thread(self):
         init = _time.time()

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -517,6 +517,7 @@ class _BaseGraphWidget(BaseObject, QWidget):
         self._plan = '' if 'Sum' in self.INTLKTYPE else self.INTLKTYPE[-1]
         self._plan = self._plan.lower()
         self._reforb = _np.zeros(len(self.BPM_NAMES), dtype=float)
+        self.update_propty_reforb('ref_orb')
 
         self._setupUi()
 

--- a/pyqt-apps/siriushla/sirius_application.py
+++ b/pyqt-apps/siriushla/sirius_application.py
@@ -45,7 +45,7 @@ def excepthook(exctype, excvalue, tracebackobj):
     notice = \
         'An unhandled exception occurred. Please report the problem '\
         'via email to <{}>.\nA log has {{}}been written to "{}".\n\n'\
-        'Error information:\n'.format("fernando.sa@lnls.br", LOGFILE)
+        'Error information:\n'.format("ana.clara@lnls.br", LOGFILE)
     timestring = time.strftime("%Y-%m-%d, %H:%M:%S") + '\n'
 
     tbinfofile = StringIO()


### PR DESCRIPTION
In Orbit Interlock control window: 
- Fixes 
  - fix bugs in graph curves and maximum Y threshold setpoints
  - turn off graph PV auto_monitor
  - wait graph update thread to finish before closing window
  - always store reference orbit in [nm]
- Enhancements
  - use checkboxes in threshold setpoint windows
  - use ref_orb as default reference 
  - use EpicsTasks and epics.PV instead of SiriusConnectionSignal in some widgets to reduce memory use
 
Some other fixes:
- (MNT) App: Change contact email in error log 
- (FIX) Radiation Monitor: fix location description labels
- (FIX) BO RF: fix circulator temperature limits
- (MNT) SOFB: add unit to Max. Orb. Distortion label