### PR TITLE
Update fast corrector related windows

### DIFF
--- a/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
+++ b/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
@@ -86,32 +86,29 @@ def get_prop2width(psname):
     }
     if psmodel != 'REGATRON_DCLink':
         dic.update({'readback': '6'})
+    dic.update({'monitor': '6'})
     if psmodel != 'FOFB_PS':
-        dic.update({'monitor': '6'})
-    else:
         dic.update({'ctrlloop': '8'})
     if psname.sec == 'LI':
         dic['conn'] = '5'
-    elif psmodel != 'FOFB_PS':
-        dic.update({
-            'opmode': '8',
-            'reset': '4',
-        })
-        if psmodel != 'REGATRON_DCLink':
-            dic.update({
-                'bbb': 10,
-                'udc': 10,
-                'ctrlmode': '6',
-                'ctrlloop': '8',
-                'wfmupdate': '8',
-                'updparms': '6',
-            })
+    else:
+        dic.update({'opmode': '8'})
+        if psmodel != 'FOFB_PS':
+            dic.update({'reset': '4'})
+            if psmodel != 'REGATRON_DCLink':
+                dic.update({
+                    'bbb': 10,
+                    'udc': 10,
+                    'ctrlmode': '6',
+                    'ctrlloop': '8',
+                    'wfmupdate': '8',
+                    'updparms': '6',
+                })
     if get_strength_name(psname):
         dic.update({
             'strength_sp': '6',
-            'strength_rb': '6'})
-        if psmodel != 'FOFB_PS':
-            dic.update({'strength_mon': '8'})
+            'strength_rb': '6',
+            'strength_mon': '8'})
     if psname.dis == 'PU':
         dic.update({'pulse': '8'})
     if HasTrim.match(psname):
@@ -133,33 +130,30 @@ def get_prop2label(psname):
     }
     if psmodel != 'REGATRON_DCLink':
         dic.update({'readback': analog + '-RB'})
+    dic.update({'monitor': analog + '-Mon'})
     if psmodel != 'FOFB_PS':
-        dic.update({'monitor': analog + '-Mon'})
-    else:
         dic.update({'ctrlloop': 'Control Loop'})
     if psname.sec == 'LI':
         dic['conn'] = 'Connected'
-    elif psmodel != 'FOFB_PS':
-        dic.update({
-            'opmode': 'OpMode',
-            'reset': 'Reset',
-        })
-        if psmodel != 'REGATRON_DCLink':
-            dic.update({
-                'bbb': 'Beagle Bone',
-                'udc': 'UDC',
-                'ctrlmode': 'Control Mode',
-                'ctrlloop': 'Control Loop',
-                'wfmupdate': 'Wfm Update',
-                'updparms': 'Upd.Params',
-            })
+    else:
+        dic.update({'opmode': 'OpMode'})
+        if psmodel != 'FOFB_PS':
+            dic.update({'reset': 'Reset'})
+            if psmodel != 'REGATRON_DCLink':
+                dic.update({
+                    'bbb': 'Beagle Bone',
+                    'udc': 'UDC',
+                    'ctrlmode': 'Control Mode',
+                    'ctrlloop': 'Control Loop',
+                    'wfmupdate': 'Wfm Update',
+                    'updparms': 'Upd.Params',
+                })
     strength = get_strength_name(psname)
     if strength:
         dic.update({
             'strength_sp': strength + '-SP',
-            'strength_rb': strength + '-RB'})
-        if psmodel != 'FOFB_PS':
-            dic.update({'strength_mon': strength + '-Mon'})
+            'strength_rb': strength + '-RB',
+            'strength_mon': strength + '-Mon'})
     if psname.dis == 'PU':
         dic.update({'pulse': 'Pulse'})
     if HasTrim.match(psname):
@@ -211,24 +205,21 @@ class SummaryWidget(QWidget):
                 not self._is_regatron and not self._is_fofb:
             self._bbb_name = PSSearch.conv_psname_2_bbbname(self._name)
             self._udc_name = PSSearch.conv_psname_2_udc(self._name)
-        self._has_opmode = not self._is_linac and not self._is_pulsed\
-            and not self._is_fofb
+        self._has_opmode = not self._is_linac and not self._is_pulsed
         self._has_ctrlmode = not self._is_regatron and not self._is_linac\
             and not self._is_fofb
         self._has_pwrstate = not self._is_reg_slave
         self._has_reset = not self._is_linac and not self._is_fofb\
             and not self._is_reg_slave
         self._has_ctrlloop = not self._is_linac and not self._is_pulsed\
-            and not self._is_regatron
+            and not self._is_regatron and not self._is_fofb
         self._has_parmupdt = not self._is_linac and not self._is_regatron\
             and not self._is_fofb
         self._has_wfmupdt = self._has_parmupdt and not self._is_dclink
         self._has_analsp = not self._is_reg_slave
         self._has_analrb = not self._is_regatron
-        self._has_analmon = not self._is_fofb
         self._has_strength = bool(
             self._strength_name and not self._li_has_not_strength)
-        self._has_strength_mon = self._has_strength and not self._is_fofb
         self._has_trim = HasTrim.match(self._name)
 
         self._create_pvs()
@@ -331,11 +322,10 @@ class SummaryWidget(QWidget):
             self._widgets_dict['readback'] = self.readback_wid
             lay.addWidget(self.readback_wid)
 
