### PR TITLE
Revert update requirements

### DIFF
--- a/pyqt-apps/requirements.txt
+++ b/pyqt-apps/requirements.txt
@@ -1,3 +1,3 @@
-pydm>=1.16.3
-QtAwesome>=1.1.1
-pyqtgraph>=0.11.1
+pydm>=1.8.0
+QtAwesome>=0.7.2
+pyqtgraph>=0.11.0

--- a/pyqt-apps/siriushla/as_ap_currinfo/charge_monitor.py
+++ b/pyqt-apps/siriushla/as_ap_currinfo/charge_monitor.py
@@ -46,8 +46,6 @@ class BOMonitor(SiriusMainWindow):
         colors = ['blue', 'red', 'green', 'magenta']
         self.timeplot.timeSpan = timespan  # [s]
         self.timeplot.bufferSize = 2*timespan  # [2 samples/s]
-        self.timeplot.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.timeplot.autoRangeY = True
         self.timeplot.showXGrid = True
         self.timeplot.showYGrid = True

--- a/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
+++ b/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
@@ -114,12 +114,10 @@ class CurrLTWindow(SiriusMainWindow):
 
         # # Graph
         self.graph = SiriusTimePlot(self, background='w')
-        self.graph.addAxis(
-            plot_data_item=None, name='curr', orientation='left')
-        self.graph.setLabel('curr', text='Current [mA]', color='blue')
-        self.graph.addAxis(
-            plot_data_item=None, name='lt', orientation='right')
-        self.graph.setLabel('lt', text='Lifetime [h]', color='red')
+        self.graph.plotItem.getAxis('left').setLabel(
+            'Current [mA]', color='blue')
+        self.graph.plotItem.getAxis('right').setLabel(
+            'Lifetime [h]', color='red')
         self.graph.showLegend = False
         self.graph.showXGrid = True
         self.graph.showYGrid = True
@@ -136,7 +134,7 @@ class CurrLTWindow(SiriusMainWindow):
 
         pvname = self.devname.substitute(propty='Current-Mon')
         self.graph.addYChannel(
-            y_channel=pvname, yAxisName='curr', name='Current',
+            y_channel=pvname, axis='left', name='Current',
             color='blue', lineWidth=1)
         self._curve_current = self.graph.curveAtIndex(0)
         self.graph.fill_curve_with_archdata(
@@ -146,15 +144,15 @@ class CurrLTWindow(SiriusMainWindow):
         pvname = _PVName(
             'SI-01M1:DI-BPM:Sum-Mon').substitute(prefix=self.prefix)
         self.graph.addYChannel(
-            y_channel=pvname, yAxisName='curr', name='Current',
-            color='blue', lineWidth=1)
+            y_channel=pvname,
+            axis='left', name='Current', color='blue', lineWidth=1)
         self._curve_bpmsum = self.graph.curveAtIndex(1)
         self.graph.fill_curve_with_archdata(
             self._curve_bpmsum,  pvname,
             t_init=t_init_iso, t_end=t_end_iso)
 
         self.graph.addYChannel(
-            y_channel='FAKE:Lifetime', yAxisName='lt', name='Lifetime',
+            y_channel='FAKE:Lifetime', axis='right', name='Lifetime',
             color='red', lineWidth=1)
         self._curve_lifetimedcct = self.graph.curveAtIndex(2)
         self.graph.fill_curve_with_archdata(
@@ -163,7 +161,7 @@ class CurrLTWindow(SiriusMainWindow):
             t_init=t_init_iso, t_end=t_end_iso, factor=3600)
 
         self.graph.addYChannel(
-            y_channel='FAKE:LifetimeBPM', yAxisName='lt', name='Lifetime',
+            y_channel='FAKE:LifetimeBPM', axis='right', name='Lifetime',
             color='red', lineWidth=1)
         self._curve_lifetimebpm = self.graph.curveAtIndex(3)
         self.graph.fill_curve_with_archdata(
@@ -202,11 +200,11 @@ class CurrLTWindow(SiriusMainWindow):
             self._update_waveforms)
 
         self.graph.addYChannel(
-            y_channel='FAKE:DCCTBuffer', yAxisName='curr', name='DCCTBuffer',
+            y_channel='FAKE:DCCTBuffer', axis='left', name='DCCTBuffer',
             color='blue', lineStyle=Qt.NoPen, symbolSize=10, symbol='o')
         self._curve_dcct_buff = self.graph.curveAtIndex(4)
         self.graph.addYChannel(
-            y_channel='FAKE:BPMBuffer', yAxisName='curr', name='BPMBuffer',
+            y_channel='FAKE:BPMBuffer', axis='left', name='BPMBuffer',
             color='blue', lineStyle=Qt.NoPen, symbolSize=10, symbol='o')
         self._curve_bpm_buff = self.graph.curveAtIndex(5)
 

--- a/pyqt-apps/siriushla/as_ap_currinfo/efficiency_monitor.py
+++ b/pyqt-apps/siriushla/as_ap_currinfo/efficiency_monitor.py
@@ -50,8 +50,6 @@ class EfficiencyMonitor(SiriusMainWindow):
         timespan = 30*60  # [s]
         self.timeplot = SiriusTimePlot(parent=self, background='w')
         self.timeplot.timeSpan = timespan
-        self.timeplot.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.timeplot.autoRangeY = False
         self.timeplot.maxYRange = 150.0
         self.timeplot.minYRange = 0.0

--- a/pyqt-apps/siriushla/as_ap_radmon/main.py
+++ b/pyqt-apps/siriushla/as_ap_radmon/main.py
@@ -109,8 +109,6 @@ class RadTotDoseMonitor(QWidget):
         timespan = 30*60  # [s]
         self.timeplot = SiriusTimePlot(
             parent=self, background='w', show_tooltip=True)
-        self.timeplot.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.timeplot.timeSpan = timespan
         self.timeplot.bufferSize = 4*60*60*10
         self.timeplot.autoRangeY = True

--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/base.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/base.py
@@ -144,7 +144,7 @@ class BaseWidget(QWidget):
         unit = 'm' if self.is_orb else 'rad'
         graph.setLabel('left', text=lab, units=unit)
         graph.setObjectName(lab.replace(' ', '')+pln)
