### PR TITLE
Add PyDMSpinboxScrollbar and override uses of PyDMLinEditScrollbar

### DIFF
--- a/pyqt-apps/siriushla/as_ap_injcontrol/base.py
+++ b/pyqt-apps/siriushla/as_ap_injcontrol/base.py
@@ -12,7 +12,7 @@ from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 
 from siriushla import util
 from siriushla.widgets import SiriusMainWindow, PyDMLed, \
-    SiriusLedState, PyDMLinEditScrollbar
+    SiriusLedState, PyDMSpinboxScrollbar
 from siriushla.as_di_scrns import SiriusScrnView
 from siriushla.as_ps_control import PSDetailWindow
 from siriushla.as_pu_control import PUDetailWindow
@@ -199,21 +199,14 @@ class BaseWindow(SiriusMainWindow):
             min-width:6em; max-width:6em; min-height:1.29em;""")
         lay.addWidget(pb, 1, 2)
 
-        sp_kick = PyDMLinEditScrollbar(
-            parent=self, channel=corr.substitute(
-                prefix=self.prefix, propty=propty_sp))
-        sp_kick.layout.setContentsMargins(0, 0, 0, 0)
-        sp_kick.layout.setSpacing(3)
-        sp_kick.setSizePolicy(QSzPlcy.Fixed, QSzPlcy.Maximum)
-        sp_kick.sp_lineedit.setStyleSheet("""
-            min-width:4em; max-width:4em; min-height:1.29em;""")
-        sp_kick.sp_lineedit.setAlignment(Qt.AlignCenter)
-        sp_kick.sp_lineedit.setSizePolicy(
-            QSzPlcy.Minimum, QSzPlcy.Minimum)
-        sp_kick.sp_lineedit.precisionFromPV = False
-        sp_kick.sp_lineedit.precision = 1
-        sp_kick.sp_scrollbar.setStyleSheet("""max-width:4em;""")
-        sp_kick.sp_scrollbar.limitsFromPV = True
+        sp_kick = PyDMSpinboxScrollbar(
+            self, corr.substitute(prefix=self.prefix, propty=propty_sp))
+        sp_kick.setStyleSheet(
+            "QDoubleSpinBox{min-width:4em; max-width:4em; }"
+            "QScrollBar{max-width:4em;}")
+        sp_kick.spinbox.precisionFromPV = False
+        sp_kick.spinbox.precision = 1
+        sp_kick.scrollbar.limitsFromPV = True
         lay.addWidget(sp_kick, 1, 3, 2, 1)
 
         lb_kick = PyDMLabel(

--- a/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
+++ b/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
@@ -18,7 +18,7 @@ from siriuspy.namesys import SiriusPVName as _PVName
 
 from siriushla import util as _hlautil
 from siriushla.widgets import SiriusMainWindow, PyDMLogLabel, SiriusLedAlert, \
-    PyDMLinEditScrollbar, PyDMLedMultiChannel, SiriusConnectionSignal
+    PyDMSpinboxScrollbar, PyDMLedMultiChannel, SiriusConnectionSignal
 from siriushla.as_ps_control import PSDetailWindow as _PSDetailWindow
 from siriushla.as_pu_control import PUDetailWindow as _PUDetailWindow
 from siriushla.as_ap_configdb import LoadConfigDialog as _LoadConfigDialog
@@ -156,7 +156,7 @@ class PosAngCorr(SiriusMainWindow):
             PyDMSpinbox{
                 min-width: 5em; max-width: 5em;
             }
-            PyDMLabel, PyDMLinEditScrollbar{
+            PyDMLabel, PyDMSpinboxScrollbar{
                 min-width: 6em; max-width: 6em;
             }
             QPushButton{
@@ -236,16 +236,10 @@ class PosAngCorr(SiriusMainWindow):
                 _hlautil.connect_window(
                     pbt, _PSDetailWindow, self, psname=corr)
             lb_name = QLabel(corr, self)
-            le_sp = PyDMLinEditScrollbar(
-                corr.substitute(prefix=self._prefix, propty='Kick-SP'), self)
-            le_sp.layout.setContentsMargins(0, 0, 0, 0)
-            le_sp.layout.setSpacing(3)
-            le_sp.setSizePolicy(QSzPlcy.Minimum, QSzPlcy.Maximum)
-            le_sp.sp_lineedit.setStyleSheet("min-height:1.29em;")
-            le_sp.sp_lineedit.setAlignment(Qt.AlignCenter)
-            le_sp.sp_lineedit.setSizePolicy(QSzPlcy.Ignored, QSzPlcy.Fixed)
-            le_sp.sp_scrollbar.setStyleSheet("max-height:0.7em;")
-            le_sp.sp_scrollbar.limitsFromPV = True
+            le_sp = PyDMSpinboxScrollbar(
+                self, corr.substitute(prefix=self._prefix, propty='Kick-SP'))
+            le_sp.spinbox.setAlignment(Qt.AlignCenter)
+            le_sp.scrollbar.limitsFromPV = True
             lb_rb = PyDMLabel(self, corr.substitute(
                 prefix=self._prefix, propty='Kick-RB'))
             lb_ref = PyDMLabel(self, self.posang_prefix.substitute(
@@ -269,21 +263,13 @@ class PosAngCorr(SiriusMainWindow):
             lay.addWidget(label_voltrb, idx+2, 3)
 
             lb_kly2_name = QLabel('Klystron 2', self)
-            le_kly2_sp = PyDMLinEditScrollbar(
-                pref+'LA-RF:LLRF:KLY2:SET_AMP', self)
-            le_kly2_sp.layout.setContentsMargins(0, 0, 0, 0)
-            le_kly2_sp.layout.setSpacing(3)
-            le_kly2_sp.setSizePolicy(QSzPlcy.Minimum, QSzPlcy.Maximum)
-            le_kly2_sp.sp_lineedit.setStyleSheet("min-height:1.29em;")
-            le_kly2_sp.sp_lineedit.precisionFromPV = False
-            le_kly2_sp.sp_lineedit.precision = 2
-            le_kly2_sp.sp_lineedit.setAlignment(Qt.AlignCenter)
-            le_kly2_sp.sp_lineedit.setSizePolicy(
-                QSzPlcy.Ignored, QSzPlcy.Fixed)
-            le_kly2_sp.sp_scrollbar.setStyleSheet("max-height:0.7em;")
-            le_kly2_sp.sp_scrollbar.limitsFromPV = True
-            lb_kly2_rb = PyDMLabel(
-                self, pref+'LA-RF:LLRF:KLY2:GET_AMP')
+            le_kly2_sp = PyDMSpinboxScrollbar(
+                self, pref+'LA-RF:LLRF:KLY2:SET_AMP')
+            le_kly2_sp.spinbox.precisionFromPV = False
+            le_kly2_sp.spinbox.precision = 2
+            le_kly2_sp.spinbox.setAlignment(Qt.AlignCenter)
+            le_kly2_sp.scrollbar.limitsFromPV = True
+            lb_kly2_rb = PyDMLabel(self, pref+'LA-RF:LLRF:KLY2:GET_AMP')
             lb_kly2_rb.precisionFromPV = False
             lb_kly2_rb.precision = 2
             lay.addWidget(lb_kly2_name, idx+3, 1,
@@ -311,17 +297,10 @@ class PosAngCorr(SiriusMainWindow):
         lb_kckr_name = QLabel(self._kckr_name, self)
         _hlautil.connect_window(
             pb_kckr, _PUDetailWindow, self, devname=self._kckr_name)
-        lb_kckr_sp = PyDMLinEditScrollbar(
-            self._kckr_name.substitute(
-                prefix=self._prefix, propty='Voltage-SP'), self)
-        lb_kckr_sp.layout.setContentsMargins(0, 0, 0, 0)
-        lb_kckr_sp.layout.setSpacing(3)
-        lb_kckr_sp.setSizePolicy(QSzPlcy.Minimum, QSzPlcy.Maximum)
-        lb_kckr_sp.sp_lineedit.setStyleSheet("min-height:1.29em;")
-        lb_kckr_sp.sp_lineedit.setAlignment(Qt.AlignCenter)
-        lb_kckr_sp.sp_lineedit.setSizePolicy(QSzPlcy.Ignored, QSzPlcy.Fixed)
-        lb_kckr_sp.sp_scrollbar.setStyleSheet("max-height:0.7em;")
-        lb_kckr_sp.sp_scrollbar.limitsFromPV = True
+        lb_kckr_sp = PyDMSpinboxScrollbar(
+            self, self._kckr_name.substitute(
+                prefix=self._prefix, propty='Voltage-SP'))
+        lb_kckr_sp.scrollbar.limitsFromPV = True
         lb_kckr_rb = PyDMLabel(self, self._kckr_name.substitute(
             prefix=self._prefix, propty='Voltage-RB'))
         lay.addWidget(pb_kckr, idx+5, 0, alignment=Qt.AlignTop)

--- a/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
+++ b/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
@@ -12,7 +12,7 @@ from siriuspy.namesys import SiriusPVName as PVName
 from siriuspy.search import PSSearch
 from siriuspy.pwrsupply.csdev import PS_LI_INTLK_THRS as _PS_LI_INTLK
 from siriushla.widgets import PyDMStateButton, SiriusLedState, \
-    SiriusLedAlert, PyDMLinEditScrollbar, PyDMLedMultiChannel, \
+    SiriusLedAlert, PyDMSpinboxScrollbar, PyDMLedMultiChannel, \
     SiriusEnumComboBox
 from .detail_widget.custom_widgets import LISpectIntlkLed
 
@@ -513,7 +513,7 @@ class SummaryWidget(QWidget):
         else:
             lay = QVBoxLayout(widget)
         lay.setSpacing(0)
-        lay.setContentsMargins(0, 0, 0, 0)
+        lay.setContentsMargins(0, 3, 0, 3)
         return widget
 
     def fillWidget(self, name):
@@ -619,11 +619,10 @@ class SummaryWidget(QWidget):
                 '#updparms_bt{min-width:25px;max-width:25px;icon-size:20px;}')
             self.updparms_wid.layout().addWidget(self.updparms_bt)
         elif name == 'setpoint' and self._has_analsp:
-            self.setpoint = PyDMLinEditScrollbar(self._analog_sp, self)
-            self.setpoint.sp_scrollbar.setTracking(False)
+            self.setpoint = PyDMSpinboxScrollbar(self, self._analog_sp)
             if self._is_fofb:
-                self.setpoint.sp_lineedit.precisionFromPV = False
-                self.setpoint.sp_lineedit.precision = 6
+                self.setpoint.spinbox.precisionFromPV = False
+                self.setpoint.spinbox.precision = 6
             self.setpoint_wid.layout().addWidget(self.setpoint)
         elif name == 'readback' and self._has_analrb:
             self.readback = PyDMLabel(self, self._analog_rb)
@@ -635,9 +634,7 @@ class SummaryWidget(QWidget):
             self.monitor = PyDMLabel(self, self._analog_mon)
             self.monitor_wid.layout().addWidget(self.monitor)
         elif name == 'strength_sp' and self._has_strength:
-            self.strength_sp_le = PyDMLinEditScrollbar(
-                parent=self, channel=self._strength_sp)
-            self.strength_sp_le.sp_scrollbar.setTracking(False)
+            self.strength_sp_le = PyDMSpinboxScrollbar(self, self._strength_sp)
             self.strength_sp_wid.layout().addWidget(self.strength_sp_le)
         elif name == 'strength_rb' and self._has_strength:
             self.strength_rb_lb = PyDMLabel(

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -27,7 +27,7 @@ from siriuspy.pwrsupply.csdev import get_ps_propty_database, get_ps_modules, \
 from siriuspy.devices import PowerSupply
 
 from ... import util
-from ...widgets import PyDMStateButton, PyDMLinEditScrollbar, SiriusTimePlot, \
+from ...widgets import PyDMStateButton, PyDMSpinboxScrollbar, SiriusTimePlot, \
     SiriusConnectionSignal, SiriusLedState, SiriusLedAlert, PyDMLed, \
     PyDMLedMultiChannel, SiriusDialog, SiriusWaveformTable, SiriusSpinbox, \
     SiriusHexaSpinbox
@@ -497,10 +497,8 @@ class PSDetailWidget(QWidget):
         self.current_ref_label = QLabel("Ref Mon")
         self.current_mon_label = QLabel("Mon")
 
-        self.current_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=self._prefixed_psname + ":Current-SP")
-        self.current_sp_widget.layout.setContentsMargins(0, 0, 0, 0)
-        self.current_sp_widget.sp_scrollbar.setTracking(False)
+        self.current_sp_widget = PyDMSpinboxScrollbar(
+            self, self._prefixed_psname + ":Current-SP")
         self.current_rb_val = PyDMLabel(
             parent=self, init_channel=self._prefixed_psname+":Current-RB")
         self.current_rb_val.showUnits = True
@@ -537,10 +535,7 @@ class PSDetailWidget(QWidget):
         self.metric_ref_label = QLabel("Ref Mon")
         self.metric_mon_label = QLabel("Mon")
 
-        self.metric_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=metric_sp_ch)
-        self.metric_sp_widget.layout.setContentsMargins(0, 0, 0, 0)
-        self.metric_sp_widget.sp_scrollbar.setTracking(False)
+        self.metric_sp_widget = PyDMSpinboxScrollbar(self, metric_sp_ch)
         self.metric_rb_val = PyDMLabel(
             parent=self, init_channel=metric_rb_ch)
         self.metric_rb_val.showUnits = True
@@ -1064,10 +1059,8 @@ class LIPSDetailWidget(PSDetailWidget):
         self.current_rb_label = QLabel("Readback")
         self.current_mon_label = QLabel("Mon")
 
-        self.current_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=self._prefixed_psname + ":Current-SP")
-        self.current_sp_widget.layout.setContentsMargins(0, 0, 0, 0)
-        self.current_sp_widget.sp_scrollbar.setTracking(False)
+        self.current_sp_widget = PyDMSpinboxScrollbar(
+            self, self._prefixed_psname + ":Current-SP")
         self.current_rb_val = PyDMLabel(
             parent=self, init_channel=self._prefixed_psname+":Current-RB")
         self.current_rb_val.showUnits = True
@@ -1096,10 +1089,7 @@ class LIPSDetailWidget(PSDetailWidget):
         self.metric_rb_label = QLabel("Readback")
         self.metric_mon_label = QLabel("Mon")
 
-        self.metric_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=metric_sp_ch)
-        self.metric_sp_widget.layout.setContentsMargins(0, 0, 0, 0)
-        self.metric_sp_widget.sp_scrollbar.setTracking(False)
+        self.metric_sp_widget = PyDMSpinboxScrollbar(self, metric_sp_ch)
         self.metric_rb_val = PyDMLabel(
             parent=self, init_channel=metric_rb_ch)
         self.metric_rb_val.showUnits = True
@@ -1261,19 +1251,16 @@ class FBPDCLinkDetailWidget(DCLinkDetailWidget):
         self.current_ref_label = QLabel("Ref Mon")
         self.current_mon_label = QLabel("Mon")
 
-        self.current_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=self._prefixed_psname + ":Voltage-SP")
-        self.current_sp_widget.layout.setContentsMargins(0, 0, 0, 0)
-        self.current_sp_widget.sp_lineedit.showUnits = False
-        self.current_sp_widget.sp_scrollbar.setTracking(False)
+        self.current_sp_widget = PyDMSpinboxScrollbar(
+            self, self._prefixed_psname + ":Voltage-SP")
         self.current_rb_val = PyDMLabel(
-            parent=self, init_channel=self._prefixed_psname+":Voltage-RB")
+            self, self._prefixed_psname+":Voltage-RB")
         self.current_rb_val.precFromPV = True
         self.current_ref_val = PyDMLabel(
-            parent=self, init_channel=self._prefixed_psname+":VoltageRef-Mon")
+            self, self._prefixed_psname+":VoltageRef-Mon")
         self.current_ref_val.precFromPV = True
         self.current_mon_val = PyDMLabel(
-            parent=self, init_channel=self._prefixed_psname+":Voltage-Mon")
+            self, self._prefixed_psname+":Voltage-Mon")
         self.current_mon_val.precFromPV = True
 
         layout = QGridLayout()
@@ -1329,10 +1316,8 @@ class FACDCLinkDetailWidget(DCLinkDetailWidget):
         self.cap_bank_ref_label = QLabel("Ref Mon")
         self.cap_bank_mon_label = QLabel("Mon")
 
-        self.cap_bank_sp_widget = PyDMLinEditScrollbar(
+        self.cap_bank_sp_widget = PyDMSpinboxScrollbar(
             self._prefixed_psname + ":CapacitorBankVoltage-SP", self)
-        self.cap_bank_sp_widget.sp_lineedit.showUnits = False
-        self.cap_bank_sp_widget.sp_scrollbar.setTracking(False)
         self.cap_bank_rb_val = PyDMLabel(
             self,
             self._prefixed_psname + ":CapacitorBankVoltage-RB")
@@ -1525,11 +1510,10 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         current_sp_label = QLabel("Setpoint")
         current_rb_label = QLabel("Readback")
 
-        self.current_sp = SiriusSpinbox(
+        self.current_sp = PyDMSpinboxScrollbar(
             self, self._prefixed_psname + ":Current-SP")
-        self.current_sp.precisionFromPV = False
-        self.current_sp.precision = 6
-        self.current_sp.showStepExponent = False
+        self.current_sp.spinbox.precisionFromPV = False
+        self.current_sp.spinbox.precision = 6
         self.current_rb = PyDMLabel(
             self, self._prefixed_psname+":Current-RB")
         self.current_rb.precisionFromPV = False
@@ -1549,9 +1533,8 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         current_sp_label = QLabel("Setpoint")
         current_rb_label = QLabel("Readback")
 
-        self.current_raw_sp = SiriusSpinbox(
+        self.current_raw_sp = PyDMSpinboxScrollbar(
             self, self._prefixed_psname + ":CurrentRaw-SP")
-        self.current_raw_sp.showStepExponent = False
         self.current_raw_rb = PyDMLabel(
             self, self._prefixed_psname+":CurrentRaw-RB")
 
@@ -1568,9 +1551,8 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         metric_sp_label = QLabel('Setpoint')
         metric_rb_label = QLabel('Readback')
 
-        self.metric_sp = SiriusSpinbox(
+        self.metric_sp = PyDMSpinboxScrollbar(
             self, self._prefixed_psname+':'+self._metric+'-SP')
-        self.metric_sp.showStepExponent = False
         self.metric_rb = PyDMLabel(
             self, self._prefixed_psname+':'+self._metric+'-RB')
         self.metric_rb.precisionFromPV = False

--- a/pyqt-apps/siriushla/as_pu_control/DetailWidget.py
+++ b/pyqt-apps/siriushla/as_pu_control/DetailWidget.py
@@ -9,7 +9,7 @@ from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 from siriushla import util
 from siriushla.widgets import SiriusLedState, SiriusLedAlert, PyDMLed, \
-    PyDMStateButton, PyDMLinEditScrollbar
+    PyDMStateButton, PyDMSpinboxScrollbar
 from siriushla.as_ti_control.hl_trigger import HLTriggerSimple
 
 
@@ -163,14 +163,12 @@ class PUDetailWidget(QWidget):
     def _voltage_layout(self):
         voltage_layout = QVBoxLayout()
 
-        self.voltage_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=self._voltage_sp_pv)
-        self.voltage_rb_label = PyDMLabel(
-            parent=self, init_channel=self._voltage_rb_pv)
-        self.voltage_rb_label .showUnits = True
+        self.voltage_sp_widget = PyDMSpinboxScrollbar(
+            self, self._voltage_sp_pv)
+        self.voltage_rb_label = PyDMLabel(self, self._voltage_rb_pv)
+        self.voltage_rb_label.showUnits = True
         self.voltage_rb_label.precisionFromPV = True
-        self.voltage_mon_label = PyDMLabel(
-            parent=self, init_channel=self._voltage_mon_pv)
+        self.voltage_mon_label = PyDMLabel(self, self._voltage_mon_pv)
         self.voltage_mon_label.showUnits = True
         self.voltage_mon_label.precisionFromPV = True
 
@@ -184,14 +182,11 @@ class PUDetailWidget(QWidget):
         return voltage_layout
 
     def _kick_layout(self):
-        self.kick_sp_widget = PyDMLinEditScrollbar(
-            parent=self, channel=self._kick_sp_pv)
-        self.kick_rb_label = PyDMLabel(
-            parent=self, init_channel=self._kick_rb_pv)
+        self.kick_sp_widget = PyDMSpinboxScrollbar(self, self._kick_sp_pv)
+        self.kick_rb_label = PyDMLabel(self, self._kick_rb_pv)
         self.kick_rb_label.showUnits = True
         self.kick_rb_label.precisionFromPV = True
-        self.kick_mon_label = PyDMLabel(
-            parent=self, init_channel=self._kick_mon_pv)
+        self.kick_mon_label = PyDMLabel(self, self._kick_mon_pv)
         self.kick_mon_label.showUnits = True
         self.kick_mon_label.precisionFromPV = True
 

--- a/pyqt-apps/siriushla/widgets/ledit_scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/ledit_scrollbar.py
@@ -1,29 +1,39 @@
 """Defines PyDM widget with a line edit and a double scrollbar."""
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QStyle, QStyleOption
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QGridLayout, QStyle, QStyleOption, \
+    QSizePolicy as QSzPol
 from qtpy.QtGui import QPainter
-from siriushla.widgets.scrollbar import PyDMScrollBar
-from siriushla.widgets.line_edit import SiriusLineEdit
+from .scrollbar import PyDMScrollBar
+from .line_edit import SiriusLineEdit
 
 
 class PyDMLinEditScrollbar(QWidget):
-    """Widget to set the setpoint of a float PV."""
+    """Composition of a LineEdit and a Scrollbar to set a float PV."""
 
-    def __init__(self, channel, parent=None):
-        """Constructor sets channel name."""
+    def __init__(self, parent=None, init_channel=None):
+        """Init."""
         super().__init__(parent)
-        self._channel = channel
-        self._setup_ui()
+        self._init_channel = init_channel
 
-    def _setup_ui(self):
-        self.layout = QVBoxLayout()
-        self.sp_lineedit = SiriusLineEdit(
-            parent=self, init_channel=self._channel)
-        self.sp_scrollbar = PyDMScrollBar(
-            parent=self, init_channel=self._channel)
-        self.sp_scrollbar.wheelEvent = lambda event: event.ignore()
-        self.layout.addWidget(self.sp_lineedit)
-        self.layout.addWidget(self.sp_scrollbar)
-        self.setLayout(self.layout)
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+
+        self.lineedit = SiriusLineEdit(
+            parent=self, init_channel=init_channel)
+        self.lineedit.setAlignment(Qt.AlignCenter)
+        self.lineedit.setStyleSheet("SiriusLineEdit{min-height:1.29em;}")
+        self.lineedit.setSizePolicy(QSzPol.Expanding, QSzPol.Preferred)
+
+        self.scrollbar = PyDMScrollBar(
+            parent=self, init_channel=init_channel)
+        self.scrollbar.wheelEvent = lambda event: event.ignore()
+        self.scrollbar.setTracking(False)
+        self.scrollbar.setStyleSheet("PyDMScrollBar{max-height:0.7em;}")
+
+        layout.addWidget(self.lineedit, 0, 0, 2, 1)
+        layout.addWidget(self.scrollbar, 2, 0, 1, 1)
 
     def paintEvent(self, event):
         """Need to override paintEvent in order to apply CSS."""

--- a/pyqt-apps/siriushla/widgets/spinbox_scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/spinbox_scrollbar.py
@@ -1,0 +1,35 @@
+"""Defines PyDM widget with a spinbox and a scrollbar."""
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QWidget, QGridLayout, QSizePolicy as QSzPol
+from .spinbox import SiriusSpinbox
+from .scrollbar import PyDMScrollBar
+
+
+class PyDMSpinboxScrollbar(QWidget):
+    """Composition of a Spinbox and a Scrollbar to set a float PV."""
+
+    def __init__(self, parent=None, init_channel=None):
+        """Init."""
+        super().__init__(parent)
+        self._init_channel = init_channel
+
+        layout = QGridLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+
+        self.spinbox = SiriusSpinbox(
+            parent=self, init_channel=init_channel)
+        self.spinbox.setAlignment(Qt.AlignCenter)
+        self.spinbox.showStepExponent = False
+        self.spinbox.setStyleSheet("SiriusSpinbox{min-height:1.29em;}")
+        self.spinbox.setSizePolicy(QSzPol.Expanding, QSzPol.Preferred)
+
+        self.scrollbar = PyDMScrollBar(
+            parent=self, init_channel=init_channel)
+        self.scrollbar.wheelEvent = lambda event: event.ignore()
+        self.scrollbar.setTracking(False)
+        self.scrollbar.setStyleSheet("PyDMScrollBar{max-height:0.7em;}")
+
+        layout.addWidget(self.spinbox, 0, 0, 2, 1)
+        layout.addWidget(self.scrollbar, 2, 0, 1, 1)


### PR DESCRIPTION
This is a simple request that comes from the early days of Sirius commissioning. Provides the use of spinboxes instead of lineedits for current and voltage control.