-        if self._has_analmon:
-            self.monitor_wid = self._build_widget(
-                name='monitor', orientation='v')
-            self._widgets_dict['monitor'] = self.monitor_wid
-            lay.addWidget(self.monitor_wid)
+        self.monitor_wid = self._build_widget(
+            name='monitor', orientation='v')
+        self._widgets_dict['monitor'] = self.monitor_wid
+        lay.addWidget(self.monitor_wid)
 
         if self._has_strength:
             self.strength_sp_wid = self._build_widget(
@@ -348,7 +338,6 @@ class SummaryWidget(QWidget):
             self._widgets_dict['strength_rb'] = self.strength_rb_wid
             lay.addWidget(self.strength_rb_wid)
 
-        if self._has_strength_mon:
             self.strength_mon_wid = self._build_widget(
                 name='strength_mon', orientation='v')
             self._widgets_dict['strength_mon'] = self.strength_mon_wid
@@ -438,16 +427,8 @@ class SummaryWidget(QWidget):
                 self._genwrn = self._prefixed_name.substitute(
                     propty='GenWarn-Mon')
         elif self._is_fofb:
-            self._intlk = [
-                self._prefixed_name.substitute(
-                    propty='PSAmpOverCurrFlagL-Sts'),
-                self._prefixed_name.substitute(
-                    propty='PSAmpOverCurrFlagR-Sts'),
-                self._prefixed_name.substitute(
-                    propty='PSAmpOverTempFlagL-Sts'),
-                self._prefixed_name.substitute(
-                    propty='PSAmpOverTempFlagR-Sts'),
-            ]
+            self._intlk = self._prefixed_name.substitute(
+                propty='AlarmsAmp-Mon')
         else:
             self._soft_intlk = self._prefixed_name.substitute(
                 propty='IntlkSoft-Mon')
@@ -486,13 +467,12 @@ class SummaryWidget(QWidget):
         if self._has_analrb:
             self._analog_rb = self._prefixed_name.substitute(
                 propty='{}-RB'.format(sp))
-        if self._has_analmon:
-            if self._is_reg_slave:
-                self._analog_mon = self._prefixed_name.substitute(
-                    propty='ModOutVolt-Mon')
-            else:
-                self._analog_mon = self._prefixed_name.substitute(
-                    propty='{}-Mon'.format(sp))
+        if self._is_reg_slave:
+            self._analog_mon = self._prefixed_name.substitute(
+                propty='ModOutVolt-Mon')
+        else:
+            self._analog_mon = self._prefixed_name.substitute(
+                propty='{}-Mon'.format(sp))
 
         # strength
         if self._has_strength:
@@ -501,7 +481,6 @@ class SummaryWidget(QWidget):
                 propty='{}-SP'.format(st))
             self._strength_rb = self._prefixed_name.substitute(
                 propty='{}-RB'.format(st))
-        if self._has_strength_mon:
             self._strength_mon = self._prefixed_name.substitute(
                 propty='{}-Mon'.format(st))
 
@@ -534,14 +513,11 @@ class SummaryWidget(QWidget):
             self.udc_lb = QLabel(self._udc_name, self)
             self.udc_wid.layout().addWidget(self.udc_lb)
         elif name == 'opmode' and self._has_opmode:
-            opmode_list = list()
             if 'Voltage' not in self._analog_name:
                 self.opmode_cb = SiriusEnumComboBox(self, self._opmode_sel)
-                opmode_list.append(self.opmode_cb)
+                self.opmode_wid.layout().addWidget(self.opmode_cb)
             self.opmode_lb = PyDMLabel(self, self._opmode_sts)
-            opmode_list.append(self.opmode_lb)
-            for wid in opmode_list:
-                self.opmode_wid.layout().addWidget(wid)
+            self.opmode_wid.layout().addWidget(self.opmode_lb)
         elif name == 'ctrlmode' and self._has_ctrlmode:
             self.ctrlmode_lb = PyDMLabel(self, self._ctrlmode_sts)
             self.ctrlmode_wid.layout().addWidget(self.ctrlmode_lb)
@@ -576,8 +552,7 @@ class SummaryWidget(QWidget):
                     self.intlk_wid.layout().addWidget(self.generr_led)
                     self.intlk_wid.layout().addWidget(self.genwrn_led)
             elif self._is_fofb:
-                self.intlk_led = PyDMLedMultiChannel(
-                    self, channels2values={ch: 1 for ch in self._intlk})
+                self.intlk_led = SiriusLedAlert(self, self._intlk)
                 self.intlk_wid.layout().addWidget(self.intlk_led)
             else:
                 self.soft_intlk_led = SiriusLedAlert(self, self._soft_intlk)
@@ -597,11 +572,8 @@ class SummaryWidget(QWidget):
                 '#reset_bt{min-width:25px; max-width:25px; icon-size:20px;}')
             self.reset_wid.layout().addWidget(self.reset_bt)
         elif name == 'ctrlloop' and self._has_ctrlloop:
-            if self._is_fofb:
-                self.ctrlloop_bt = PyDMStateButton(self, self._ctrlloop_sel)
-            else:
-                self.ctrlloop_bt = PyDMStateButton(
-                    self, self._ctrlloop_sel, invert=True)
+            self.ctrlloop_bt = PyDMStateButton(
+                self, self._ctrlloop_sel, invert=True)
             self.ctrlloop_lb = PyDMLabel(self, self._ctrlloop_sts)
             self.ctrlloop_wid.layout().addWidget(self.ctrlloop_bt)
             self.ctrlloop_wid.layout().addWidget(self.ctrlloop_lb)
@@ -630,8 +602,11 @@ class SummaryWidget(QWidget):
                 self.readback.precisionFromPV = False
                 self.readback.precision = 6
             self.readback_wid.layout().addWidget(self.readback)
-        elif name == 'monitor' and self._has_analmon:
+        elif name == 'monitor':
             self.monitor = PyDMLabel(self, self._analog_mon)
+            if self._is_fofb:
+                self.monitor.precisionFromPV = False
+                self.monitor.precision = 6
             self.monitor_wid.layout().addWidget(self.monitor)
         elif name == 'strength_sp' and self._has_strength:
             self.strength_sp_le = PyDMSpinboxScrollbar(self, self._strength_sp)
@@ -641,7 +616,7 @@ class SummaryWidget(QWidget):
                 parent=self, init_channel=self._strength_rb)
             self.strength_rb_lb.showUnits = True
             self.strength_rb_wid.layout().addWidget(self.strength_rb_lb)
-        elif name == 'strength_mon' and self._has_strength_mon:
+        elif name == 'strength_mon' and self._has_strength:
             self.strength_mon_lb = PyDMLabel(
                 parent=self, init_channel=self._strength_mon)
             self.strength_mon_lb.showUnits = True
@@ -666,6 +641,8 @@ class SummaryWidget(QWidget):
         if hasattr(self, 'opmode_cb'):
             if self.opmode_cb.isEnabled():
                 index = self.opmode_cb.findText('SlowRef')