-        view = graph.getAxis('left').linkedView()
+
         for i, lname in enumerate(self.line_names):
             opts = dict(
                 y_channel='A',
@@ -161,14 +161,14 @@ class BaseWidget(QWidget):
             pen.setStyle(4)
             cpstd = InfiniteLine(pos=0.0, pen=pen, angle=0)
             self.updater[i].ave_pstd[pln].connect(cpstd.setValue)
-            view.addItem(cpstd)
+            graph.addItem(cpstd)
             cmstd = InfiniteLine(pos=0.0, pen=pen, angle=0)
             self.updater[i].ave_mstd[pln].connect(cmstd.setValue)
-            view.addItem(cmstd)
+            graph.addItem(cmstd)
             pen.setStyle(2)
             cave = InfiniteLine(pos=0.0, pen=pen, angle=0)
             self.updater[i].ave[pln].connect(cave.setValue)
-            view.addItem(cave)
+            graph.addItem(cave)
             cdta = graph.curveAtIndex(-1)
             self.updater[i].data_sig[pln].connect(
                 _part(self._update_waveform, cdta, pln, i))
@@ -279,7 +279,7 @@ class BaseWidget(QWidget):
             grpbx = self.findChild(QGroupBox, 'GroupBox' + str(i))
             for pln in ('x', 'y'):
                 curve = self.graph[pln].curveAtIndex(i)
-                lines = self.graph[pln].getAxis('left').linkedView().addedItems
+                lines = self.graph[pln].plotItem.items
                 lines = [x for x in lines if isinstance(x, InfiniteLine)]
                 cbx = grpbx.findChild(QCheckBox, pln + 'checkbox')
                 grpbx.toggled.connect(curve.setVisible)
@@ -577,7 +577,6 @@ class Graph(SiriusWaveformPlot):
     def __init__(self, *args, **kwargs):
         """."""
         super().__init__(*args, **kwargs)
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.setObjectName('graph')
         self.setStyleSheet('#graph {min-height: 13em; min-width: 20em;}')
         self.maxRedrawRate = 2

--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/correctors.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/correctors.py
@@ -80,9 +80,8 @@ class CorrectorsWidget(BaseWidget):
                 maxkick = InfLine(
                     conv=1e-6, pos=0.0, pen=pen, angle=0, name=name)
                 minkick = InfLine(conv=-1e-6, pos=0.0, pen=pen, angle=0)
-                view = self.graph[pln].getAxis('left').linkedView()
-                view.addItem(maxkick)
-                view.addItem(minkick)
+                self.graph[pln].addItem(maxkick)
+                self.graph[pln].addItem(minkick)
                 chan = _ConnSig(
                     self.devpref.substitute(propty=pvi + corr + '-RB'))
                 self._chans.append(chan)

--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/respmat.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/respmat.py
@@ -132,7 +132,7 @@ class ShowMatrixWidget(QWidget):
             pen = mkPen(**dic)
             line = InfLine(pos=i*self._csorb.circum+bpm_pos[0]/2, pen=pen)
             self._inflines.append(line)
-            self.graph.getAxis('left').linkedView().addItem(line)
+            self.graph.addItem(line)
 
 
 class SingularValues(QWidget):
@@ -188,7 +188,7 @@ class SingularValues(QWidget):
         pen.setStyle(2)
         pen.setWidth(3)
         line = InfLine(pos=0, pen=pen, angle=90)
-        graph.getAxis('left').linkedView().addItem(line)
+        graph.addItem(line)
         self._chan.new_value_signal[int].connect(_part(self.setValue, line))
 
         graph.setObjectName('graph_singvalues')

--- a/pyqt-apps/siriushla/as_di_bpms/base.py
+++ b/pyqt-apps/siriushla/as_di_bpms/base.py
@@ -115,7 +115,6 @@ class BaseGraph(BaseWidget):
         self.setupui()
 
     def setupgraph(self, graph):
-        graph.addAxis(plot_data_item=None, name='left', orientation='left')
         graph.mouseEnabledX = True
         graph.setShowXGrid(True)
         graph.setShowYGrid(True)

--- a/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
+++ b/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
@@ -11,7 +11,6 @@ from qtpy.QtWidgets import QFormLayout, QGridLayout, QHBoxLayout, \
     QVBoxLayout, QSizePolicy as QSzPlcy, QLabel, QPushButton,\
     QSpacerItem, QGroupBox, QWidget
 import qtawesome as qta
-from pyqtgraph import BarGraphItem
 
 from pydm.widgets import PyDMEnumComboBox, PyDMSpinbox, PyDMPushButton
 from pydm.widgets.waveformplot import WaveformCurveItem
@@ -584,8 +583,6 @@ class _ICTCalibration(QWidget):
 
     def _setupGraph(self):
         graph_rawread = _MyWaveformPlot(self)
-        graph_rawread.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         graph_rawread.setObjectName('graph_rawread')
         graph_rawread.autoRangeX = True
         graph_rawread.autoRangeY = True
@@ -653,11 +650,9 @@ class _MyWaveformCurveItem(WaveformCurveItem):
 
 class _MyWaveformPlot(SiriusWaveformPlot):
 
-    def addChannel(self, y_channel=None, x_channel=None, plot_style=None,
-                   name=None, color=None, lineStyle=None, lineWidth=None,
-                   symbol=None, symbolSize=None, barWidth=None,
-                   upperThreshold=None, lowerThreshold=None,
-                   thresholdColor=None, redraw_mode=None, yAxisName=None):
+    def addChannel(self, y_channel=None, x_channel=None, name=None,
+                   color=None, lineStyle=None, lineWidth=None,
+                   symbol=None, symbolSize=None, redraw_mode=None):
         """Reimplement to use _MyWaveformCurveItem."""
         plot_opts = {}
         plot_opts['symbol'] = symbol
@@ -671,17 +666,8 @@ class _MyWaveformPlot(SiriusWaveformPlot):
             plot_opts['redraw_mode'] = redraw_mode
         self._needs_redraw = False
         curve = _MyWaveformCurveItem(
-            y_addr=y_channel, x_addr=x_channel, plot_style=plot_style,
-            name=name, color=color, yAxisName=yAxisName, **plot_opts)
+            y_addr=y_channel, x_addr=x_channel, name=name,
+            color=color, **plot_opts)
         self.channel_pairs[(y_channel, x_channel)] = curve
-        if plot_style == 'Bar':
-            if barWidth is None:
-                barWidth = 1.0
-            curve.bar_graph_item = BarGraphItem(
-                x=[], height=[], width=barWidth, brush=color)
-            curve.setBarGraphInfo(
-                barWidth, upperThreshold, lowerThreshold, thresholdColor)
-        self.addCurve(curve, curve_color=color, y_axis_name=yAxisName)
-        if curve.bar_graph_item is not None:
-            curve.getViewBox().addItem(curve.bar_graph_item)
+        self.addCurve(curve, curve_color=color)
         curve.data_changed.connect(self.set_needs_redraw)

--- a/pyqt-apps/siriushla/as_di_tune/spectra.py
+++ b/pyqt-apps/siriushla/as_di_tune/spectra.py
@@ -26,7 +26,6 @@ class TuneSpectraView(SiriusWaveformPlot):
         self.prefix = prefix
         self.section = section
 
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.autoRangeX = True
         self.autoRangeY = True
         self.showXGrid = True

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -669,8 +669,6 @@ class PSDetailWidget(QWidget):
         self.curve_siggen.setObjectName('graph')
         self.curve_siggen.setStyleSheet(
             '#graph{max-height:15em; max-width:16.5em;}')