+                if index == -1:
+                    return
                 self.opmode_cb.internal_combo_box_activated_int(index)
 
     def turn_on(self):

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
@@ -620,10 +620,10 @@ class BasePSControlWidget(QWidget):
         menu = QMenu("Actions", self)
         menu.addAction(self.turn_on_act)
         menu.addAction(self.turn_off_act)
-        menu.addAction(self.ctrlloop_close_act)
-        menu.addAction(self.ctrlloop_open_act)
         menu.addAction(self.set_current_sp_act)
         if not self._dev_list[0].dev in ('FCH', 'FCV'):
+            menu.addAction(self.ctrlloop_close_act)
+            menu.addAction(self.ctrlloop_open_act)
             menu.addAction(self.set_slowref_act)
             menu.addAction(self.reset_act)
             menu.addAction(self.wfmupdate_on_act)

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
@@ -199,6 +199,8 @@ class PSContainer(QWidget):
     def contextMenuEvent(self, event):
         """Overload to create a custom context menu."""
         widget = self.childAt(event.pos())
+        if not widget:
+            return
         parent = widget.parent()
         grand_parent = parent.parent()
         if widget.objectName() == 'DCLinkContainer' or \

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/FastCorrectorControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/FastCorrectorControlWidget.py
@@ -20,8 +20,3 @@ class SIFastCorrectorControlWidget(BasePSControlWidget):
     def _getGroups(self):
         return [('Horizontal Fast Correctors', '-FCH'),
                 ('Vertical Fast Corretors', '-FCV')]
-
-    def _getVisibleProps(self):
-        return [
-            'detail', 'state', 'intlk', 'setpoint', 'readback',
-            'strength_sp', 'strength_rb']

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/InterlockWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/InterlockWindow.py
@@ -21,6 +21,7 @@ class InterlockWidget(QWidget):
         self.led = SiriusLedAlert(self, init_channel, bit)
         self.label = QLabel(label, self)
         lay = QHBoxLayout()
+        lay.setAlignment(Qt.AlignLeft)
         lay.addWidget(self.led)
         lay.addWidget(self.label)
         self.setLayout(lay)

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/InterlockWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/InterlockWindow.py
@@ -64,7 +64,7 @@ class InterlockWindow(SiriusMainWindow):
 
     def __init__(self, parent=None, devname='', interlock=None, auxdev=list(),
                  auxdev2mod=dict()):
-        """."""
+        """Init."""
         super().__init__(parent)
         self._devname = _PVName(devname)
         self._auxdev = auxdev
@@ -92,6 +92,9 @@ class InterlockWindow(SiriusMainWindow):
             self._intlktype = 'IIB'
             if 'Alarms' in self._interlock[0]:
                 auxlabel = 'Alarms'
+        elif self._devname.dev in ['FCH', 'FCV']:
+            self._intlktype = 'Amp'
+            auxlabel = 'Alarms'
 
         self._intlkname = self._intlktype + ' ' + auxlabel
         self.setWindowTitle(self._devname + ' - ' + self._intlkname)

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -28,7 +28,7 @@ from siriuspy.devices import PowerSupply
 
 from ... import util
 from ...widgets import PyDMStateButton, PyDMSpinboxScrollbar, SiriusTimePlot, \
-    SiriusConnectionSignal, SiriusLedState, SiriusLedAlert, PyDMLed, \
+    SiriusConnectionSignal, SiriusLedState, SiriusLedAlert, \
     PyDMLedMultiChannel, SiriusDialog, SiriusWaveformTable, SiriusSpinbox, \
     SiriusHexaSpinbox
 from .InterlockWindow import InterlockWindow, LIInterlockWindow
@@ -43,7 +43,8 @@ class PSDetailWidget(QWidget):
             min-width: 7em;
             max-width: 7em;
         }
-        #opmode_rb_label{
+        #opmode_rb_label,
+        #psstatus_mon{
             min-width: 7em;
             max-width: 7em;
             qproperty-alignment: AlignCenter;
@@ -1389,20 +1390,32 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.opmode_box.setObjectName('operation_mode')
         self.pwrstate_box = QGroupBox('PwrState')
         self.pwrstate_box.setObjectName('power_state')
-        self.ctrlloop_box = QGroupBox('Control Loop')
-        self.ctrlloop_box.setObjectName('ctrlloop_box')
+        self.status_box = QGroupBox('Status')
+        self.status_box.setObjectName('status')
         self.interlock_box = QGroupBox('Interlock')
         self.interlock_box.setObjectName('interlock')
-        self.params_box = QGroupBox('Params')
+        self.paramstab = QTabWidget()
+        self.paramstab.setObjectName('SITab')
+        self.params_box = QWidget()
         self.params_box.setObjectName('params_box')
-        self.currtab = QTabWidget()
-        self.currtab.setObjectName('SITab')
-        self.current_a_box = QWidget()
-        self.current_a_box.setObjectName('current')
-        self.currtab.addTab(self.current_a_box, 'Current [A]')
+        self.paramstab.addTab(self.params_box, 'Params')
+        self.testconf_box = QWidget()
+        self.testconf_box.setObjectName('testconf_box')
+        self.paramstab.addTab(self.testconf_box, 'Test Conf.')
+        self.analogtab = QTabWidget()
+        self.analogtab.setObjectName('SITab')
+        self.current_box = QWidget()
+        self.current_box.setObjectName('current')
+        self.analogtab.addTab(self.current_box, 'Current [A]')
         self.current_raw_box = QWidget()
         self.current_raw_box.setObjectName('current')
-        self.currtab.addTab(self.current_raw_box, 'Current [Raw]')
+        self.analogtab.addTab(self.current_raw_box, 'Curr.[Raw]')
+        self.voltage_box = QWidget()
+        self.voltage_box.setObjectName('voltage')
+        self.analogtab.addTab(self.voltage_box, 'Volt.[V]')
+        self.voltage_raw_box = QWidget()
+        self.voltage_raw_box.setObjectName('voltage')
+        self.analogtab.addTab(self.voltage_raw_box, 'Volt.[Raw]')
         self.metric_box = QGroupBox(self._metric)
         self.metric_box.setObjectName('metric')
         self.waveform_box = self._wfmWidget()
@@ -1410,12 +1423,22 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         # Set group boxes layouts
         self.opmode_box.setLayout(self._opModeLayout())
         self.pwrstate_box.setLayout(self._powerStateLayout())
-        self.ctrlloop_box.setLayout(self._ctrlLoopLayout())
+        self.status_box.setLayout(self._statusLayout())
         self.interlock_box.setLayout(self._interlockLayout())
         self.params_box.setLayout(self._paramsLayout())
-        self.current_a_box.setLayout(self._currentALayout())
+        self.testconf_box.setLayout(self._testConfLayout())
+        self.current_box.setLayout(self._currentLayout())
         self.current_raw_box.setLayout(self._currentRawLayout())
+        self.voltage_box.setLayout(self._voltageLayout())
+        self.voltage_raw_box.setLayout(self._voltageRawLayout())
         self.metric_box.setLayout(self._metricLayout())
+
+        self.setStyleSheet("""
+            #SITab::pane {
+                border-left: 2px solid gray;
+                border-bottom: 2px solid gray;
+                border-right: 2px solid gray;
+            }""")
 
         # Add group boxes to laytout
         self.layout = self._setWidgetLayout()
@@ -1427,10 +1450,10 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         boxes_layout = QGridLayout()
         boxes_layout.addWidget(self.opmode_box, 0, 0)
         boxes_layout.addWidget(self.pwrstate_box, 0, 1)
-        boxes_layout.addWidget(self.ctrlloop_box, 1, 0)
+        boxes_layout.addWidget(self.status_box, 1, 0)
         boxes_layout.addWidget(self.interlock_box, 1, 1)
-        boxes_layout.addWidget(self.params_box, 2, 0, 1, 2)
-        boxes_layout.addWidget(self.currtab, 0, 2)
+        boxes_layout.addWidget(self.paramstab, 2, 0, 1, 2)
+        boxes_layout.addWidget(self.analogtab, 0, 2)
         boxes_layout.addWidget(self.metric_box, 1, 2)
         boxes_layout.addWidget(self.waveform_box, 2, 2)
 
@@ -1452,63 +1475,24 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         return layout
 
     def _opModeLayout(self):
-        test_lb = QLabel('Tests', self)
-
-        oltriang_lb = QLabel('Open/Triang', self)
-        self.oltriang_sb = PyDMStateButton(
-            self, self._prefixed_psname + ':TestOpenLoopTriang-Sel')
-        self.oltriang_rb = SiriusLedState(
-            self, self._prefixed_psname + ':TestOpenLoopTriang-Sts')
-
-        olsquare_lb = QLabel('Open/Square', self)
-        self.olsquare_sb = PyDMStateButton(
-            self, self._prefixed_psname + ':TestOpenLoopSquare-Sel')
-        self.olsquare_rb = SiriusLedState(
-            self, self._prefixed_psname + ':TestOpenLoopSquare-Sts')
-
-        clsquare_lb = QLabel('Closed/Square', self)
-        self.clsquare_sb = PyDMStateButton(
-            self, self._prefixed_psname + ':TestClosedLoopSquare-Sel')
-        self.clsquare_rb = SiriusLedState(
-            self, self._prefixed_psname + ':TestClosedLoopSquare-Sts')
+        self.opmode_sp = PyDMEnumComboBox(
+            self, self._prefixed_psname + ":OpMode-Sel")
+        self.opmode_sp.setObjectName("opmode_sp_cbox")
+        self.opmode_rb = PyDMLabel(
+            self, self._prefixed_psname + ":OpMode-Sts")
+        self.opmode_rb.setObjectName("opmode_rb_label")
 
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignCenter)
-        layout.setHorizontalSpacing(4)
-        layout.addWidget(test_lb, 0, 0, 1, 3, Qt.AlignHCenter)
-        layout.addWidget(oltriang_lb, 1, 0, Qt.AlignHCenter)
-        layout.addWidget(self.oltriang_sb, 1, 1, Qt.AlignRight)
-        layout.addWidget(self.oltriang_rb, 1, 2, Qt.AlignLeft)
-        layout.addWidget(olsquare_lb, 2, 0, Qt.AlignHCenter)
-        layout.addWidget(self.olsquare_sb, 2, 1, Qt.AlignRight)
-        layout.addWidget(self.olsquare_rb, 2, 2, Qt.AlignLeft)
-        layout.addWidget(clsquare_lb, 3, 0, Qt.AlignHCenter)
-        layout.addWidget(self.clsquare_sb, 3, 1, Qt.AlignRight)
-        layout.addWidget(self.clsquare_rb, 3, 2, Qt.AlignLeft)
+        layout.addWidget(self.opmode_sp, 0, 0, Qt.AlignHCenter)
+        layout.addWidget(self.opmode_rb, 1, 0, Qt.AlignHCenter)
         return layout
 
-    def _ctrlLoopLayout(self):
-        self.ctrlloop_btn = PyDMStateButton(
-            parent=self, init_channel=self._prefixed_psname + ":CtrlLoop-Sel")
-        self.ctrlloop_label = PyDMLabel(
-            parent=self, init_channel=self._prefixed_psname + ":CtrlLoop-Sts")
-        self.ctrlloop_label.setObjectName('ctrlloop_label')
-        self.ctrlloop_led = SiriusLedState(
-            parent=self, init_channel=self._prefixed_psname + ":CtrlLoop-Sts")
-
-        lay_sts = QHBoxLayout()
-        lay_sts.addWidget(self.ctrlloop_led)
-        lay_sts.addWidget(self.ctrlloop_label)
-
-        layout = QGridLayout()
-        layout.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.ctrlloop_btn, 0, 0, Qt.AlignHCenter)
-        layout.addLayout(lay_sts, 1, 0)
-        return layout
-
-    def _currentALayout(self):
+    def _currentLayout(self):
         current_sp_label = QLabel("Setpoint")
         current_rb_label = QLabel("Readback")