-        self.curve_siggen.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.curve_siggen.setLabel('left', text='Current [A]', color='gray')
         self.curve_siggen.setLabel('bottom', text='Time [s]', color='gray')
         self.curve_siggen.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
@@ -821,7 +819,6 @@ class PSDetailWidget(QWidget):
         self.wfm = SiriusWaveformPlot()
         self.wfm.setObjectName('graph')
         self.wfm.setStyleSheet('#graph{max-height:15em; max-width:16.5em;}')
-        self.wfm.addAxis(plot_data_item=None, name='left', orientation='left')
         self.wfm.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
         self.wfm.autoRangeX = True
         self.wfm.autoRangeY = True

--- a/pyqt-apps/siriushla/as_ps_control/ps_wfmerror_mon.py
+++ b/pyqt-apps/siriushla/as_ps_control/ps_wfmerror_mon.py
@@ -20,7 +20,6 @@ class Graph(SiriusWaveformPlot):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.setObjectName('graph')
         self.setStyleSheet('#graph {min-height: 15em; min-width: 25em;}')
         self.maxRedrawRate = 2

--- a/pyqt-apps/siriushla/as_ps_diag/ps_graph_mon.py
+++ b/pyqt-apps/siriushla/as_ps_diag/ps_graph_mon.py
@@ -311,7 +311,6 @@ class PSGraph(SiriusWaveformPlot):
                  symbols=list(), color='blue'):
         """Init."""
         super().__init__(parent)
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.setBackgroundColor(QColor(255, 255, 255))
         self.setAutoRangeX(True)
         self.setAutoRangeY(True)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -9,12 +9,11 @@ from qtpy.QtGui import QColor
 import qtawesome as qta
 from pyqtgraph import InfiniteLine, mkPen
 
-from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox, \
-    PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox, PyDMSpinbox
 
 from ..widgets import SiriusMainWindow, PyDMStateButton, PyDMLed, \
     SiriusLedAlert, SiriusLedState, PyDMLedMultiChannel, SiriusTimePlot, \
-    SiriusConnectionSignal, SiriusLabel, SiriusWaveformPlot
+    SiriusConnectionSignal, SiriusPushButton, SiriusLabel, SiriusWaveformPlot
 from ..util import connect_window, get_appropriate_color
 from .details import TransmLineStatusDetails, CavityStatusDetails, \
     LLRFInterlockDetails, TempMonitor
@@ -205,20 +204,18 @@ class RFMainControl(SiriusMainWindow):
         # # Reset Global
         self.ld_globreset = QLabel(
             'Reset Global', self, alignment=Qt.AlignRight)
-        self.pb_globreset = PyDMPushButton(
-            label='', icon=qta.icon('fa5s.sync'), pressValue=1, releaseValue=0,
+        self.pb_globreset = SiriusPushButton(
+            label='', icon=qta.icon('fa5s.sync'), releaseValue=0,
             parent=self, init_channel=self.prefix+self.chs['Reset']['Global'])
-        self.pb_globreset.writeWhenRelease = True
         self.pb_globreset.setObjectName('pb_globreset')
         self.pb_globreset.setStyleSheet(
             '#pb_globreset{min-width:25px; max-width:25px; icon-size:20px;}')
 
         # # Reset LLRF
         self.ld_llrfreset = QLabel('Reset LLRF', self, alignment=Qt.AlignRight)
-        self.pb_llrfreset = PyDMPushButton(
-            label='', icon=qta.icon('fa5s.sync'), pressValue=1, releaseValue=0,
+        self.pb_llrfreset = SiriusPushButton(
+            label='', icon=qta.icon('fa5s.sync'), releaseValue=0,
             parent=self, init_channel=self.prefix+self.chs['Reset']['LLRF'])
-        self.pb_llrfreset.writeWhenRelease = True
         self.pb_llrfreset.setObjectName('pb_llrfreset')
         self.pb_llrfreset.setStyleSheet(
             '#pb_llrfreset{min-width:25px; max-width:25px; icon-size:20px;}')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -544,8 +544,6 @@ class RFMainControl(SiriusMainWindow):
             QSpacerItem(10, 10, QSzPlcy.Expanding, QSzPlcy.Expanding), 4, 4)
 
         self.graph_plunmotors = SiriusTimePlot(self)
-        self.graph_plunmotors.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.graph_plunmotors.setObjectName('graph')
         self.graph_plunmotors.setStyleSheet(
             '#graph{min-height:15em;min-width:20em;max-height:15em;}')
@@ -842,8 +840,6 @@ class RFMainControl(SiriusMainWindow):
     def _rampMonLayout(self):
         self.ramp_graph = SiriusWaveformPlot(
             parent=self, background=QColor(255, 255, 255))
-        self.ramp_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.ramp_graph.setObjectName('graph')
         self.ramp_graph.setStyleSheet(
             '#graph{min-height:15em;min-width:21em;max-height:15em;}')
@@ -1022,8 +1018,6 @@ class RFMainControl(SiriusMainWindow):
         lay_vals.addWidget(self.cb_units, 0, 2)
 
         self.pwr_mon_graph = SiriusTimePlot(self)
-        self.pwr_mon_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.pwr_mon_graph.autoRangeX = True
         self.pwr_mon_graph.autoRangeY = True
         self.pwr_mon_graph.backgroundColor = QColor(255, 255, 255)
@@ -1176,8 +1170,6 @@ class RFMainControl(SiriusMainWindow):
             self.led_tempcellok, alignment=Qt.AlignRight)
 
         self.tempcell_graph = SiriusTimePlot(self)
-        self.tempcell_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.tempcell_graph.setObjectName('tempcell_graph')
         self.tempcell_graph.autoRangeX = True
         self.tempcell_graph.autoRangeY = True
@@ -1211,9 +1203,8 @@ class RFMainControl(SiriusMainWindow):
         pen = mkPen(color='k', width=2, style=Qt.DashLine)
         self.line_cell_maxlim = InfiniteLine(angle=0, pen=pen)
         self.line_cell_minlim = InfiniteLine(angle=0, pen=pen)
-        view = self.tempcell_graph.getAxis('left').linkedView()
-        view.addItem(self.line_cell_maxlim)
-        view.addItem(self.line_cell_minlim)
+        self.tempcell_graph.addItem(self.line_cell_maxlim)
+        self.tempcell_graph.addItem(self.line_cell_minlim)
 
         # # Coupler
         lb_tempcoup = QLabel('<h3> • Coupler</h3>', self)
@@ -1224,8 +1215,6 @@ class RFMainControl(SiriusMainWindow):
             self.led_tempcoupok, alignment=Qt.AlignRight)
 
         self.tempcoup_graph = SiriusTimePlot(self)
-        self.tempcoup_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.tempcoup_graph.setObjectName('tempcoup_graph')
         self.tempcoup_graph.autoRangeX = True
         self.tempcoup_graph.autoRangeY = True