+        current_ref_label = QLabel("Ref Mon")
+        current_mon_label = QLabel("Mon")
 
         self.current_sp = PyDMSpinboxScrollbar(
             self, self._prefixed_psname + ":Current-SP")
@@ -1519,6 +1503,16 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.current_rb.precisionFromPV = False
         self.current_rb.precision = 6
         self.current_rb.showUnits = True
+        self.current_ref = PyDMLabel(
+            self, self._prefixed_psname+":CurrentRef-Mon")
+        self.current_ref.precisionFromPV = False
+        self.current_ref.precision = 6
+        self.current_ref.showUnits = True
+        self.current_mon = PyDMLabel(
+            self, self._prefixed_psname+":Current-Mon")
+        self.current_mon.precisionFromPV = False
+        self.current_mon.precision = 6
+        self.current_mon.showUnits = True
 
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignTop)
@@ -1526,17 +1520,27 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         layout.addWidget(self.current_sp, 0, 1)
         layout.addWidget(current_rb_label, 1, 0, Qt.AlignRight)
         layout.addWidget(self.current_rb, 1, 1)
+        layout.addWidget(current_ref_label, 2, 0, Qt.AlignRight)
+        layout.addWidget(self.current_ref, 2, 1)
+        layout.addWidget(current_mon_label, 3, 0, Qt.AlignRight)
+        layout.addWidget(self.current_mon, 3, 1)
         layout.setColumnStretch(2, 1)
         return layout
 
     def _currentRawLayout(self):
         current_sp_label = QLabel("Setpoint")
         current_rb_label = QLabel("Readback")
+        current_ref_label = QLabel("Ref Mon")
+        current_mon_label = QLabel("Mon")
 
         self.current_raw_sp = PyDMSpinboxScrollbar(
             self, self._prefixed_psname + ":CurrentRaw-SP")
         self.current_raw_rb = PyDMLabel(
             self, self._prefixed_psname+":CurrentRaw-RB")
+        self.current_raw_ref = PyDMLabel(
+            self, self._prefixed_psname+":CurrentRawRef-Mon")
+        self.current_raw_mon = PyDMLabel(
+            self, self._prefixed_psname+":CurrentRaw-Mon")
 
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignTop)
@@ -1544,46 +1548,104 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         layout.addWidget(self.current_raw_sp, 0, 1)
         layout.addWidget(current_rb_label, 1, 0, Qt.AlignRight)
         layout.addWidget(self.current_raw_rb, 1, 1)
+        layout.addWidget(current_ref_label, 2, 0, Qt.AlignRight)
+        layout.addWidget(self.current_raw_ref, 2, 1)
+        layout.addWidget(current_mon_label, 3, 0, Qt.AlignRight)
+        layout.addWidget(self.current_raw_mon, 3, 1)
         layout.setColumnStretch(2, 1)
         return layout
 
-    def _metricLayout(self):
-        metric_sp_label = QLabel('Setpoint')
-        metric_rb_label = QLabel('Readback')
+    def _voltageLayout(self):
+        voltage_sp_label = QLabel("Setpoint")
+        voltage_rb_label = QLabel("Readback")
+        voltage_mn_label = QLabel("Mon")
 
-        self.metric_sp = PyDMSpinboxScrollbar(
-            self, self._prefixed_psname+':'+self._metric+'-SP')
-        self.metric_rb = PyDMLabel(
-            self, self._prefixed_psname+':'+self._metric+'-RB')
-        self.metric_rb.precisionFromPV = False
-        self.metric_rb.precision = 6
-        self.metric_rb.showUnits = True
+        self.voltage_sp = PyDMSpinboxScrollbar(
+            self, self._prefixed_psname + ":Voltage-SP")
+        self.voltage_sp.spinbox.precisionFromPV = False
+        self.voltage_sp.spinbox.precision = 6
+        self.voltage_rb = PyDMLabel(
+            self, self._prefixed_psname+":Voltage-RB")
+        self.voltage_rb.precisionFromPV = False
+        self.voltage_rb.precision = 6
+        self.voltage_rb.showUnits = True
+        self.voltage_mn = PyDMLabel(
+            self, self._prefixed_psname+":Voltage-Mon")
+        self.voltage_mn.precisionFromPV = False
+        self.voltage_mn.precision = 6
+        self.voltage_mn.showUnits = True
 
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignTop)
-        layout.addWidget(metric_sp_label, 0, 0, Qt.AlignRight)
-        layout.addWidget(self.metric_sp, 0, 1)
-        layout.addWidget(metric_rb_label, 1, 0, Qt.AlignRight)
-        layout.addWidget(self.metric_rb, 1, 1)
+        layout.addWidget(voltage_sp_label, 0, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_sp, 0, 1)
+        layout.addWidget(voltage_rb_label, 1, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_rb, 1, 1)
+        layout.addWidget(voltage_mn_label, 2, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_mn, 2, 1)
+        layout.setColumnStretch(2, 1)
+        return layout
+
+    def _voltageRawLayout(self):
+        voltage_sp_label = QLabel("Setpoint")
+        voltage_rb_label = QLabel("Readback")
+        voltage_mn_label = QLabel("Mon")
+
+        self.voltage_raw_sp = PyDMSpinboxScrollbar(
+            self, self._prefixed_psname + ":Voltage-SP")
+        self.voltage_raw_sp.spinbox.precisionFromPV = False
+        self.voltage_raw_sp.spinbox.precision = 6
+        self.voltage_raw_rb = PyDMLabel(
+            self, self._prefixed_psname+":Voltage-RB")
+        self.voltage_raw_rb.precisionFromPV = False
+        self.voltage_raw_rb.precision = 6
+        self.voltage_rb.showUnits = True
+        self.voltage_raw_mn = PyDMLabel(
+            self, self._prefixed_psname+":Voltage-Mon")
+        self.voltage_raw_mn.precisionFromPV = False
+        self.voltage_raw_mn.precision = 6
+        self.voltage_raw_mn.showUnits = True
+
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.addWidget(voltage_sp_label, 0, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_raw_sp, 0, 1)
+        layout.addWidget(voltage_rb_label, 1, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_raw_rb, 1, 1)
+        layout.addWidget(voltage_mn_label, 2, 0, Qt.AlignRight)
+        layout.addWidget(self.voltage_raw_mn, 2, 1)
         layout.setColumnStretch(2, 1)
         return layout
 
     def _interlockLayout(self):
-        alarms = [
-            'PSAmpOverCurrFlagL-Sts',
-            'PSAmpOverCurrFlagR-Sts',
-            'PSAmpOverTempFlagL-Sts',
-            'PSAmpOverTempFlagR-Sts',
-        ]
+        self.alarm_label = QLabel('AlarmsAmp', self, alignment=Qt.AlignCenter)
+        self.alarm_bt = QPushButton(qta.icon('fa5s.list-ul'), '', self)
+        self.alarm_bt.setObjectName('alarm_bt')
+        self.alarm_bt.setStyleSheet(
+            '#alarm_bt{min-width:25px; max-width:25px; icon-size:20px;}')
+        util.connect_window(
+            self.alarm_bt, InterlockWindow, self,
+            devname=self._psname, interlock='AlarmsAmp')
+        self.alarm_led = SiriusLedAlert(
+            parent=self, init_channel=self._prefixed_psname + ":AlarmsAmp-Mon")
+
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignCenter)
-        for i, alm in enumerate(alarms):
-            led = PyDMLed(self, self._prefixed_psname + ':' + alm)
-            led.onColor = led.LightGreen
-            led.offColor = led.Red
-            label = QLabel(alm.split('-')[0].split('PSAmp')[1], self)
-            layout.addWidget(led, i, 0)
-            layout.addWidget(label, i, 1)
+        layout.addWidget(self.alarm_bt, 0, 0)
+        layout.addWidget(self.alarm_label, 0, 1)
+        layout.addWidget(self.alarm_led, 0, 2)
+        return layout
+
+    def _statusLayout(self):
+        psstatus_label = QLabel('Value: ', self)
+        self.psstatus_mon = PyDMLabel(
+            self, self._prefixed_psname + ":PSStatus-Mon")
+        self.psstatus_mon.setObjectName("psstatus_mon")
+
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignCenter)
+        layout.addWidget(psstatus_label, 0, 0, Qt.AlignRight)
+        layout.addWidget(self.psstatus_mon, 0, 1, Qt.AlignLeft)
         return layout
 
     def _paramsLayout(self):
@@ -1670,6 +1732,7 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.voffs_rb.precision = 8
 
         layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
         layout.addWidget(ctlkp_lb, 0, 0, Qt.AlignRight)
         layout.addWidget(self.ctlkp_sp, 0, 1)
         layout.addWidget(self.ctlkp_rb, 0, 2)
@@ -1688,6 +1751,44 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         layout.addWidget(voffs_lb, 5, 0, Qt.AlignRight)
         layout.addWidget(self.voffs_sp, 5, 1)
         layout.addWidget(self.voffs_rb, 5, 2)