@@ -1242,9 +1231,8 @@ class RFMainControl(SiriusMainWindow):
         self.tempcoup_graph.setLabel('left', '')
         self.line_coup_maxlim = InfiniteLine(angle=0, pen=pen)
         self.line_coup_minlim = InfiniteLine(angle=0, pen=pen)
-        view = self.tempcoup_graph.getAxis('left').linkedView()
-        view.addItem(self.line_coup_maxlim)
-        view.addItem(self.line_coup_minlim)
+        self.tempcoup_graph.addItem(self.line_coup_maxlim)
+        self.tempcoup_graph.addItem(self.line_coup_minlim)
 
         self.cavtemp_wid = QWidget()
         lay_cavtemp = QVBoxLayout(self.cavtemp_wid)
@@ -1275,8 +1263,6 @@ class RFMainControl(SiriusMainWindow):
             self.led_tempcircok, alignment=Qt.AlignRight)
 
         self.tempcirc_graph = SiriusTimePlot(self)
-        self.tempcirc_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.tempcirc_graph.setObjectName('tempcirc_graph')
         self.tempcirc_graph.autoRangeX = True
         self.tempcirc_graph.autoRangeY = True
@@ -1299,9 +1285,8 @@ class RFMainControl(SiriusMainWindow):
             pos=lims_circ[1], angle=0, pen=pen)
         self.line_circ_minlim = InfiniteLine(
             pos=lims_circ[0], angle=0, pen=pen)
-        view = self.tempcirc_graph.getAxis('left').linkedView()
-        view.addItem(self.line_circ_maxlim)
-        view.addItem(self.line_circ_minlim)
+        self.tempcirc_graph.addItem(self.line_circ_maxlim)
+        self.tempcirc_graph.addItem(self.line_circ_minlim)
 
         self.trltemp_wid = QWidget()
         lay_trltemp = QVBoxLayout(self.trltemp_wid)
@@ -1325,8 +1310,6 @@ class RFMainControl(SiriusMainWindow):
         hbox_vacuum_state.addWidget(self.led_condrun, alignment=Qt.AlignRight)
 
         self.vacuum_graph = SiriusTimePlot(self)
-        self.vacuum_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.vacuum_graph.setObjectName('vacuum_graph')
         self.vacuum_graph.autoRangeX = True
         self.vacuum_graph.autoRangeY = True

--- a/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
+++ b/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
@@ -1,24 +1,21 @@
 
 
 from qtpy.QtWidgets import QHBoxLayout, QWidget
-from pydm.widgets import PyDMPushButton
+from siriushla.widgets import SiriusPushButton
 
 
 class RFEnblDsblButton(QWidget):
     """Button to enbl/dsbl attribute controlled by 2 PVs."""
 
     def __init__(self, parent=None, channels=dict()):
-        """Init."""
         super().__init__(parent)
-        self.pb_off = PyDMPushButton(
+        self.pb_off = SiriusPushButton(
             parent=self, label='Off', init_channel=channels['off'],
-            pressValue=1, releaseValue=0)
-        self.pb_off.writeWhenRelease = True
+            releaseValue=0)
         self.pb_off.setStyleSheet('min-width:1.4em; max-width:1.4em;')
-        self.pb_on = PyDMPushButton(
+        self.pb_on = SiriusPushButton(
             parent=self, label='On', init_channel=channels['on'],
-            pressValue=1, releaseValue=0)
-        self.pb_on.writeWhenRelease = True
+            releaseValue=0)
         self.pb_on.setStyleSheet('min-width:1.4em; max-width:1.4em;')
         lay = QHBoxLayout(self)
         lay.setContentsMargins(0, 0, 0, 0)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -17,7 +17,7 @@ from siriuspy.timesys import csdev as _cstime
 from ..widgets import PyDMLed, PyDMStateButton, SiriusLedState, \
     SiriusEnumComboBox, SiriusLedAlert, SiriusLabel, \
     SiriusSpinbox, SiriusConnectionSignal, SiriusWaveformTable, \
-    SiriusHexaSpinbox, SiriusWaveformPlot
+    SiriusPushButton, SiriusHexaSpinbox, SiriusWaveformPlot
 from ..widgets.windows import create_window_from_widget, SiriusDialog
 from ..util import connect_window, get_appropriate_color
 
@@ -383,10 +383,9 @@ class EVG(BaseWidget):
 
         lb = QLabel("<b>Download</b>")
         pvname = self.get_pvname('Download-Cmd')