+        return layout
+
+    def _testConfLayout(self):
+        testlima_lb = QLabel(
+            'Limit A', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        self.testlima_sp = SiriusSpinbox(
+            self, self._prefixed_psname + ':TestLimA-SP')
+        self.testlima_sp.showStepExponent = False
+        self.testlima_rb = PyDMLabel(
+            self, self._prefixed_psname + ':TestLimA-RB')
+
+        testlimb_lb = QLabel(
+            'Limit B', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        self.testlimb_sp = SiriusSpinbox(
+            self, self._prefixed_psname + ':TestLimB-SP')
+        self.testlimb_sp.showStepExponent = False
+        self.testlimb_rb = PyDMLabel(
+            self, self._prefixed_psname + ':TestLimB-RB')
+
+        testwaveper_lb = QLabel(
+            'Wave Period', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        self.testwaveper_sp = SiriusSpinbox(
+            self, self._prefixed_psname + ':TestWavePeriod-SP')
+        self.testwaveper_sp.showStepExponent = False
+        self.testwaveper_rb = PyDMLabel(
+            self, self._prefixed_psname + ':TestWavePeriod-RB')
+
+        layout = QGridLayout()
+        layout.setAlignment(Qt.AlignTop)
+        layout.addWidget(testlima_lb, 0, 0, Qt.AlignRight)
+        layout.addWidget(self.testlima_sp, 0, 1)
+        layout.addWidget(self.testlima_rb, 0, 2)
+        layout.addWidget(testlimb_lb, 1, 0, Qt.AlignRight)
+        layout.addWidget(self.testlimb_sp, 1, 1)
+        layout.addWidget(self.testlimb_rb, 1, 2)
+        layout.addWidget(testwaveper_lb, 2, 0, Qt.AlignRight)
+        layout.addWidget(self.testwaveper_sp, 2, 1)
+        layout.addWidget(self.testwaveper_rb, 2, 2)
         return layout
 
     def _wfmWidget(self):
@@ -1766,12 +1867,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         tab.addTab(self.graph_volt, 'Volt.')
         tab.addTab(self.graph_chist, 'Curr.Hist.')
         tab.setCurrentIndex(2)
-        tab.setStyleSheet("""
-            #SITab::pane {
-                border-left: 2px solid gray;
-                border-bottom: 2px solid gray;
-                border-right: 2px solid gray;
-            }""")
         return tab
 
     def _plot_currhist(self, new_array):

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -1390,8 +1390,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.opmode_box.setObjectName('operation_mode')
         self.pwrstate_box = QGroupBox('PwrState')
         self.pwrstate_box.setObjectName('power_state')
-        self.status_box = QGroupBox('Status')
-        self.status_box.setObjectName('status')
         self.interlock_box = QGroupBox('Interlock')
         self.interlock_box.setObjectName('interlock')
         self.paramstab = QTabWidget()
@@ -1423,7 +1421,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         # Set group boxes layouts
         self.opmode_box.setLayout(self._opModeLayout())
         self.pwrstate_box.setLayout(self._powerStateLayout())
-        self.status_box.setLayout(self._statusLayout())
         self.interlock_box.setLayout(self._interlockLayout())
         self.params_box.setLayout(self._paramsLayout())
         self.testconf_box.setLayout(self._testConfLayout())
@@ -1450,8 +1447,7 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         boxes_layout = QGridLayout()
         boxes_layout.addWidget(self.opmode_box, 0, 0)
         boxes_layout.addWidget(self.pwrstate_box, 0, 1)
-        boxes_layout.addWidget(self.status_box, 1, 0)
-        boxes_layout.addWidget(self.interlock_box, 1, 1)
+        boxes_layout.addWidget(self.interlock_box, 1, 0, 1, 2)
         boxes_layout.addWidget(self.paramstab, 2, 0, 1, 2)
         boxes_layout.addWidget(self.analogtab, 0, 2)
         boxes_layout.addWidget(self.metric_box, 1, 2)
@@ -1634,18 +1630,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         layout.addWidget(self.alarm_bt, 0, 0)
         layout.addWidget(self.alarm_label, 0, 1)
         layout.addWidget(self.alarm_led, 0, 2)
-        return layout
-
-    def _statusLayout(self):
-        psstatus_label = QLabel('Value: ', self)
-        self.psstatus_mon = PyDMLabel(
-            self, self._prefixed_psname + ":PSStatus-Mon")
-        self.psstatus_mon.setObjectName("psstatus_mon")
-
-        layout = QGridLayout()
-        layout.setAlignment(Qt.AlignCenter)
-        layout.addWidget(psstatus_label, 0, 0, Qt.AlignRight)
-        layout.addWidget(self.psstatus_mon, 0, 1, Qt.AlignLeft)
         return layout
 
     def _paramsLayout(self):

--- a/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
@@ -534,14 +534,15 @@ class CycleWindow(SiriusMainWindow):
 
         # update buttons and self._prepared dict if not in advanced mode
         if not self._is_adv_mode:
-            has_si = False
-            for psn in PSSearch.get_psnames({'sec': 'SI', 'dis': 'PS'}):
+            has_sifam = False
+            sifamfilt = {'sec': 'SI', 'sub': 'Fam', 'dis': 'PS'}
+            for psn in PSSearch.get_psnames(sifamfilt):
                 if psn not in self.pwrsupplies_tree._item_map:
                     continue
                 item = self.pwrsupplies_tree._item_map[psn]
-                has_si |= item.checkState(0) != 0
+                has_sifam |= item.checkState(0) != 0
 
-            if not has_si:
+            if not has_sifam:
                 self.cycle_bt.setText('8. Cycle')
                 self.restore_timing_bt.setText(
                     '9. Restore Timing Initial State')

--- a/pyqt-apps/siriushla/as_ps_test/conn.py
+++ b/pyqt-apps/siriushla/as_ps_test/conn.py
@@ -451,8 +451,8 @@ class TesterPSLinac(_TesterBase):
         status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
-                self._pvs['Current-SP'].value,
-                self._pvs['Current-Mon'].value)
+                self._pvs['Current-Mon'].value,
+                self._pvs['Current-SP'].value)
         return status
 
     def check_comm(self):

--- a/pyqt-apps/siriushla/as_ps_test/conn.py
+++ b/pyqt-apps/siriushla/as_ps_test/conn.py
@@ -490,13 +490,14 @@ class TesterPSFOFB(_TesterBase):
         """Set manual mode."""
         if state != _PSC.OpMode.SlowRef:
             return
-        self._pvs['OpMode-Sel'].value = _PSC.OpModeFOFB.CL_MANUAL
+        self._pvs['OpMode-Sel'].value = _PSC.OpModeFOFB.closed_loop_manual
 
     def check_opmode(self, state):
         """Check whether power supply is in manual mode."""
         if state != _PSC.OpMode.SlowRef:
             return True
-        return self._pvs['OpMode-Sts'].value == _PSC.OpModeFOFB.CL_MANUAL
+        return self._pvs['OpMode-Sts'].value == \
+            _PSC.OpModeFOFB.closed_loop_manual
 
     def check_intlk(self):
         """Check interlocks."""

--- a/pyqt-apps/siriushla/as_ps_test/conn.py
+++ b/pyqt-apps/siriushla/as_ps_test/conn.py
@@ -206,8 +206,7 @@ class TesterDCLink(_TesterPSBase):
                          DEFAULT_CAP_BANK_VOLT[self.device])
 
     def check_status(self):
-        status = True
-        status &= self.check_intlk()
+        status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
                 self._pvs['CapacitorBankVoltage-Mon'].value,
@@ -280,8 +279,7 @@ class TesterDCLinkRegatron(_TesterBase):
                            rtol=0.05)
 
     def check_status(self):
-        status = True
-        status &= self.check_intlk()
+        status = self.check_intlk()
         if self.check_pwrstate():
             status &= self.check_capvolt()
         return status
@@ -348,8 +346,7 @@ class TesterPS(_TesterPSBase):
 
     def check_status(self):
         """Check Status."""
-        status = True
-        status &= self.check_intlk()
+        status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
                 self._pvs['Current-Mon'].value,
@@ -451,8 +448,7 @@ class TesterPSLinac(_TesterBase):
 
     def check_status(self):
         """Check Status."""
-        status = True
-        status &= self.check_intlk()
+        status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
                 self._pvs['Current-SP'].value,
@@ -672,8 +668,7 @@ class _TesterPUBase(_TesterBase):
         return status
 
     def check_status(self):
-        status = True
-        status &= self.check_intlk()
+        status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
                 self._pvs['Voltage-Mon'].value,

--- a/pyqt-apps/siriushla/as_ps_test/conn.py
+++ b/pyqt-apps/siriushla/as_ps_test/conn.py
@@ -468,20 +468,14 @@ class TesterPSLinac(_TesterBase):
 class TesterPSFOFB(_TesterBase):
     """FOFB PS tester."""
 
-    CTRLLOOP_CLOSED = 1
-
     def __init__(self, device):
         """Init."""
         super().__init__(device)
         self.properties = [
-            'PSAmpOverCurrFlagL-Sts', 'PSAmpOverTempFlagL-Sts',
-            'PSAmpOverCurrFlagR-Sts', 'PSAmpOverTempFlagR-Sts',
+            'AlarmsAmp-Mon',
             'PwrState-Sel', 'PwrState-Sts',
-            'CtrlLoop-Sel', 'CtrlLoop-Sts',
-            'Current-SP', 'Current-RB',
-            'TestOpenLoopTriang-Sel', 'TestOpenLoopTriang-Sts',
-            'TestOpenLoopSquare-Sel', 'TestOpenLoopSquare-Sts',
-            'TestClosedLoopSquare-Sel', 'TestClosedLoopSquare-Sts',
+            'Current-SP', 'CurrentRef-Mon', 'Current-Mon',
+            'OpMode-Sel', 'OpMode-Sts',
         ]
         for ppty in self.properties:
             self._pvs[ppty] = _PV(
@@ -493,29 +487,20 @@ class TesterPSFOFB(_TesterBase):
         self.test_tol = splims['TSTR']
 
     def set_opmode(self, state):
-        """Set manual mode, disable tests."""
+        """Set manual mode."""
         if state != _PSC.OpMode.SlowRef:
             return
-        self._pvs['TestOpenLoopTriang-Sel'].value = _PSC.DsblEnbl.Dsbl
-        self._pvs['TestOpenLoopSquare-Sel'].value = _PSC.DsblEnbl.Dsbl
-        self._pvs['TestClosedLoopSquare-Sel'].value = _PSC.DsblEnbl.Dsbl
+        self._pvs['OpMode-Sel'].value = _PSC.OpModeFOFB.CL_MANUAL
 
     def check_opmode(self, state):
-        """Check whether power supply is in manual mode, test disabled."""
+        """Check whether power supply is in manual mode."""
         if state != _PSC.OpMode.SlowRef:
             return True
-        ok = self._pvs['TestOpenLoopTriang-Sts'].value == _PSC.DsblEnbl.Dsbl
-        ok &= self._pvs['TestOpenLoopSquare-Sts'].value == _PSC.DsblEnbl.Dsbl
-        ok &= self._pvs['TestClosedLoopSquare-Sts'].value == _PSC.DsblEnbl.Dsbl
-        return ok
+        return self._pvs['OpMode-Sts'].value == _PSC.OpModeFOFB.CL_MANUAL
 
     def check_intlk(self):
         """Check interlocks."""
-        status = (self._pvs['PSAmpOverCurrFlagL-Sts'].value == 1)
-        status &= (self._pvs['PSAmpOverTempFlagL-Sts'].value == 1)
-        status &= (self._pvs['PSAmpOverCurrFlagR-Sts'].value == 1)
-        status &= (self._pvs['PSAmpOverTempFlagR-Sts'].value == 1)
-        return status
+        return self._pvs['AlarmsAmp-Mon'].value == 0
 
     def set_pwrstate(self, state='on'):
         """Set PwrState."""
@@ -526,14 +511,6 @@ class TesterPSFOFB(_TesterBase):
         """Check PwrState."""
         value = _PSC.OffOn.On if state == 'on' else _PSC.OffOn.Off
         return self._pvs['PwrState-Sts'].value == value
-
-    def set_ctrlloop(self):
-        """Set CtrlLoop."""
-        self._pvs['CtrlLoop-Sel'].value = TesterPSFOFB.CTRLLOOP_CLOSED
-
-    def check_ctrlloop(self):
-        """Check CtrlLoop."""
-        return self._pvs['CtrlLoop-Sts'].value == TesterPSFOFB.CTRLLOOP_CLOSED
 
     def set_current(self, test=False, value=None):
         """Set current."""
@@ -551,16 +528,15 @@ class TesterPSFOFB(_TesterBase):
                 value = self.test_current
             else:
                 value = 0
-        status = self._cmp(self._pvs['Current-RB'].value, value)
-        return status
+        return self._cmp(self._pvs['Current-Mon'].value, value)
 
     def check_status(self):
         """Check Status."""
         status = self.check_intlk()
         if self.check_pwrstate():
             status &= self._cmp(
-                self._pvs['Current-RB'].value,
-                self._pvs['Current-SP'].value)
+                self._pvs['Current-Mon'].value,
+                self._pvs['CurrentRef-Mon'].value)
         return status
 
     def check_comm(self):

--- a/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
+++ b/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
@@ -567,12 +567,12 @@ class PSTestWindow(SiriusMainWindow):
             if not devices:
                 return
             dev_label = 'PU'
-        devices_not_rst = {
+        devices_rst = {
             dev for dev in devices if dev.sec != 'LI' and
             dev.dev not in ('FCH', 'FCV')}
 
         task0 = CreateTesters(devices, parent=self)
-        task1 = ResetIntlk(devices_not_rst, parent=self)
+        task1 = ResetIntlk(devices_rst, parent=self)
         task2 = CheckIntlk(devices, parent=self)
         task2.itemDone.connect(self._log)
         tasks = [task0, task1, task2]

--- a/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
+++ b/pyqt-apps/siriushla/as_ps_test/ps_test_window.py
@@ -444,7 +444,7 @@ class PSTestWindow(SiriusMainWindow):
         lay.setHorizontalSpacing(15)
         lay.setVerticalSpacing(5)
         lay.addWidget(QLabel(
-            '<h3>Power Supplies Test</h3>', self, alignment=Qt.AlignCenter),
+            '<h3>Power Supply Test</h3>', self, alignment=Qt.AlignCenter),
             0, 0, 1, 3)
         lay.addWidget(self.tab, 1, 0)
         lay.addLayout(list_layout, 1, 1)


### PR DESCRIPTION
- Fix cycle procedure to not require cycling trims when cycling only fast correctors (related to https://github.com/lnls-sirius/dev-packages/pull/824).
- Update fast corrector control and detail windows.
- Update PSGraph to control new fast corrector PVs; use Current-Mon instead of FOFB channel current array to show Current-Mon curve option.
- Update PSTest to control new fast corrector PVs.
- Fix minor bugs and cleanup code.

New fast corrector detail window:
![Screenshot from 2022-07-05 16-20-15](https://user-images.githubusercontent.com/21130191/177400067-fde2ffa7-1978-48af-bb97-8fb7f0dcf8a4.png)