-        sp = PyDMPushButton(
+        sp = SiriusPushButton(
             self, label='', icon=qta.icon('fa5s.download'),
             pressValue=1, releaseValue=0, init_channel=pvname)  # ?
-        sp.writeWhenRelease = True
         gb = self._create_small_group('', info_wid, (lb, sp))
         lay.addWidget(gb, 1, 0, alignment=Qt.AlignHCenter)
 
@@ -1225,10 +1224,9 @@ class FOUT(BaseWidget):
 
         lb = QLabel("<b>Download</b>")
         pvname = self.get_pvname('Download-Cmd')
-        sp = PyDMPushButton(
+        sp = SiriusPushButton(
             self, label='', icon=qta.icon('fa5s.download'),
             pressValue=1, releaseValue=0, init_channel=pvname)  # ?
-        sp.writeWhenRelease = True
         gb = self._create_small_group('', info_wid, (lb, sp))
         info_lay.addWidget(gb, 1, 0, alignment=Qt.AlignTop)
 
@@ -1826,10 +1824,9 @@ class _EVR_EVE(BaseWidget):
 
         lb = QLabel("<b>Download</b>")
         pvname = self.get_pvname('Download-Cmd')
-        sp = PyDMPushButton(
+        sp = SiriusPushButton(
             self, label='', icon=qta.icon('fa5s.download'),
             pressValue=1, releaseValue=0, init_channel=pvname)  # ?
-        sp.writeWhenRelease = True
         gb = self._create_small_group('', info_wid, (lb, sp))
         info_lay.addWidget(gb, 0, 3, alignment=Qt.AlignTop)
 
@@ -1925,10 +1922,9 @@ class _EVR_EVE(BaseWidget):
             '', gbox_log, (ld_logrst, self.sb_logrst, self.led_logrst))
 
         ld_logpul = QLabel('<b>Pull</b>', self)
-        self.bt_logpul = PyDMPushButton(
+        self.bt_logpul = SiriusPushButton(
             parent=self, init_channel=self.get_pvname('pull'),
             pressValue=1, releaseValue=0)  # ?
-        self.bt_logpul.writeWhenRelease = True
         self.bt_logpul.setIcon(qta.icon('fa5s.arrow-down'))
         self.bt_logpul.setObjectName('bt')
         self.bt_logpul.setStyleSheet(
@@ -1992,10 +1988,9 @@ class _EVR_EVE(BaseWidget):
             '', gbox_buf, (ld_bufcnt, self.lb_bufcnt))
 
         ld_bufrst = QLabel('<b>Reset</b>', self)
-        self.bt_bufrst = PyDMPushButton(
+        self.bt_bufrst = SiriusPushButton(
             parent=self, init_channel=self.get_pvname('rstSoftBuff'),
             pressValue=1, releaseValue=0)  # ?
-        self.bt_bufrst.writeWhenRelease = True
         self.bt_bufrst.setIcon(qta.icon('fa5s.sync'))
         self.bt_bufrst.setObjectName('bt')
         self.bt_bufrst.setStyleSheet(

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -663,8 +663,6 @@ class BucketListGraph(BaseWidget):
     def _setupUi(self):
         # Graph
         self.graph = SiriusWaveformPlot(self)
-        self.graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.graph.setBackgroundColor(QColor(255, 255, 255))
         self.graph.maxRedrawRate = 2
         self.graph.mouseEnabledX = True

--- a/pyqt-apps/siriushla/bo_ap_ramp/custom_widgets.py
+++ b/pyqt-apps/siriushla/bo_ap_ramp/custom_widgets.py
@@ -110,7 +110,6 @@ class GraphKicks(SiriusWaveformPlot):
                  tooltip_names=list(), c0=0, color='blue'):
         """Init."""
         super().__init__(parent)
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.setBackgroundColor(QColor(255, 255, 255))
         self.setAutoRangeX(True)
         self.setAutoRangeY(True)

--- a/pyqt-apps/siriushla/li_ap_mps/main.py
+++ b/pyqt-apps/siriushla/li_ap_mps/main.py
@@ -4,11 +4,12 @@ from qtpy.QtWidgets import QWidget, QGroupBox, QHBoxLayout, \
     QGridLayout, QLabel, QTabWidget, \
     QPushButton
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMSpinbox
 from .util import PV_MPS, MPS_PREFIX, CTRL_TYPE, GROUP_POS, \
     GROUP_POSALL, LBL_MPS, LBL_WATER, PV_TEMP_MPS, TEMP_TYPE, LBL_ALL
 from ..util import get_appropriate_color
-from ..widgets import PyDMLedMultiChannel, PyDMLed, SiriusLabel
+from ..widgets import PyDMLedMultiChannel, PyDMLed, SiriusLabel, \
+    SiriusPushButton
 from .bypass_btn import BypassBtn
 
 
@@ -65,13 +66,12 @@ class MPSControl(QWidget):
                 self,
                 init_channel=device_name + pv_name + ctrl_type)
         elif ctrl_type == '_R':
-            widget = PyDMPushButton(
+            widget = SiriusPushButton(
                 self,
                 init_channel=device_name + pv_name + ctrl_type,
                 label='Reset',
                 pressValue=1,
                 releaseValue=0)
-            widget.writeWhenRelease = True
         widget.setStyleSheet('''
             min-width: 3.2em; max-width: 4.2em;
             min-height: 1.29em; max-height: 1.29em;
@@ -186,13 +186,12 @@ class MPSControl(QWidget):
                 name = 'Close'
 
             pb_lay = QHBoxLayout()
-            widget = PyDMPushButton(
+            widget = SiriusPushButton(
                 self,
                 init_channel=device_name + pv_name,
                 label=name,
                 pressValue=1,
                 releaseValue=0)
-            widget.writeWhenRelease = True
             widget.setStyleSheet('''
                 min-width: 3.2em; max-width: 4.2em;
                 min-height: 1.29em; max-height: 1.29em;

--- a/pyqt-apps/siriushla/li_pu_modltr/main.py
+++ b/pyqt-apps/siriushla/li_pu_modltr/main.py
@@ -13,7 +13,7 @@ from siriuspy.namesys import SiriusPVName as _PVName
 
 from ..util import connect_window, get_appropriate_color
 from ..widgets import SiriusMainWindow, SiriusLedState, SiriusSpinbox, \
-    PyDMStateButton, SiriusLabel
+    SiriusPushButton, PyDMStateButton, SiriusLabel
 from .auxiliary_dialogs import ModIntlkDetailDialog, ModEmerStopDialog
 
 
@@ -88,10 +88,9 @@ class LIModltrWindow(SiriusMainWindow):
         led_output = SiriusLedState(self, dev+':OutPut_Status')
 
         # Reset
-        pb_reset = PyDMPushButton(
+        pb_reset = SiriusPushButton(
             self, label='Reset', icon=qta.icon('fa5s.sync'),
             pressValue=1, releaseValue=0, init_channel=dev+':RESET')
-        pb_reset.writeWhenRelease = True
         pb_reset.setObjectName('reset')
         pb_reset.setStyleSheet("""
             #reset{

--- a/pyqt-apps/siriushla/li_rf_llrf/main.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/main.py
@@ -204,7 +204,6 @@ class GraphIvsQ(QWidget):
         self.setLayout(lay1)
 
         graph = SiriusWaveformPlot(self)
-        graph.addAxis(plot_data_item=None, name='left', orientation='left')
         graph.setObjectName('graph')
         graph.setStyleSheet('#graph {min-height: 15em; min-width: 20em;}')
         graph.maxRedrawRate = 2
@@ -281,7 +280,6 @@ class GraphAmpPha(QWidget):
         self.setLayout(lay1)
 
         graph = SiriusTimePlot(self)
-        graph.addAxis(plot_data_item=None, name='left', orientation='left')
         graph.setObjectName('graph')
         graph.setStyleSheet('#graph {min-height: 7em; min-width: 20em;}')
         graph.maxRedrawRate = 2

--- a/pyqt-apps/siriushla/si_ap_genstatus/main.py
+++ b/pyqt-apps/siriushla/si_ap_genstatus/main.py
@@ -138,8 +138,6 @@ class SIGenStatusWindow(SiriusMainWindow):
         self.tune_mon.lb_tunefracv.setStyleSheet('QLabel{font-size: 45pt;}')
 
         self.curr_graph = SiriusTimePlot(self)
-        self.curr_graph.addAxis(
-            plot_data_item=None, name='left', orientation='left')
         self.curr_graph.setObjectName('curr_graph')
         self.curr_graph.setStyleSheet(
             '#curr_graph{min-width: 20em; min-height: 14em;}')

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -288,7 +288,6 @@ class Graph(BaseObject, SiriusWaveformPlot):
         """Init."""
         BaseObject.__init__(self)
         SiriusWaveformPlot.__init__(self, parent)
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
         self.setBackgroundColor(QColor(255, 255, 255))
         self.setAutoRangeX(True)
         self.setAutoRangeY(True)

--- a/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
+++ b/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
@@ -3,12 +3,12 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, QHBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, PyDMPushButton
+from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import SiriusFrame, SiriusLabel
+from ..widgets import SiriusFrame, SiriusLabel, SiriusPushButton
 
 from .custom_widgets import MyScaleIndicator
 from .util import set_bbb_color
@@ -468,10 +468,9 @@ class BbBInterlock(QWidget):
         fr_sts = SiriusFrame(self, pvn, is_float=True)
         fr_sts.borderWidth = 2
         fr_sts.add_widget(lb_sts)
-        pb_rst = PyDMPushButton(
+        pb_rst = SiriusPushButton(
             self, init_channel=self.dev_pref+':ILOCK_RESET', pressValue=1,
             releaseValue=0)
-        pb_rst.writeWhenRelease = True
         pb_rst.setText('Reset')
         pb_rst.setToolTip('Reset Counts')
         pb_rst.setIcon(qta.icon('fa5s.sync'))
@@ -511,19 +510,17 @@ class BbBInterlock(QWidget):
         sb_thr.showStepExponent = False
         sb_thr.showUnits = True
 
-        pb_upt = PyDMPushButton(
+        pb_upt = SiriusPushButton(
             self, init_channel=self.dev_pref+':ILOCK_UPDATE', pressValue=1,
             releaseValue=0)
-        pb_upt.writeWhenRelease = True
         pb_upt.setText('Update Filter')
         pb_upt.setToolTip('Update Filter Config')
         pb_upt.setIcon(qta.icon('mdi.sync'))
         pb_upt.setStyleSheet("icon-size:20px;")
 
-        pb_ld = PyDMPushButton(
+        pb_ld = SiriusPushButton(
             self, init_channel=self.dev_pref+':BO_CPCOEFF', pressValue=1,
             releaseValue=0)
-        pb_ld.writeWhenRelease = True
         pb_ld.setText('Apply Filter')
         pb_ld.setToolTip('Apply Filter Config to Feedback')
         pb_ld.setIcon(qta.icon('mdi.upload'))

--- a/pyqt-apps/siriushla/si_di_bbb/bbb.py
+++ b/pyqt-apps/siriushla/si_di_bbb/bbb.py
@@ -4,7 +4,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, \
     QGroupBox, QSpacerItem, QSizePolicy as QSzPlcy, QPushButton, QHBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, PyDMPushButton
+from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
@@ -12,7 +12,7 @@ from siriuspy.namesys import SiriusPVName as _PVName
 from ..util import connect_window, connect_newprocess
 from ..widgets.windows import create_window_from_widget
 from ..widgets import SiriusMainWindow, SiriusLedAlert, PyDMStateButton, \
-    PyDMLedMultiChannel, DetachableTabWidget, SiriusLabel
+    PyDMLedMultiChannel, DetachableTabWidget, SiriusLabel, SiriusPushButton
 
 from .acquisition import BbBAcqSRAM, BbBAcqBRAM, BbBAcqSB
 from .coefficients import BbBCoefficientsWidget
@@ -272,10 +272,9 @@ class BbBStatusWidget(QWidget):
 
         ld_intvl = QLabel('Interval [s]', alignment=Qt.AlignCenter)
         lb_intvl = SiriusLabel(self, self.dev_pref+':RST_COUNT')
-        pb_intvl = PyDMPushButton(
+        pb_intvl = SiriusPushButton(
             self, init_channel=self.dev_pref+':CNTRST', pressValue=1,
             releaseValue=0)
-        pb_intvl.writeWhenRelease = True
         pb_intvl.setText('Reset')
         pb_intvl.setToolTip('Reset Counts')
         pb_intvl.setIcon(qta.icon('fa5s.sync'))

--- a/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
@@ -23,8 +23,6 @@ class WfmGraph(SiriusWaveformPlot):
         self.setStyleSheet(
             '#graph {min-height: 6em; min-width: 15em;}')
 
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
-
         self.maxRedrawRate = 2
 
         self.autoRangeX = True
@@ -111,8 +109,6 @@ class TimeGraph(SiriusTimePlot):
         self.setObjectName('graph')
         self.setStyleSheet(
             '#graph {min-height: 6em; min-width: 8em;}')
-
-        self.addAxis(plot_data_item=None, name='left', orientation='left')
 
         self.autoRangeX = True
         self.autoRangeY = True

--- a/pyqt-apps/siriushla/si_di_bbb/pwr_amps.py
+++ b/pyqt-apps/siriushla/si_di_bbb/pwr_amps.py
@@ -5,13 +5,13 @@ from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, \
     QHBoxLayout, QSizePolicy as QSzPlcy, QSpacerItem
 import qtawesome as qta
-from pydm.widgets import PyDMLineEdit, PyDMPushButton
+from pydm.widgets import PyDMLineEdit
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
 from ..widgets import PyDMStateButton, SiriusLedState, SiriusSpinbox, \
-    SiriusLabel, PyDMLed
+    SiriusLabel, PyDMLed, SiriusPushButton
 
 from .custom_widgets import MyScaleIndicator
 from .util import set_bbb_color
@@ -285,9 +285,8 @@ class BbBPwrAmpsWidget(QWidget):
         ld_main = QLabel(
             '<h3>AR Amplifier</h3>', self, alignment=Qt.AlignCenter)
 
-        conf = PyDMPushButton(
+        conf = SiriusPushButton(
             self, init_channel=pref+':Rst-Cmd', pressValue=1, releaseValue=0)
-        conf.writeWhenRelease = True
         conf.setText('Reset')
         conf.setToolTip('Reset State')
         conf.setIcon(qta.icon('fa5s.sync'))

--- a/pyqt-apps/siriushla/si_di_bbb/timing.py
+++ b/pyqt-apps/siriushla/si_di_bbb/timing.py
@@ -4,12 +4,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, \
     QGroupBox
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMSpinbox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import SiriusFrame, SiriusSpinbox, SiriusLabel
+from ..widgets import SiriusFrame, SiriusSpinbox, SiriusLabel, SiriusPushButton
 from .util import set_bbb_color
 
 
@@ -51,10 +51,9 @@ class BbBTimingWidget(QWidget):
 
         # Timing Control
         ld_clkrst = QLabel('Clock Reset', self)
-        pb_clkrst = PyDMPushButton(
+        pb_clkrst = SiriusPushButton(
             self, init_channel=self.dev_pref+':CLKRST', pressValue=1,
             releaseValue=0)
-        pb_clkrst.writeWhenRelease = True
         pb_clkrst.setText('Reset')
         pb_clkrst.setToolTip('Reset Clock')
         pb_clkrst.setIcon(qta.icon('fa5s.sync'))

--- a/pyqt-apps/siriushla/widgets/__init__.py
+++ b/pyqt-apps/siriushla/widgets/__init__.py
@@ -26,5 +26,6 @@ from .enum_combo_box import SiriusEnumComboBox
 from .frame import SiriusFrame, SiriusAlarmFrame
 from .process_image import SiriusProcessImage
 from .detachable_tabwidget import DetachableTabWidget
+from .pushbutton import SiriusPushButton
 from .waveformtable import SiriusWaveformTable
 from .selection_matrix import SelectionMatrixWidget

--- a/pyqt-apps/siriushla/widgets/label.py
+++ b/pyqt-apps/siriushla/widgets/label.py
@@ -5,9 +5,8 @@ from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property, Q_ENUMS
 from pydm.utilities import units
 from pydm.widgets.display_format import DisplayFormat, parse_value_for_display
-from pydm.widgets.base import PyDMWidget, TextFormatter, str_types
+from pydm.widgets.base import PyDMWidget, TextFormatter
 from pydm.utilities import is_pydm_app, is_qt_designer
-from pydm import config
 
 from siriuspy.clientarch import Time as _Time
 
@@ -34,10 +33,6 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
         """Init."""
         QLabel.__init__(self, parent, **kws)
         PyDMWidget.__init__(self, init_channel=init_channel)
-        if 'Text' not in SiriusLabel.RULE_PROPERTIES:
-            SiriusLabel.RULE_PROPERTIES = PyDMWidget.RULE_PROPERTIES.copy()
-            SiriusLabel.RULE_PROPERTIES.update(
-                {'Text': ['value_changed', str]})
         self.app = QApplication.instance()
         self.setTextFormat(Qt.PlainText)
         self.setTextInteractionFlags(Qt.NoTextInteraction)
@@ -59,7 +54,7 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
         if self._display_format_type == new_type:
             return
         self._display_format_type = new_type
-        if not is_qt_designer() or config.DESIGNER_ONLINE:
+        if not is_qt_designer():
             # Trigger the update of display format
             self.value_changed(self.value)
 
@@ -115,7 +110,7 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
             string_encoding=self._string_encoding, widget=self)
         # If the value is a string, just display it as-is, no formatting
         # needed.
-        if isinstance(new_value, str_types):
+        if isinstance(new_value, str):
             if self._show_units and self._unit != "":
                 new_value = "{} {}".format(new_value, self._unit)
             self.setText(new_value)

--- a/pyqt-apps/siriushla/widgets/pushbutton.py
+++ b/pyqt-apps/siriushla/widgets/pushbutton.py
@@ -1,0 +1,118 @@
+"""Sirius pushbutton."""
+
+from qtpy.QtCore import Slot, Property
+
+from pydm.widgets import PyDMPushButton
+
+
+class SiriusPushButton(PyDMPushButton):
+    """
+    Basic PushButton to send a fixed value.
+
+    The PyDMPushButton is meant to hold a specific value, and send that value
+    to a channel when it is clicked, much like the MessageButton does in EDM.
+    The PyDMPushButton works in two different modes of operation, first, a
+    fixed value can be given to the :attr:`.pressValue` attribute, whenever the
+    button is clicked a signal containing this value will be sent to the
+    connected channel. This is the default behavior of the button. However, if
+    the :attr:`.relativeChange` is set to True, the fixed value will be added
+    to the current value of the channel. This means that the button will
+    increment a channel by a fixed amount with every click, a consistent
+    relative move
+
+    Parameters
+    ----------
+    parent : QObject, optional
+        Parent of PyDMPushButton
+
+    init_channel : str, optional
+        ID of channel to manipulate
+
+    label : str, optional
+        String to place on button
+
+    icon : QIcon, optional
+        An Icon to display on the PyDMPushButton
+
+    pressValue : int, float, str
+        Value to be sent when the button is pressed
+
+    releaseValue : int, float, str
+        Value to be sent when the button is released
+
+    relative : bool, optional
+        Choice to have the button perform a relative put, instead of always
+        setting to an absolute value
+
+    """
+
+    def __init__(self, parent=None, init_channel=None, label='', icon=None,
+                 pressValue=1, releaseValue=None, relative=False):
+        PyDMPushButton.__init__(
+            self, parent=parent, label=label, icon=icon,
+            pressValue=pressValue, relative=relative,
+            init_channel=init_channel)
+        self._releaseValue = releaseValue
+        self.clicked.disconnect(self.sendValue)
+        self.pressed.connect(self.sendValue)
+        self.released.connect(self.sendReleaseValue)
+
+    @Property(str)
+    def releaseValue(self):
+        """
+        This property holds the value to send back through the channel.
+
+        The type of this value does not matter because it is automatically
+        converted to match the prexisting value type of the channel. However,
+        the sign of the value matters. Not used when relative flag is True.
+
+        Returns
+        -------
+        str
+        """
+        if self._releaseValue is None:
+            return None
+        return str(self._releaseValue)
+
+    @releaseValue.setter
+    def releaseValue(self, value):
+        """
+        This property holds the value to send back through the channel.
+
+        The type of this value does not matter because it is automatically
+        converted to match the prexisting value type of the channel. However,
+        the sign of the value matters. Not used when relative flag is True.
+
+        Parameters
+        ----------
+        value : str
+        """
+        if value is None:
+            self._releaseValue = None
+        elif str(value) != self._releaseValue:
+            self._releaseValue = str(value)
+
+    @Slot()
+    def sendReleaseValue(self):
+        """
+        Send a new value to the channel.
+
+        This function interprets the settings of the PyDMPushButton and sends
+        the appropriate value out through the :attr:`.send_value_signal`.
+
+        Returns
+        -------
+        None if any of the following condition is False:
+            1. There's no new value (pressValue) for the widget
+            2. There's no initial or current value for the widget
+            3. The relative flag is True
+        Otherwise, return the value sent to the channel:
+            1. The value sent to the channel is the same as the releaseValue
+        """
+        if self._releaseValue is None or self.value is None or self._relative:
+            return None
+
+        send_value = self._releaseValue
+        self.send_value_signal[self.channeltype].emit(
+            self.channeltype(send_value))
+        return send_value

--- a/pyqt-apps/siriushla/widgets/signal_channel.py
+++ b/pyqt-apps/siriushla/widgets/signal_channel.py
@@ -19,10 +19,6 @@ class SiriusConnectionSignal(QObject, PyDMChannel):
     new_severity_signal = Signal(int)
     upper_ctrl_limit_signal = Signal([float], [int])
     lower_ctrl_limit_signal = Signal([float], [int])
-    upper_alarm_limit_signal = Signal([float], [int])
-    lower_alarm_limit_signal = Signal([float], [int])
-    upper_warning_limit_signal = Signal([float], [int])
-    lower_warning_limit_signal = Signal([float], [int])
 
     def __init__(self, address, **kws):
         QObject.__init__(self)
@@ -37,10 +33,6 @@ class SiriusConnectionSignal(QObject, PyDMChannel):
         self.prec_slot = self._prec_slot
         self.upper_ctrl_limit_slot = self._upper_ctrl_limit_slot
         self.lower_ctrl_limit_slot = self._lower_ctrl_limit_slot
-        self.upper_alarm_limit_slot = self._upper_alarm_limit_slot
-        self.lower_alarm_limit_slot = self._lower_alarm_limit_slot
-        self.upper_warning_limit_slot = self._upper_warning_limit_slot
-        self.lower_warning_limit_slot = self._lower_warning_limit_slot
         self.value_signal = self.send_value_signal
 
         self.channeltype = None
@@ -98,23 +90,3 @@ class SiriusConnectionSignal(QObject, PyDMChannel):
     @Slot(float)
     def _lower_ctrl_limit_slot(self, lower_ctrl_limit):
         self.lower_ctrl_limit_signal.emit(lower_ctrl_limit)
-
-    @Slot(int)
-    @Slot(float)
-    def _upper_alarm_limit_slot(self, upper_alarm_limit):
-        self.upper_alarm_limit_signal.emit(upper_alarm_limit)
-
-    @Slot(int)
-    @Slot(float)
-    def _lower_alarm_limit_slot(self, lower_alarm_limit):
-        self.lower_alarm_limit_signal.emit(lower_alarm_limit)
-
-    @Slot(int)
-    @Slot(float)
-    def _upper_warning_limit_slot(self, upper_warning_limit):
-        self.upper_warning_limit_signal.emit(upper_warning_limit)
-
-    @Slot(int)
-    @Slot(float)
-    def _lower_warning_limit_slot(self, lower_warning_limit):
-        self.lower_warning_limit_signal.emit(lower_warning_limit)

--- a/pyqt-apps/siriushla/widgets/timeplot.py
+++ b/pyqt-apps/siriushla/widgets/timeplot.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import QInputDialog, QLabel, QApplication, QAction
 
 from pyqtgraph import ViewBox, mkBrush
 
+from pydm import utilities
 from pydm.widgets.timeplot import TimePlotCurveItem, PyDMTimePlot, \
     DEFAULT_X_MIN
 
@@ -54,7 +55,7 @@ class SiriusTimePlotItem(TimePlotCurveItem):
             super().receiveNewValue(new_value)
 
     @Slot()
-    def redrawCurve(self, min_x=None, max_x=None):
+    def redrawCurve(self):
         """
         Rederive redrawCurve to use data only refered to timespan.
         """
@@ -71,13 +72,7 @@ class SiriusTimePlotItem(TimePlotCurveItem):
             if not self._plot_by_timestamps:
                 x -= now
 
-            if self.plot_style is None or self.plot_style == 'Line':
-                self.setData(y=y, x=x)
-            elif self.plot_style == 'Bar':
-                min_index = _np.searchsorted(x, min_x)
-                max_index = _np.searchsorted(x, max_x) + 1
-                self._setBarGraphItem(
-                    x=x[min_index:max_index], y=y[min_index:max_index])
+            self.setData(y=y, x=x)
         except (ZeroDivisionError, OverflowError):
             # Solve an issue with pyqtgraph and initial downsampling
             pass
@@ -105,6 +100,13 @@ class SiriusTimePlot(PyDMTimePlot):
         super().__init__(*args, **kws)
         self._filled_with_arch_data = dict()
         self._show_tooltip = show_tooltip
+
+        self.vb2 = ViewBox()
+        self.plotItem.scene().addItem(self.vb2)
+        self.vb2.setXLink(self.plotItem)
+        self.plotItem.getAxis('right').linkToView(self.vb2)
+        self._updateViews()
+        self.plotItem.vb.sigResized.connect(self._updateViews)
 
         self.carch = None
 
@@ -148,12 +150,55 @@ class SiriusTimePlot(PyDMTimePlot):
         """
         self._show_tooltip = new_show
 
-    def createCurveItem(self, y_channel, plot_by_timestamps, plot_style, name,
-                        color, yAxisName, useArchiveData, **plot_opts):
-        return SiriusTimePlotItem(
-            self, y_channel, plot_by_timestamps=plot_by_timestamps,
-            plot_style=plot_style, name=name, color=color,
-            yAxisName=yAxisName, **plot_opts)
+    def addCurve(self, plot_item, axis='left', curve_color=None):
+        """Reimplement to use right axis."""
+        if curve_color is None:
+            curve_color = utilities.colors.default_colors[
+                len(self._curves) % len(utilities.colors.default_colors)]
+            plot_item.color_string = curve_color
+        self._curves.append(plot_item)
+        if axis == 'left':
+            self.plotItem.addItem(plot_item)
+        elif axis == 'right':
+            if not self.plotItem.getAxis('right').isVisible():
+                self.plotItem.showAxis('right')
+            self.vb2.addItem(plot_item)
+        else:
+            raise ValueError('Choose a valid axis!')
+
+        # Connect channels
+        for chan in plot_item.channels():
+            if chan:
+                chan.connect()
+
+    def addYChannel(
+            self, y_channel=None, name=None, color=None, lineStyle=None,
+            lineWidth=None, symbol=None, symbolSize=None, axis='left'):
+        """Reimplement to use SiriusTimePlotItem and right axis."""
+        plot_opts = dict()
+        plot_opts['symbol'] = symbol
+        if symbolSize is not None:
+            plot_opts['symbolSize'] = symbolSize
+        if lineStyle is not None:
+            plot_opts['lineStyle'] = lineStyle
+        if lineWidth is not None:
+            plot_opts['lineWidth'] = lineWidth
+
+        # Add curve
+        new_curve = SiriusTimePlotItem(
+            self, y_channel,
+            plot_by_timestamps=self._plot_by_timestamps,
+            name=name, color=color, **plot_opts)
+        new_curve.setUpdatesAsynchronously(self.updatesAsynchronously)
+        new_curve.setBufferSize(self._bufferSize, initialize_buffer=True)
+
+        self.update_timer.timeout.connect(new_curve.asyncUpdate)
+        self.addCurve(new_curve, axis, curve_color=color)
+
+        new_curve.data_changed.connect(self.set_needs_redraw)
+        self.redraw_timer.start()
+
+        return new_curve
 
     def updateXAxis(self, update_immediately=False):
         """Reimplement to show only existing range."""
@@ -161,7 +206,7 @@ class SiriusTimePlot(PyDMTimePlot):
             return
 
         if self._plot_by_timestamps:
-            if self._update_mode == PyDMTimePlot.OnValueChange:
+            if self._update_mode == PyDMTimePlot.SynchronousMode:
                 maxrange = max([curve.max_x() for curve in self._curves])
             else:
                 maxrange = time.time()
@@ -182,6 +227,10 @@ class SiriusTimePlot(PyDMTimePlot):
             if diff_time > DEFAULT_X_MIN:
                 diff_time = DEFAULT_X_MIN
             self.getViewBox().setLimits(minXRange=diff_time)
+
+    def _updateViews(self):
+        self.vb2.setGeometry(self.plotItem.vb.sceneBoundingRect())
+        self.vb2.linkedViewChanged(self.plotItem.vb, self.vb2.XAxis)
 
     def _get_value_from_arch(
             self, pvname, t_init, t_end, process_type, process_bin_intvl):


### PR DESCRIPTION
This PR reverts changes introduced at https://github.com/lnls-sirius/hla/pull/551 which are dependent on the new version of PyDM. The motivation here is that I erroneously updated PyDM for a version that depends on pyqtgraph 0.12.0, which in turn depends on python >= 3.7, but pydm itself didn't update its dependency to latest version of python and I didn't pay attention... So, first of all, we need to update our python version, so we can bring those news. Sorry guys for all inconvenience.