### PR TITLE
Remove PyDMSpinbox

### DIFF
--- a/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
+++ b/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import QLabel, QGroupBox, QWidget, QSpacerItem,\
     QGridLayout, QHBoxLayout, QVBoxLayout
 import qtawesome as qta
 from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit,\
-    PyDMPushButton, PyDMSpinbox
+    PyDMPushButton
 
 from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 from siriuspy.namesys import SiriusPVName as _PVName
@@ -361,7 +361,7 @@ class CurrLTWindow(SiriusMainWindow):
         hlay_maxintvl = QHBoxLayout()
         hlay_maxintvl.addWidget(self._pb_plussett)
         hlay_maxintvl.addWidget(self._ld_maxintvl)
-        self._sb_maxintvl = PyDMSpinbox(
+        self._sb_maxintvl = SiriusSpinbox(
             self, self.devname.substitute(propty='MaxSplIntvl-SP'))
         self._sb_maxintvl.precisionFromPV = True
         self._sb_maxintvl.showStepExponent = False
@@ -434,7 +434,7 @@ class CurrLTWindow(SiriusMainWindow):
         self._ld_intvlbtwspl = QLabel(
             'Interval Between\nSamples [s]:', self,
             alignment=Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
-        self._sb_intvlbtwspl = PyDMSpinbox(
+        self._sb_intvlbtwspl = SiriusSpinbox(
             self, self.devname.substitute(propty='MinIntvlBtwSpl-SP'))
         self._sb_intvlbtwspl.precisionFromPV = True
         self._sb_intvlbtwspl.showStepExponent = False
@@ -454,7 +454,7 @@ class CurrLTWindow(SiriusMainWindow):
         self._ld_bufdcurr = QLabel(
             'Auto Reset Delta\nCurrent [mA]:', self,
             alignment=Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
-        self._sb_bufdcurr = PyDMSpinbox(
+        self._sb_bufdcurr = SiriusSpinbox(
             self, self.devname.substitute(propty='BuffAutoRstDCurr-SP'))
         self._sb_bufdcurr.showStepExponent = False
         self._lb_bufdcurr = SiriusLabel(

--- a/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
+++ b/pyqt-apps/siriushla/as_ap_currinfo/current_and_lifetime.py
@@ -335,7 +335,6 @@ class CurrLTWindow(SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
         self._sb_curroffset = SiriusSpinbox(
             self, self.devname.substitute(propty='CurrOffset-SP'))
-        self._sb_curroffset.showStepExponent = False
         self._lb_curroffset = SiriusLabel(
             self, self.devname.substitute(propty='CurrOffset-RB'))
         self._lb_curroffset.setAlignment(Qt.AlignCenter)
@@ -364,7 +363,6 @@ class CurrLTWindow(SiriusMainWindow):
         self._sb_maxintvl = SiriusSpinbox(
             self, self.devname.substitute(propty='MaxSplIntvl-SP'))
         self._sb_maxintvl.precisionFromPV = True
-        self._sb_maxintvl.showStepExponent = False
         self._lb_maxintvl = SiriusLabel(
             self, self.devname.substitute(propty='MaxSplIntvl-RB'))
         self._lb_maxintvl.setAlignment(Qt.AlignCenter)
@@ -437,7 +435,6 @@ class CurrLTWindow(SiriusMainWindow):
         self._sb_intvlbtwspl = SiriusSpinbox(
             self, self.devname.substitute(propty='MinIntvlBtwSpl-SP'))
         self._sb_intvlbtwspl.precisionFromPV = True
-        self._sb_intvlbtwspl.showStepExponent = False
         self._lb_intvlbtwspl = SiriusLabel(
             self, self.devname.substitute(propty='MinIntvlBtwSpl-RB'))
         self._lb_intvlbtwspl.setAlignment(Qt.AlignCenter)
@@ -456,7 +453,6 @@ class CurrLTWindow(SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignTrailing | Qt.AlignVCenter)
         self._sb_bufdcurr = SiriusSpinbox(
             self, self.devname.substitute(propty='BuffAutoRstDCurr-SP'))
-        self._sb_bufdcurr.showStepExponent = False
         self._lb_bufdcurr = SiriusLabel(
             self, self.devname.substitute(propty='BuffAutoRstDCurr-RB'))
 

--- a/pyqt-apps/siriushla/as_ap_injcontrol/injbo.py
+++ b/pyqt-apps/siriushla/as_ap_injcontrol/injbo.py
@@ -128,7 +128,6 @@ class InjBOControlWindow(BaseWindow):
             pos_sp = SiriusSpinbox(
                 self, posang_prefix.substitute(propty='DeltaPos'+axis+'-SP'))
             pos_sp.setObjectName('pos_sp_'+axis.lower())
-            pos_sp.showStepExponent = False
             pos_rb = SiriusLabel(
                 self, posang_prefix.substitute(propty='DeltaPos'+axis+'-RB'),
                 keep_unit=True)
@@ -140,7 +139,6 @@ class InjBOControlWindow(BaseWindow):
             ang_sp = SiriusSpinbox(
                 self, posang_prefix.substitute(propty='DeltaAng'+axis+'-SP'))
             ang_sp.setObjectName('ang_sp_'+axis.lower())
-            ang_sp.showStepExponent = False
             ang_rb = SiriusLabel(
                 self, posang_prefix.substitute(propty='DeltaAng'+axis+'-RB'),
                 keep_unit=True)

--- a/pyqt-apps/siriushla/as_ap_injcontrol/injbo.py
+++ b/pyqt-apps/siriushla/as_ap_injcontrol/injbo.py
@@ -6,10 +6,10 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QVBoxLayout, QHBoxLayout, QWidget, \
     QSizePolicy as QSzPlcy, QGroupBox, QLabel, QPushButton, QAction
 
-from pydm.widgets import PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMPushButton
 from siriuspy.namesys import SiriusPVName
 from siriushla import util
-from siriushla.widgets import SiriusLabel
+from siriushla.widgets import SiriusLabel, SiriusSpinbox
 from siriushla.as_ap_posang import CorrParamsDetailWindow
 from siriushla.as_ap_injcontrol.base import BaseWindow
 
@@ -125,7 +125,7 @@ class InjBOControlWindow(BaseWindow):
             lb_pos = QLabel('<h4>Δ'+axis.lower()+'</h4>', self,
                             alignment=Qt.AlignRight)
             lb_pos.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
-            pos_sp = PyDMSpinbox(
+            pos_sp = SiriusSpinbox(
                 self, posang_prefix.substitute(propty='DeltaPos'+axis+'-SP'))
             pos_sp.setObjectName('pos_sp_'+axis.lower())
             pos_sp.showStepExponent = False
@@ -137,7 +137,7 @@ class InjBOControlWindow(BaseWindow):
             lb_ang = QLabel('<h4>Δ'+axis.lower()+'\'</h4>', self,
                             alignment=Qt.AlignRight)
             lb_ang.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
-            ang_sp = PyDMSpinbox(
+            ang_sp = SiriusSpinbox(
                 self, posang_prefix.substitute(propty='DeltaAng'+axis+'-SP'))
             ang_sp.setObjectName('ang_sp_'+axis.lower())
             ang_sp.showStepExponent = False

--- a/pyqt-apps/siriushla/as_ap_injection/main.py
+++ b/pyqt-apps/siriushla/as_ap_injection/main.py
@@ -252,7 +252,6 @@ class InjCtrlWindow(SiriusMainWindow):
         labelsdesc.append(self._ld_currtgt)
         self._sb_currtgt = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='TargetCurrent-SP'))
-        self._sb_currtgt.showStepExponent = False
         self._lb_currtgt = SiriusLabel(
             self, self._inj_prefix.substitute(propty='TargetCurrent-RB'),
             keep_unit=True)
@@ -308,7 +307,6 @@ class InjCtrlWindow(SiriusMainWindow):
         labelsdesc.append(self._ld_sbbias)
         self._sb_sbbias = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='SglBunBiasVolt-SP'))
-        self._sb_sbbias.showStepExponent = False
         self._lb_sbbias = SiriusLabel(
             self, self._inj_prefix.substitute(propty='SglBunBiasVolt-RB'),
             keep_unit=True)
@@ -323,7 +321,6 @@ class InjCtrlWindow(SiriusMainWindow):
         labelsdesc.append(self._ld_mbbias)
         self._sb_mbbias = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='MultBunBiasVolt-SP'))
-        self._sb_mbbias.showStepExponent = False
         self._lb_mbbias = SiriusLabel(
             self, self._inj_prefix.substitute(propty='MultBunBiasVolt-RB'),
             keep_unit=True)
@@ -345,7 +342,6 @@ class InjCtrlWindow(SiriusMainWindow):
         labelsdesc.append(self._ld_filaopcurr)
         self._sb_filaopcurr = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='FilaOpCurr-SP'))
-        self._sb_filaopcurr.showStepExponent = False
         self._lb_filaopcurr = SiriusLabel(
             self, self._inj_prefix.substitute(propty='FilaOpCurr-RB'),
             keep_unit=True)
@@ -365,7 +361,6 @@ class InjCtrlWindow(SiriusMainWindow):
         labelsdesc.append(self._ld_hvopvolt)
         self._sb_hvopvolt = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='HVOpVolt-SP'))
-        self._sb_hvopvolt.showStepExponent = False
         self._lb_hvopvolt = SiriusLabel(
             self, self._inj_prefix.substitute(propty='HVOpVolt-RB'),
             keep_unit=True)
@@ -472,7 +467,6 @@ class InjCtrlWindow(SiriusMainWindow):
         self._ld_tuperd = QLabel('Period', self)
         self._sb_tuperd = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='TopUpPeriod-SP'))
-        self._sb_tuperd.showStepExponent = False
         self._lb_tuperd = SiriusLabel(
             self, self._inj_prefix.substitute(propty='TopUpPeriod-RB'))
         self._lb_tuperd.showUnits = True
@@ -480,7 +474,6 @@ class InjCtrlWindow(SiriusMainWindow):
         self._ld_tunrpu = QLabel('Nr.Pulses', self)
         self._sb_tunrpu = SiriusSpinbox(
             self, self._inj_prefix.substitute(propty='TopUpNrPulses-SP'))
-        self._sb_tunrpu.showStepExponent = False
         self._lb_tunrpu = SiriusLabel(
             self, self._inj_prefix.substitute(propty='TopUpNrPulses-RB'))
         self._lb_tunrpu.showUnits = True

--- a/pyqt-apps/siriushla/as_ap_launcher/main.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/main.py
@@ -221,7 +221,6 @@ class MainLauncher(SiriusMainWindow):
             '<h4>Target Curr.</h4>', self, alignment=Qt.AlignCenter)
         self._sb_currtgt = SiriusSpinbox(
             self, injctrl_dev.substitute(propty='TargetCurrent-SP'))
-        self._sb_currtgt.showStepExponent = False
         self._lb_currtgt = SiriusLabel(
             self, injctrl_dev.substitute(propty='TargetCurrent-RB'),
             keep_unit=True)

--- a/pyqt-apps/siriushla/as_ap_measure/emittance_meas.py
+++ b/pyqt-apps/siriushla/as_ap_measure/emittance_meas.py
@@ -338,7 +338,6 @@ class EmittanceMeasure(QWidget):
         lbl = SiriusLabel(
             gb, _PVName('LI-01:PS-QF3:Current-Mon').substitute(
                 prefix=self._prefix))
-        spnbox.showStepExponent = False
         gb.layout().addWidget(spnbox)
         gb.layout().addWidget(lbl)
         gb.layout().setAlignment(Qt.AlignTop)

--- a/pyqt-apps/siriushla/as_ap_measure/energy_meas.py
+++ b/pyqt-apps/siriushla/as_ap_measure/energy_meas.py
@@ -77,7 +77,6 @@ class EnergyMeasure(QWidget):
             'LI-01:PS-Spect:Current-SP').substitute(prefix=self.prefix))
         lbl = SiriusLabel(wid, _PVName(
             'LI-01:PS-Spect:Current-Mon').substitute(prefix=self.prefix))
-        spnbox.showStepExponent = False
         wid.layout().addWidget(spnbox)
         wid.layout().addWidget(lbl)
         vl.addWidget(QLabel('Spectrometer Current [A]', gb_ctrl))

--- a/pyqt-apps/siriushla/as_ap_opticscorr/main.py
+++ b/pyqt-apps/siriushla/as_ap_opticscorr/main.py
@@ -4,16 +4,15 @@ from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, \
     QPushButton, QVBoxLayout, QSpacerItem, QSizePolicy as QSzPly, \
     QHBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMPushButton, PyDMEnumComboBox, \
-    PyDMSpinbox, PyDMLineEdit
+from pydm.widgets import PyDMPushButton, PyDMEnumComboBox, PyDMLineEdit
 
 from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.opticscorr.csdev import Const as _Const
 
 from siriushla import util as _hlautil
-from siriushla.widgets import SiriusMainWindow, PyDMLogLabel, PyDMStateButton, \
-    SiriusLabel
+from siriushla.widgets import SiriusMainWindow, PyDMLogLabel, SiriusSpinbox, \
+    PyDMStateButton, SiriusLabel
 from siriushla.as_ps_control import PSDetailWindow as _PSDetailWindow
 from .details import CorrParamsDetailWindow as _CorrParamsDetailWindow
 from .custom_widgets import StatusLed as _StatusLed, \
@@ -143,10 +142,10 @@ class OpticsCorrWindow(SiriusMainWindow):
         self.lb_mon = QLabel(
             '<h4>Estimative</h4>', self, alignment=Qt.AlignCenter)
 
-        self.sb_paramx = PyDMSpinbox(self, self.ioc_prefix.substitute(
+        self.sb_paramx = SiriusSpinbox(self, self.ioc_prefix.substitute(
             propty=self.param_pv.format('X', 'SP')))
         self.sb_paramx.showStepExponent = False
-        self.sb_paramy = PyDMSpinbox(self, self.ioc_prefix.substitute(
+        self.sb_paramy = SiriusSpinbox(self, self.ioc_prefix.substitute(
             propty=self.param_pv.format('Y', 'SP')))
         self.sb_paramy.showStepExponent = False
 
@@ -194,12 +193,12 @@ class OpticsCorrWindow(SiriusMainWindow):
             self.pb_change_sp = QPushButton(self._icon_absval, '', self)
             self.pb_change_sp.clicked.connect(self._change_chrom_sp)
 
-            self.sb_paramx_delta = PyDMSpinbox(
+            self.sb_paramx_delta = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='DeltaChromX-SP'))
             self.sb_paramx_delta.showStepExponent = False
             self.sb_paramx_delta.setVisible(False)
 
-            self.sb_paramy_delta = PyDMSpinbox(
+            self.sb_paramy_delta = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='DeltaChromY-SP'))
             self.sb_paramy_delta.showStepExponent = False
             self.sb_paramy_delta.setVisible(False)
@@ -343,7 +342,7 @@ class OpticsCorrWindow(SiriusMainWindow):
                 lay.addWidget(lb_meas_chrom, 6, 0, 1, 3)
 
                 lb_meas_chrom_dfRF = QLabel('ΔFreq RF [Hz]', self)
-                self.sb_meas_chrom_dfRF = PyDMSpinbox(
+                self.sb_meas_chrom_dfRF = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromDeltaFreqRF-SP'))
                 self.sb_meas_chrom_dfRF.showStepExponent = False
@@ -355,7 +354,7 @@ class OpticsCorrWindow(SiriusMainWindow):
                 lay.addWidget(self.lb_meas_chrom_dfRF, 7, 2)
 
                 lb_meas_chrom_wait = QLabel('Wait Tune [s]', self)
-                self.sb_meas_chrom_wait = PyDMSpinbox(
+                self.sb_meas_chrom_wait = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromWaitTune-SP'))
                 self.sb_meas_chrom_wait.showStepExponent = False
@@ -367,7 +366,7 @@ class OpticsCorrWindow(SiriusMainWindow):
                 lay.addWidget(self.lb_meas_chrom_wait, 8, 2)
 
                 lb_meas_chrom_nrsteps = QLabel('Nr Steps', self)
-                self.sb_meas_chrom_nrsteps = PyDMSpinbox(
+                self.sb_meas_chrom_nrsteps = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromNrSteps-SP'))
                 self.sb_meas_chrom_nrsteps.showStepExponent = False
@@ -447,7 +446,7 @@ class OpticsCorrWindow(SiriusMainWindow):
                 propty='MeasConfigDelta'+self.intstrength+'Fam'+mag_type+'F')
             lb_meas_conf_dfamF = QLabel(
                 'Fam. Δ'+self.intstrength+' '+mag_type+'F '+unit, self)
-            self.sb_meas_conf_dfamF = PyDMSpinbox(
+            self.sb_meas_conf_dfamF = SiriusSpinbox(
                 self, pvn.substitute(propty_suffix='SP'))
             self.sb_meas_conf_dfamF.showStepExponent = False
             self.lb_meas_conf_dfamF = SiriusLabel(
@@ -460,7 +459,7 @@ class OpticsCorrWindow(SiriusMainWindow):
                 propty='MeasConfigDelta'+self.intstrength+'Fam'+mag_type+'D')
             lb_meas_conf_dfamD = QLabel(
                 'Fam. Δ'+self.intstrength+' '+mag_type+'D '+unit, self)
-            self.sb_meas_conf_dfamD = PyDMSpinbox(
+            self.sb_meas_conf_dfamD = SiriusSpinbox(
                 self, pvn.substitute(propty_suffix='SP'))
             self.sb_meas_conf_dfamD.showStepExponent = False
             self.lb_meas_conf_dfamD = SiriusLabel(
@@ -470,7 +469,7 @@ class OpticsCorrWindow(SiriusMainWindow):
             lay.addWidget(self.lb_meas_conf_dfamD, row+3, 2)
 
             lb_meas_conf_wait = QLabel('Wait [s]', self)
-            self.sb_meas_conf_wait = PyDMSpinbox(
+            self.sb_meas_conf_wait = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='MeasConfigWait-SP'))
             self.sb_meas_conf_wait.showStepExponent = False
             self.lb_meas_conf_wait = SiriusLabel(

--- a/pyqt-apps/siriushla/as_ap_opticscorr/main.py
+++ b/pyqt-apps/siriushla/as_ap_opticscorr/main.py
@@ -144,10 +144,8 @@ class OpticsCorrWindow(SiriusMainWindow):
 
         self.sb_paramx = SiriusSpinbox(self, self.ioc_prefix.substitute(
             propty=self.param_pv.format('X', 'SP')))
-        self.sb_paramx.showStepExponent = False
         self.sb_paramy = SiriusSpinbox(self, self.ioc_prefix.substitute(
             propty=self.param_pv.format('Y', 'SP')))
-        self.sb_paramy.showStepExponent = False
 
         self.lb_paramx = SiriusLabel(self, self.ioc_prefix.substitute(
             propty=self.param_pv.format('X', 'RB')))
@@ -195,12 +193,10 @@ class OpticsCorrWindow(SiriusMainWindow):
 
             self.sb_paramx_delta = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='DeltaChromX-SP'))
-            self.sb_paramx_delta.showStepExponent = False
             self.sb_paramx_delta.setVisible(False)
 
             self.sb_paramy_delta = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='DeltaChromY-SP'))
-            self.sb_paramy_delta.showStepExponent = False
             self.sb_paramy_delta.setVisible(False)
 
             self.lb_paramx_delta = SiriusLabel(
@@ -345,7 +341,6 @@ class OpticsCorrWindow(SiriusMainWindow):
                 self.sb_meas_chrom_dfRF = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromDeltaFreqRF-SP'))
-                self.sb_meas_chrom_dfRF.showStepExponent = False
                 self.lb_meas_chrom_dfRF = SiriusLabel(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromDeltaFreqRF-RB'))
@@ -357,7 +352,6 @@ class OpticsCorrWindow(SiriusMainWindow):
                 self.sb_meas_chrom_wait = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromWaitTune-SP'))
-                self.sb_meas_chrom_wait.showStepExponent = False
                 self.lb_meas_chrom_wait = SiriusLabel(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromWaitTune-RB'))
@@ -369,7 +363,6 @@ class OpticsCorrWindow(SiriusMainWindow):
                 self.sb_meas_chrom_nrsteps = SiriusSpinbox(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromNrSteps-SP'))
-                self.sb_meas_chrom_nrsteps.showStepExponent = False
                 self.lb_meas_chrom_nrsteps = SiriusLabel(
                     self, self.ioc_prefix.substitute(
                         propty='MeasChromNrSteps-RB'))
@@ -448,7 +441,6 @@ class OpticsCorrWindow(SiriusMainWindow):
                 'Fam. Δ'+self.intstrength+' '+mag_type+'F '+unit, self)
             self.sb_meas_conf_dfamF = SiriusSpinbox(
                 self, pvn.substitute(propty_suffix='SP'))
-            self.sb_meas_conf_dfamF.showStepExponent = False
             self.lb_meas_conf_dfamF = SiriusLabel(
                 self, pvn.substitute(propty_suffix='RB'))
             lay.addWidget(lb_meas_conf_dfamF, row+2, 0)
@@ -461,7 +453,6 @@ class OpticsCorrWindow(SiriusMainWindow):
                 'Fam. Δ'+self.intstrength+' '+mag_type+'D '+unit, self)
             self.sb_meas_conf_dfamD = SiriusSpinbox(
                 self, pvn.substitute(propty_suffix='SP'))
-            self.sb_meas_conf_dfamD.showStepExponent = False
             self.lb_meas_conf_dfamD = SiriusLabel(
                 self, pvn.substitute(propty_suffix='RB'))
             lay.addWidget(lb_meas_conf_dfamD, row+3, 0)
@@ -471,7 +462,6 @@ class OpticsCorrWindow(SiriusMainWindow):
             lb_meas_conf_wait = QLabel('Wait [s]', self)
             self.sb_meas_conf_wait = SiriusSpinbox(
                 self, self.ioc_prefix.substitute(propty='MeasConfigWait-SP'))
-            self.sb_meas_conf_wait.showStepExponent = False
             self.lb_meas_conf_wait = SiriusLabel(
                 self, self.ioc_prefix.substitute(propty='MeasConfigWait-RB'))
             lay.addWidget(lb_meas_conf_wait, row+4, 0)

--- a/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
+++ b/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import QGridLayout, QLabel, QGroupBox, QAbstractItemView, \
     QMessageBox, QApplication, QHBoxLayout
 from qtpy.QtCore import Qt
 import qtawesome as qta
-from pydm.widgets import PyDMLineEdit, PyDMPushButton, PyDMSpinbox
+from pydm.widgets import PyDMLineEdit, PyDMPushButton
 
 from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 from siriuspy.posang.csdev import Const
@@ -18,7 +18,7 @@ from siriuspy.namesys import SiriusPVName as _PVName
 from siriushla import util as _hlautil
 from siriushla.widgets import SiriusMainWindow, PyDMLogLabel, SiriusLedAlert, \
     PyDMSpinboxScrollbar, PyDMLedMultiChannel, SiriusConnectionSignal, \
-    SiriusLabel, SiriusWaveformTable
+    SiriusLabel, SiriusWaveformTable, SiriusSpinbox
 from siriushla.as_ps_control import PSDetailWindow as _PSDetailWindow
 from siriushla.as_pu_control import PUDetailWindow as _PUDetailWindow
 from siriushla.as_ap_configdb import LoadConfigDialog as _LoadConfigDialog
@@ -153,7 +153,7 @@ class PosAngCorr(SiriusMainWindow):
 
         # stlesheet
         self.setStyleSheet("""
-            PyDMSpinbox{
+            SiriusSpinbox{
                 min-width: 5em; max-width: 5em;
             }
             SiriusLabel, PyDMSpinboxScrollbar{
@@ -171,7 +171,7 @@ class PosAngCorr(SiriusMainWindow):
     def _setupDeltaControlLayout(self, axis=''):
         # pos
         label_pos = QLabel("<h4>Δ"+axis+"</h4>", self)
-        sb_deltapos = PyDMSpinbox(self, self.posang_prefix.substitute(
+        sb_deltapos = SiriusSpinbox(self, self.posang_prefix.substitute(
             propty='DeltaPos'+axis.upper()+'-SP'))
         sb_deltapos.step_exponent = -2
         sb_deltapos.update_step_size()
@@ -182,7 +182,7 @@ class PosAngCorr(SiriusMainWindow):
         self._my_input_widgets.append(sb_deltapos)
         # ang
         label_ang = QLabel("<h4>Δ"+axis+"'</h4>", self)
-        sb_deltaang = PyDMSpinbox(self, self.posang_prefix.substitute(
+        sb_deltaang = SiriusSpinbox(self, self.posang_prefix.substitute(
             propty='DeltaAng'+axis.upper()+'-SP'))
         sb_deltaang.step_exponent = -2
         sb_deltaang.update_step_size()

--- a/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
+++ b/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
@@ -175,7 +175,6 @@ class PosAngCorr(SiriusMainWindow):
             propty='DeltaPos'+axis.upper()+'-SP'))
         sb_deltapos.step_exponent = -2
         sb_deltapos.update_step_size()
-        sb_deltapos.showStepExponent = False
         lb_deltapos = SiriusLabel(self, self.posang_prefix.substitute(
             propty='DeltaPos'+axis.upper()+'-RB'), keep_unit=True)
         lb_deltapos.showUnits = True
@@ -186,7 +185,6 @@ class PosAngCorr(SiriusMainWindow):
             propty='DeltaAng'+axis.upper()+'-SP'))
         sb_deltaang.step_exponent = -2
         sb_deltaang.update_step_size()
-        sb_deltaang.showStepExponent = False
         lb_deltaang = SiriusLabel(self, self.posang_prefix.substitute(
             propty='DeltaAng'+axis.upper()+'-RB'), keep_unit=True)
         lb_deltaang.showUnits = True

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/base.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/base.py
@@ -62,7 +62,6 @@ class BaseWidget(BaseObject, QWidget):
             lay = QHBoxLayout(wid)
         lay.setContentsMargins(0, 0, 0, 0)
         pdm_spbx = SiriusSpinbox(wid, basename.substitute(propty_suffix='SP'))
-        pdm_spbx.showStepExponent = False
         pdm_lbl = SiriusLabel(wid, basename.substitute(propty_suffix='RB'))
         pdm_lbl.setAlignment(Qt.AlignCenter)
         lay.addWidget(pdm_spbx)

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -130,7 +130,6 @@ class SOFBControl(BaseWidget):
         lbl = QLabel('Num. Pts.', orb_wid)
         stp = SiriusSpinbox(
             orb_wid, self.devpref.substitute(propty='SmoothNrPts-SP'))
-        stp.showStepExponent = False
         rdb = SiriusLabel(
             orb_wid, self.devpref.substitute(propty='SmoothNrPts-RB'))
         rdb.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
@@ -291,7 +290,6 @@ class SOFBControl(BaseWidget):
 
         spb = SiriusSpinbox(
             wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-SP'))
-        spb.showStepExponent = False
         lbl = SiriusLabel(
             wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-RB'))
         lbl.showUnits = False
@@ -563,7 +561,6 @@ class PerformanceWidget(QWidget):
         slsh.setStyleSheet('min-width:0.7em; max-width:0.7em;')
 
         spb = SiriusSpinbox(self, lamb('LoopPrintEveryNumIters-SP'))
-        spb.showStepExponent = False
         ldrb = SiriusLabel(self, lamb('LoopPrintEveryNumIters-RB'))
         ldmon = SiriusLabel(self, lamb('LoopNumIters-Mon'))
         ld_rate = SiriusLabel(self, lamb('LoopEffectiveRate-Mon'))

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -269,6 +269,7 @@ class SOFBControl(BaseWidget):
         gdl.addWidget(QLabel('Setpoint', wid), 0, 1)
         gdl.addWidget(QLabel('Status', wid), 0, 2)
         gdl.addWidget(QLabel('Monitor', wid), 0, 3)
+        gdl.addWidget(QLabel('%', wid), 0, 4, alignment=Qt.AlignCenter)
         props = [
             'FOFBDownloadKicks', 'FOFBUpdateRefOrb',
             'FOFBNullSpaceProj', 'FOFBZeroDistortionAtBPMs']
@@ -287,6 +288,17 @@ class SOFBControl(BaseWidget):
             gdl.addWidget(spt, i+1, 1)
             gdl.addWidget(rdb, i+1, 2)
             gdl.addWidget(mon, i+1, 3)
+
+        spb = SiriusSpinbox(
+            wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-SP'))
+        spb.showStepExponent = False
+        lbl = SiriusLabel(
+            wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-RB'))
+        lbl.showUnits = False
+        gdl2 = QGridLayout()
+        gdl2.addWidget(spb, 0, 0)
+        gdl2.addWidget(lbl, 1, 0)
+        gdl.addLayout(gdl2, 1, 4)
         gdl.setRowStretch(5, 3)
         return wid
 

--- a/pyqt-apps/siriushla/as_di_bpms/base.py
+++ b/pyqt-apps/siriushla/as_di_bpms/base.py
@@ -53,7 +53,6 @@ class BaseWidget(QWidget):
                     chan1 = self.get_pvname(pv1, is_data=isdata)
                     wid = SiriusSpinbox(self, init_channel=chan1)
                     wid.setStyleSheet("min-width:5em;")
-                    wid.showStepExponent = False
                     wid.limitsFromChannel = False
                     pvn = self.data_prefix + pv1
                     wid.setMinimum(self.bpmdb[pvn].get('low', -1e10))

--- a/pyqt-apps/siriushla/as_di_bpms/fft.py
+++ b/pyqt-apps/siriushla/as_di_bpms/fft.py
@@ -35,7 +35,6 @@ class FFTConfig(BaseWidget):
         CLASS = PyDMEnumComboBox if enum else SiriusSpinbox
         wid = CLASS(self)
         self._make_connections(wid, pv)
-        if not enum:
         lab = QLabel(label)
         lab.setStyleSheet("""min-width:8em;""")
         self.fl.addRow(lab, wid)

--- a/pyqt-apps/siriushla/as_di_bpms/fft.py
+++ b/pyqt-apps/siriushla/as_di_bpms/fft.py
@@ -36,7 +36,6 @@ class FFTConfig(BaseWidget):
         wid = CLASS(self)
         self._make_connections(wid, pv)
         if not enum:
-            wid.showStepExponent = False
         lab = QLabel(label)
         lab.setStyleSheet("""min-width:8em;""")
         self.fl.addRow(lab, wid)

--- a/pyqt-apps/siriushla/as_di_bpms/triggers.py
+++ b/pyqt-apps/siriushla/as_di_bpms/triggers.py
@@ -89,7 +89,6 @@ class PhysicalTriggers(BaseWidget):
         chan = self.get_pvname(pvn)
         spbx = SiriusSpinbox(
             grpbx, init_channel=chan)
-        spbx.showStepExponent = False
         spbx.limitsFromChannel = False
         low = self.bpmdb[pvn].get('low', -1e10)
         high = self.bpmdb[pvn].get('high', 1e10)
@@ -104,7 +103,6 @@ class PhysicalTriggers(BaseWidget):
         chan = self.get_pvname(pvn)
         spbx = SiriusSpinbox(
             grpbx, init_channel=chan)
-        spbx.showStepExponent = False
         spbx.limitsFromChannel = False
         low = self.bpmdb[pvn].get('low', -1e10)
         high = self.bpmdb[pvn].get('high', 1e10)
@@ -184,7 +182,6 @@ class LogicalTriggers(BaseWidget):
         chan = self.get_pvname(pvn)
         spbx = SiriusSpinbox(
             grpbx, init_channel=chan)
-        spbx.showStepExponent = False
         spbx.limitsFromChannel = False
         low = self.bpmdb[pvn].get('low', -1e10)
         high = self.bpmdb[pvn].get('high', 1e10)
@@ -199,7 +196,6 @@ class LogicalTriggers(BaseWidget):
         chan = self.get_pvname(pvn)
         spbx = SiriusSpinbox(
             grpbx, init_channel=chan)
-        spbx.showStepExponent = False
         spbx.limitsFromChannel = False
         low = self.bpmdb[pvn].get('low', -1e10)
         high = self.bpmdb[pvn].get('high', 1e10)

--- a/pyqt-apps/siriushla/as_di_dccts/settings.py
+++ b/pyqt-apps/siriushla/as_di_dccts/settings.py
@@ -6,7 +6,7 @@ from qtpy.QtWidgets import QWidget, QLabel, QPushButton, QGroupBox, \
     QSizePolicy as QSzPly
 import qtawesome as qta
 
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, PyDMPushButton
+from pydm.widgets import PyDMEnumComboBox, PyDMPushButton
 
 from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.diagbeam.dcct.csdev import Const as _DCCTc, get_dcct_database
@@ -14,7 +14,7 @@ from siriuspy.epics import PV as _PV
 
 from siriushla.widgets.windows import create_window_from_widget
 from siriushla.widgets import PyDMStateButton, SiriusConnectionSignal, \
-    SiriusLedState, SiriusLedAlert, SiriusLabel
+    SiriusLedState, SiriusLedAlert, SiriusLabel, SiriusSpinbox
 from siriushla import util as _hlautil
 from siriushla.as_ti_control.hl_trigger import HLTriggerSimple
 
@@ -152,7 +152,7 @@ class DCCTSettings(QWidget):
         self.setLayout(lay)
         self.setStyleSheet("""
             QSpinBox, QComboBox, QPushButton,
-            PyDMSpinbox, PyDMEnumComboBox, SiriusLabel{
+            SiriusSpinbox, PyDMEnumComboBox, SiriusLabel{
                 min-width:6em; max-width:6em;}
             .QLabel{max-height:1.5em;}""")
 
@@ -165,7 +165,7 @@ class DCCTSettings(QWidget):
             visible = False
 
         l_smpcnt = QLabel('Sample Count: ', self)
-        spinbox_SampleCnt = PyDMSpinbox(
+        spinbox_SampleCnt = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-SP'))
         spinbox_SampleCnt.showStepExponent = False
         label_SampleCnt = SiriusLabel(
@@ -175,7 +175,7 @@ class DCCTSettings(QWidget):
         hlay_smpcnt.addWidget(label_SampleCnt)
 
         l_measperiod = QLabel('Period [s]: ', self)
-        spinbox_MeasPeriod = PyDMSpinbox(
+        spinbox_MeasPeriod = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-SP'))
         spinbox_MeasPeriod.showStepExponent = False
         label_MeasPeriod = SiriusLabel(
@@ -254,7 +254,7 @@ class DCCTSettingsDetails(QWidget):
         self.setLayout(lay)
 
         self.setStyleSheet("""
-            PyDMSpinbox, SiriusLabel{
+            SiriusSpinbox, SiriusLabel{
                 min-width:6em; max-width:6em;
                 qproperty-alignment: AlignCenter;}
             PyDMLedMultiChannel, PyDMStateButton, PyDMEnumComboBox{
@@ -335,7 +335,7 @@ class DCCTSettingsDetails(QWidget):
         hlay_lowlimenbl.addWidget(self.pydmlabel_LowLimEnbl)
 
         l_currthold = QLabel('Current Threshold [mA]: ', self)
-        self.pydmspinbox_CurrThold = PyDMSpinbox(
+        self.pydmspinbox_CurrThold = SiriusSpinbox(
             self, self.dcct_prefix.substitute(propty='CurrThold-SP'))
         self.pydmspinbox_CurrThold.showStepExponent = False
         self.pydmlabel_CurrThold = SiriusLabel(
@@ -392,7 +392,7 @@ class DCCTSettingsDetails(QWidget):
         gbox_modesettings = QGroupBox(mode+' Measurement Mode Settings', self)
 
         l_smpcnt = QLabel('Sample Count: ', self)
-        spinbox_SampleCnt = PyDMSpinbox(
+        spinbox_SampleCnt = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-SP'))
         spinbox_SampleCnt.showStepExponent = False
         label_SampleCnt = SiriusLabel(
@@ -402,7 +402,7 @@ class DCCTSettingsDetails(QWidget):
         hlay_smpcnt.addWidget(label_SampleCnt)
 
         l_measperiod = QLabel('Period [s]: ', self)
-        spinbox_MeasPeriod = PyDMSpinbox(
+        spinbox_MeasPeriod = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-SP'))
         spinbox_MeasPeriod.showStepExponent = False
         label_MeasPeriod = SiriusLabel(
@@ -436,7 +436,7 @@ class DCCTSettingsDetails(QWidget):
         hlay_offset.addWidget(label_RelEnbl)
 
         l_rellvl = QLabel('Relative Offset Level [V]: ', self)
-        spinbox_RelLvl = PyDMSpinbox(
+        spinbox_RelLvl = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'RelLvl-SP'))
         spinbox_RelLvl.showStepExponent = False
         label_RelLvl = SiriusLabel(
@@ -489,7 +489,7 @@ class DCCTSettingsDetails(QWidget):
             hlay_avgenbl.addWidget(label_AvgFilterEnbl)
 
             l_avgcnt = QLabel('Samples: ', self)
-            spinbox_AvgFilterCount = PyDMSpinbox(self, prefix.substitute(
+            spinbox_AvgFilterCount = SiriusSpinbox(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterCnt-SP'))
             spinbox_AvgFilterCount.showStepExponent = False
             label_AvgFilterCount = SiriusLabel(self, prefix.substitute(
@@ -508,7 +508,7 @@ class DCCTSettingsDetails(QWidget):
             hlay_avgtyp.addWidget(label_AvgFilterTyp)
 
             l_avgwin = QLabel('Noise window size [%]: ', self)
-            spinbox_AvgFilterWind = PyDMSpinbox(self, prefix.substitute(
+            spinbox_AvgFilterWind = SiriusSpinbox(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterWind-SP'))
             spinbox_AvgFilterWind.showStepExponent = False
             label_AvgFilterWind = SiriusLabel(self, prefix.substitute(
@@ -528,7 +528,7 @@ class DCCTSettingsDetails(QWidget):
         gbox_modesettings.setLayout(flay_modesettings)
         gbox_modesettings.setVisible(visible)
         gbox_modesettings.setStyleSheet("""
-            PyDMSpinbox, SiriusLabel{
+            SiriusLabel{
                 min-width:6em; max-width:6em;
                 qproperty-alignment: AlignCenter;}
             PyDMLedMultiChannel, PyDMStateButton, PyDMEnumComboBox{

--- a/pyqt-apps/siriushla/as_di_dccts/settings.py
+++ b/pyqt-apps/siriushla/as_di_dccts/settings.py
@@ -520,7 +520,7 @@ class DCCTSettingsDetails(QWidget):
         gbox_modesettings.setLayout(flay_modesettings)
         gbox_modesettings.setVisible(visible)
         gbox_modesettings.setStyleSheet("""
-            SiriusLabel{
+            SiriusSpinbox, SiriusLabel{
                 min-width:6em; max-width:6em;
                 qproperty-alignment: AlignCenter;}
             PyDMLedMultiChannel, PyDMStateButton, PyDMEnumComboBox{

--- a/pyqt-apps/siriushla/as_di_dccts/settings.py
+++ b/pyqt-apps/siriushla/as_di_dccts/settings.py
@@ -167,7 +167,6 @@ class DCCTSettings(QWidget):
         l_smpcnt = QLabel('Sample Count: ', self)
         spinbox_SampleCnt = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-SP'))
-        spinbox_SampleCnt.showStepExponent = False
         label_SampleCnt = SiriusLabel(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-RB'))
         hlay_smpcnt = QHBoxLayout()
@@ -177,7 +176,6 @@ class DCCTSettings(QWidget):
         l_measperiod = QLabel('Period [s]: ', self)
         spinbox_MeasPeriod = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-SP'))
-        spinbox_MeasPeriod.showStepExponent = False
         label_MeasPeriod = SiriusLabel(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-RB'))
         hlay_measperiod = QHBoxLayout()
@@ -337,7 +335,6 @@ class DCCTSettingsDetails(QWidget):
         l_currthold = QLabel('Current Threshold [mA]: ', self)
         self.pydmspinbox_CurrThold = SiriusSpinbox(
             self, self.dcct_prefix.substitute(propty='CurrThold-SP'))
-        self.pydmspinbox_CurrThold.showStepExponent = False
         self.pydmlabel_CurrThold = SiriusLabel(
             self, self.dcct_prefix.substitute(propty='CurrThold-RB'))
         hlay_currthold = QHBoxLayout()
@@ -394,7 +391,6 @@ class DCCTSettingsDetails(QWidget):
         l_smpcnt = QLabel('Sample Count: ', self)
         spinbox_SampleCnt = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-SP'))
-        spinbox_SampleCnt.showStepExponent = False
         label_SampleCnt = SiriusLabel(
             self, prefix.substitute(propty=prefix.propty_name+'SampleCnt-RB'))
         hlay_smpcnt = QHBoxLayout()
@@ -404,7 +400,6 @@ class DCCTSettingsDetails(QWidget):
         l_measperiod = QLabel('Period [s]: ', self)
         spinbox_MeasPeriod = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-SP'))
-        spinbox_MeasPeriod.showStepExponent = False
         label_MeasPeriod = SiriusLabel(
             self, prefix.substitute(propty=prefix.propty_name+'MeasPeriod-RB'))
         hlay_measperiod = QHBoxLayout()
@@ -438,7 +433,6 @@ class DCCTSettingsDetails(QWidget):
         l_rellvl = QLabel('Relative Offset Level [V]: ', self)
         spinbox_RelLvl = SiriusSpinbox(
             self, prefix.substitute(propty=prefix.propty_name+'RelLvl-SP'))
-        spinbox_RelLvl.showStepExponent = False
         label_RelLvl = SiriusLabel(
             self, prefix.substitute(propty=prefix.propty_name+'RelLvl-RB'))
         label_RelLvl.precisionFromPV = False
@@ -491,7 +485,6 @@ class DCCTSettingsDetails(QWidget):
             l_avgcnt = QLabel('Samples: ', self)
             spinbox_AvgFilterCount = SiriusSpinbox(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterCnt-SP'))
-            spinbox_AvgFilterCount.showStepExponent = False
             label_AvgFilterCount = SiriusLabel(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterCnt-RB'))
             hlay_avgcnt = QHBoxLayout()
@@ -510,7 +503,6 @@ class DCCTSettingsDetails(QWidget):
             l_avgwin = QLabel('Noise window size [%]: ', self)
             spinbox_AvgFilterWind = SiriusSpinbox(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterWind-SP'))
-            spinbox_AvgFilterWind.showStepExponent = False
             label_AvgFilterWind = SiriusLabel(self, prefix.substitute(
                 propty=prefix.propty_name+'AvgFilterWind-RB'))
             hlay_avgwin = QHBoxLayout()

--- a/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
+++ b/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
@@ -299,13 +299,11 @@ class _ICTSettings(SiriusDialog):
         l_DigiDelay = QLabel('Delay: ', self)
         self.pydmspinbox_DigiDelay = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-SP'))
-        self.pydmspinbox_DigiDelay.showStepExponent = False
         self.pydmlabel_DigiDelay = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-RB'))
         l_DigiDuration = QLabel('Duration: ', self)
         self.pydmspinbox_DigiDuration = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-SP'))
-        self.pydmspinbox_DigiDuration.showStepExponent = False
         self.pydmlabel_DigiDuration = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-RB'))
         lay_Digi = QGridLayout()
@@ -344,13 +342,11 @@ class _ICTSettings(SiriusDialog):
         l_IntegDelay = QLabel('Delay: ', self)
         self.pydmspinbox_IntegDelay = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-SP'))
-        self.pydmspinbox_IntegDelay.showStepExponent = False
         self.pydmlabel_IntegDelay = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-RB'))
         l_IntegDuration = QLabel('Delay: ', self)
         self.pydmspinbox_IntegDuration = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-SP'))
-        self.pydmspinbox_IntegDuration.showStepExponent = False
         self.pydmlabel_IntegDuration = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-RB'))
         lay_Integ = QGridLayout()
@@ -367,7 +363,6 @@ class _ICTSettings(SiriusDialog):
         l_thold = QLabel('Threshold [nC]: ', self)
         self.pydmspinbox_Threshold = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Threshold-SP'))
-        self.pydmspinbox_Threshold.showStepExponent = False
         self.pydmlabel_Threshold = SiriusLabel(
             self, self.ict_prefix.substitute(propty='Threshold-RB'))
         hlay_thold = QHBoxLayout()
@@ -449,7 +444,6 @@ class _ICTCalibration(QWidget):
         l_thold = QLabel('Charge Threshold [nC]: ', self)
         self.pydmspinbox_Threshold = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Threshold-SP'))
-        self.pydmspinbox_Threshold.showStepExponent = False
         self.pydmlabel_Threshold = SiriusLabel(
             self, self.ict_prefix.substitute(propty='Threshold-RB'))
         hlay_thold = QHBoxLayout()
@@ -469,7 +463,6 @@ class _ICTCalibration(QWidget):
         l_2ndreaddy = QLabel('2nd Read Delay [s]: ', self)
         self.pydmspinbox_2ndReadDly = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='2ndReadDly-SP'))
-        self.pydmspinbox_2ndReadDly.showStepExponent = False
         self.pydmlabel_2ndReadDly = SiriusLabel(
             self, self.ict_prefix.substitute(propty='2ndReadDly-RB'))
         hlay_2ndreaddy = QHBoxLayout()
@@ -479,7 +472,6 @@ class _ICTCalibration(QWidget):
         l_samplecnt = QLabel('Sample Count: ', self)
         self.pydmspinbox_SampleCnt = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='SampleCnt-SP'))
-        self.pydmspinbox_SampleCnt.showStepExponent = False
         self.pydmlabel_SampleCnt = SiriusLabel(
             self, self.ict_prefix.substitute(propty='SampleCnt-RB'))
         hlay_samplecnt = QHBoxLayout()
@@ -489,7 +481,6 @@ class _ICTCalibration(QWidget):
         l_aperture = QLabel('Aperture [us]: ', self)
         self.pydmspinbox_Aperture = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Aperture-SP'))
-        self.pydmspinbox_Aperture.showStepExponent = False
         self.pydmlabel_Aperture = SiriusLabel(
             self, self.ict_prefix.substitute(propty='Aperture-RB'))
         hlay_aperture = QHBoxLayout()
@@ -499,7 +490,6 @@ class _ICTCalibration(QWidget):
         l_samplerate = QLabel('Sample Rate [rdgs/s]: ', self)
         self.pydmspinbox_SampleRate = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='SampleRate-SP'))
-        self.pydmspinbox_SampleRate.showStepExponent = False
         self.pydmlabel_SampleRate = SiriusLabel(
             self, self.ict_prefix.substitute(propty='SampleRate-RB'))
         hlay_samplerate = QHBoxLayout()
@@ -519,7 +509,6 @@ class _ICTCalibration(QWidget):
         l_bcmrange = QLabel('BCM Range [V]: ', self)
         self.pydmspinbox_BCMRange = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='BCMRange-SP'))
-        self.pydmspinbox_BCMRange.showStepExponent = False
 
         l_range = QLabel('Range: ', self)
         self.pydmenumcombobox_Range = PyDMEnumComboBox(

--- a/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
+++ b/pyqt-apps/siriushla/as_di_icts/ICT_monitor.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import QFormLayout, QGridLayout, QHBoxLayout, \
     QSpacerItem, QGroupBox, QWidget
 import qtawesome as qta
 
-from pydm.widgets import PyDMEnumComboBox, PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMEnumComboBox, PyDMPushButton
 from pydm.widgets.waveformplot import WaveformCurveItem
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
 
@@ -22,7 +22,7 @@ from siriuspy.epics import PV
 
 from siriushla.widgets import SiriusMainWindow, SiriusDialog, \
     SiriusLedAlert, PyDMStateButton, PyDMLedMultiChannel, QSpinBoxPlus, \
-    SiriusWaveformPlot, SiriusLabel
+    SiriusWaveformPlot, SiriusLabel, SiriusSpinbox
 from siriushla.widgets.windows import create_window_from_widget
 from siriushla import util
 from siriushla.as_ti_control.hl_trigger import HLTriggerDetailed
@@ -205,7 +205,7 @@ class _ICTSettings(SiriusDialog):
         hlay_cal.addWidget(self.bt_cal)
 
         self.setStyleSheet("""
-            PyDMSpinbox{
+            SiriusSpinbox{
                 min-width:7.10em; max-width:7.10em;
                 min-height:1.29em; max-height:1.29em;
                 qproperty-alignment: AlignCenter;
@@ -297,13 +297,13 @@ class _ICTSettings(SiriusDialog):
             self.pb_DigiDetails, trg_w, parent=self,
             device=self.ict_trig_digi_prefix, prefix=self.prefix)
         l_DigiDelay = QLabel('Delay: ', self)
-        self.pydmspinbox_DigiDelay = PyDMSpinbox(
+        self.pydmspinbox_DigiDelay = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-SP'))
         self.pydmspinbox_DigiDelay.showStepExponent = False
         self.pydmlabel_DigiDelay = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-RB'))
         l_DigiDuration = QLabel('Duration: ', self)
-        self.pydmspinbox_DigiDuration = PyDMSpinbox(
+        self.pydmspinbox_DigiDuration = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-SP'))
         self.pydmspinbox_DigiDuration.showStepExponent = False
         self.pydmlabel_DigiDuration = SiriusLabel(
@@ -342,13 +342,13 @@ class _ICTSettings(SiriusDialog):
             self.pb_IntegDetails, trg_w, parent=self,
             device=self.ict_trig_integ_prefix, prefix=self.prefix)
         l_IntegDelay = QLabel('Delay: ', self)
-        self.pydmspinbox_IntegDelay = PyDMSpinbox(
+        self.pydmspinbox_IntegDelay = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-SP'))
         self.pydmspinbox_IntegDelay.showStepExponent = False
         self.pydmlabel_IntegDelay = SiriusLabel(
             self, self.ict_trig_digi_prefix.substitute(propty='Delay-RB'))
         l_IntegDuration = QLabel('Delay: ', self)
-        self.pydmspinbox_IntegDuration = PyDMSpinbox(
+        self.pydmspinbox_IntegDuration = SiriusSpinbox(
             self, self.ict_trig_digi_prefix.substitute(propty='Duration-SP'))
         self.pydmspinbox_IntegDuration.showStepExponent = False
         self.pydmlabel_IntegDuration = SiriusLabel(
@@ -365,7 +365,7 @@ class _ICTSettings(SiriusDialog):
         lay_Integ.addWidget(self.pydmlabel_IntegDuration, 2, 2)
 
         l_thold = QLabel('Threshold [nC]: ', self)
-        self.pydmspinbox_Threshold = PyDMSpinbox(
+        self.pydmspinbox_Threshold = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Threshold-SP'))
         self.pydmspinbox_Threshold.showStepExponent = False
         self.pydmlabel_Threshold = SiriusLabel(
@@ -423,7 +423,7 @@ class _ICTCalibration(QWidget):
         style = '#' + self.objectName() + """{
                 min-width:65em;
                 min-height:34em;}
-            PyDMSpinbox{
+            SiriusSpinbox{
                 min-width:7.10em; max-width:7.10em;
                 min-height:1.29em; max-height:1.29em;
                 qproperty-alignment: AlignCenter;\n}
@@ -447,7 +447,7 @@ class _ICTCalibration(QWidget):
 
     def _setupMeasSettingsLayout(self):
         l_thold = QLabel('Charge Threshold [nC]: ', self)
-        self.pydmspinbox_Threshold = PyDMSpinbox(
+        self.pydmspinbox_Threshold = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Threshold-SP'))
         self.pydmspinbox_Threshold.showStepExponent = False
         self.pydmlabel_Threshold = SiriusLabel(
@@ -467,7 +467,7 @@ class _ICTCalibration(QWidget):
         hlay_hfreject.addWidget(self.pydmlabel_HFReject)
 
         l_2ndreaddy = QLabel('2nd Read Delay [s]: ', self)
-        self.pydmspinbox_2ndReadDly = PyDMSpinbox(
+        self.pydmspinbox_2ndReadDly = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='2ndReadDly-SP'))
         self.pydmspinbox_2ndReadDly.showStepExponent = False
         self.pydmlabel_2ndReadDly = SiriusLabel(
@@ -477,7 +477,7 @@ class _ICTCalibration(QWidget):
         hlay_2ndreaddy.addWidget(self.pydmlabel_2ndReadDly)
 
         l_samplecnt = QLabel('Sample Count: ', self)
-        self.pydmspinbox_SampleCnt = PyDMSpinbox(
+        self.pydmspinbox_SampleCnt = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='SampleCnt-SP'))
         self.pydmspinbox_SampleCnt.showStepExponent = False
         self.pydmlabel_SampleCnt = SiriusLabel(
@@ -487,7 +487,7 @@ class _ICTCalibration(QWidget):
         hlay_samplecnt.addWidget(self.pydmlabel_SampleCnt)
 
         l_aperture = QLabel('Aperture [us]: ', self)
-        self.pydmspinbox_Aperture = PyDMSpinbox(
+        self.pydmspinbox_Aperture = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='Aperture-SP'))
         self.pydmspinbox_Aperture.showStepExponent = False
         self.pydmlabel_Aperture = SiriusLabel(
@@ -497,7 +497,7 @@ class _ICTCalibration(QWidget):
         hlay_aperture.addWidget(self.pydmlabel_Aperture)
 
         l_samplerate = QLabel('Sample Rate [rdgs/s]: ', self)
-        self.pydmspinbox_SampleRate = PyDMSpinbox(
+        self.pydmspinbox_SampleRate = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='SampleRate-SP'))
         self.pydmspinbox_SampleRate.showStepExponent = False
         self.pydmlabel_SampleRate = SiriusLabel(
@@ -517,7 +517,7 @@ class _ICTCalibration(QWidget):
         hlay_imped.addWidget(self.pydmlabel_Imped)
 
         l_bcmrange = QLabel('BCM Range [V]: ', self)
-        self.pydmspinbox_BCMRange = PyDMSpinbox(
+        self.pydmspinbox_BCMRange = SiriusSpinbox(
             self, self.ict_prefix.substitute(propty='BCMRange-SP'))
         self.pydmspinbox_BCMRange.showStepExponent = False
 

--- a/pyqt-apps/siriushla/as_di_tune/controls.py
+++ b/pyqt-apps/siriushla/as_di_tune/controls.py
@@ -5,13 +5,13 @@ from qtpy.QtWidgets import QWidget, QLabel, QPushButton, QGridLayout, \
     QTabWidget, QVBoxLayout, QApplication
 import qtawesome as qta
 
-from pydm.widgets import PyDMSpinbox, PyDMLineEdit, \
-    PyDMEnumComboBox, PyDMPushButton
+from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox, PyDMPushButton
 
 from siriuspy.namesys import SiriusPVName
 import siriushla.util as util
 from siriushla.widgets import PyDMLedMultiChannel, PyDMLed, PyDMStateButton, \
-    SiriusStringComboBox, SiriusLedState, SiriusConnectionSignal, SiriusLabel
+    SiriusStringComboBox, SiriusLedState, SiriusConnectionSignal, \
+    SiriusLabel, SiriusSpinbox
 from .details import TuneDetails, SITuneMarkerDetails
 from .util import marker_color
 
@@ -161,7 +161,7 @@ class TuneControls(QWidget):
 
         # Harmonic
         lbl_h = QLabel('Harmonic (n)', self)
-        self.sb_h = PyDMSpinbox(
+        self.sb_h = SiriusSpinbox(
             self, self.device.substitute(propty='RevN-SP'))
         self.sb_h.showStepExponent = False
         self.sb_h.precisionFromPV = True
@@ -179,7 +179,7 @@ class TuneControls(QWidget):
 
         # Frequency Offset
         lbl_foff = QLabel('Freq. Offset [kHz]', self)
-        self.sb_foff = PyDMSpinbox(
+        self.sb_foff = SiriusSpinbox(
             self, self.device.substitute(propty='FreqOff-SP'))
         self.sb_foff.showStepExponent = False
         self.sb_foff.precisionFromPV = True
@@ -405,7 +405,7 @@ class TuneControls(QWidget):
             #detail, #mark_dtl{
                 min-width:35px; max-width:35px; icon-size:20px;
             }
-            SiriusLabel, PyDMSpinbox, PyDMStateButton,
+            SiriusLabel, SiriusSpinbox, PyDMStateButton,
             PyDMLineEdit, PyDMEnumComboBox{
                 min-width:6em; max-width:6em;
             }""")

--- a/pyqt-apps/siriushla/as_di_tune/controls.py
+++ b/pyqt-apps/siriushla/as_di_tune/controls.py
@@ -163,7 +163,6 @@ class TuneControls(QWidget):
         lbl_h = QLabel('Harmonic (n)', self)
         self.sb_h = SiriusSpinbox(
             self, self.device.substitute(propty='RevN-SP'))
-        self.sb_h.showStepExponent = False
         self.sb_h.precisionFromPV = True
         self.lb_h = SiriusLabel(
             self, self.device.substitute(propty='RevN-RB'))
@@ -181,7 +180,6 @@ class TuneControls(QWidget):
         lbl_foff = QLabel('Freq. Offset [kHz]', self)
         self.sb_foff = SiriusSpinbox(
             self, self.device.substitute(propty='FreqOff-SP'))
-        self.sb_foff.showStepExponent = False
         self.sb_foff.precisionFromPV = True
         self.lb_foff = SiriusLabel(
             self, self.device.substitute(propty='FreqOff-RB'))

--- a/pyqt-apps/siriushla/as_di_tune/details.py
+++ b/pyqt-apps/siriushla/as_di_tune/details.py
@@ -4,13 +4,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QFormLayout, QHBoxLayout, QVBoxLayout, \
     QGridLayout, QGroupBox, QWidget, QSpacerItem, QSizePolicy as QSzPlcy
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, \
-    PyDMPushButton, PyDMLineEdit
+from pydm.widgets import PyDMEnumComboBox, PyDMPushButton, PyDMLineEdit
 
 from siriuspy.namesys import SiriusPVName
 from siriushla.widgets import PyDMLedMultiChannel, SiriusMainWindow, \
     PyDMStateButton, SiriusLedState, SiriusConnectionSignal, PyDMLed, \
-    SiriusStringComboBox, SiriusLabel
+    SiriusStringComboBox, SiriusLabel, SiriusSpinbox
 from siriushla.as_ti_control import HLTriggerSimple
 
 
@@ -95,7 +94,7 @@ class TuneDetails(SiriusMainWindow):
                 min-height:1.29em; max-height:1.29em;
                 qproperty-alignment: "AlignVCenter | AlignHCenter";
             }
-            SiriusLabel, PyDMSpinbox, PyDMEnumComboBox,
+            SiriusLabel, SiriusSpinbox, PyDMEnumComboBox,
             PyDMStateButton{
                 min-width:6em; max-width:6em;
             }""")
@@ -228,7 +227,7 @@ class TuneDetails(SiriusMainWindow):
 
         # Harmonic
         lbl_h = QLabel('Harmonic (n)', self)
-        self.sb_h = PyDMSpinbox(
+        self.sb_h = SiriusSpinbox(
             self, self.device.substitute(propty='RevN-SP'))
         self.sb_h.showStepExponent = False
         self.sb_h.precisionFromPV = True
@@ -246,7 +245,7 @@ class TuneDetails(SiriusMainWindow):
 
         # Frequency Offset
         lbl_foff = QLabel('Frequency Offset [kHz]', self)
-        self.sb_foff = PyDMSpinbox(
+        self.sb_foff = SiriusSpinbox(
             self, self.device.substitute(propty='FreqOff-SP'))
         self.sb_foff.showStepExponent = False
         self.sb_foff.precisionFromPV = True
@@ -280,7 +279,7 @@ class TuneDetails(SiriusMainWindow):
 
         # Amplifier Gain
         lbl_drivegain = QLabel('Amplifier Gain [dB]', self)
-        self.sb_drivegain = PyDMSpinbox(
+        self.sb_drivegain = SiriusSpinbox(
             self, self.device.substitute(propty='AmpGain-SP'))
         self.sb_drivegain.showStepExponent = False
         self.sb_drivegain.precisionFromPV = True
@@ -304,7 +303,7 @@ class TuneDetails(SiriusMainWindow):
 
             # Noise Amplitude
             lbl_noiseamp = QLabel('Noise Amplitude [V]', self)
-            self.sb_noiseamp = PyDMSpinbox(
+            self.sb_noiseamp = SiriusSpinbox(
                 self, self.device.substitute(propty='NoiseAmpl-SP'))
             self.sb_noiseamp.showStepExponent = False
             self.sb_noiseamp.precisionFromPV = True
@@ -653,7 +652,7 @@ class SITuneMarkerDetails(SiriusMainWindow):
                 min-height:1.29em; max-height:1.29em;
                 qproperty-alignment: "AlignVCenter | AlignHCenter";
             }
-            SiriusLabel, PyDMSpinbox, PyDMEnumComboBox,
+            SiriusLabel, SiriusSpinbox, PyDMEnumComboBox,
             PyDMStateButton{
                 min-width:6em; max-width:6em;
             }""")

--- a/pyqt-apps/siriushla/as_di_tune/details.py
+++ b/pyqt-apps/siriushla/as_di_tune/details.py
@@ -229,7 +229,6 @@ class TuneDetails(SiriusMainWindow):
         lbl_h = QLabel('Harmonic (n)', self)
         self.sb_h = SiriusSpinbox(
             self, self.device.substitute(propty='RevN-SP'))
-        self.sb_h.showStepExponent = False
         self.sb_h.precisionFromPV = True
         self.lb_h = SiriusLabel(
             self, self.device.substitute(propty='RevN-RB'))
@@ -247,7 +246,6 @@ class TuneDetails(SiriusMainWindow):
         lbl_foff = QLabel('Frequency Offset [kHz]', self)
         self.sb_foff = SiriusSpinbox(
             self, self.device.substitute(propty='FreqOff-SP'))
-        self.sb_foff.showStepExponent = False
         self.sb_foff.precisionFromPV = True
         self.lb_foff = SiriusLabel(
             self, self.device.substitute(propty='FreqOff-RB'))
@@ -281,7 +279,6 @@ class TuneDetails(SiriusMainWindow):
         lbl_drivegain = QLabel('Amplifier Gain [dB]', self)
         self.sb_drivegain = SiriusSpinbox(
             self, self.device.substitute(propty='AmpGain-SP'))
-        self.sb_drivegain.showStepExponent = False
         self.sb_drivegain.precisionFromPV = True
         self.lb_drivegain = SiriusLabel(
             self, self.device.substitute(propty='AmpGain-RB'))
@@ -305,7 +302,6 @@ class TuneDetails(SiriusMainWindow):
             lbl_noiseamp = QLabel('Noise Amplitude [V]', self)
             self.sb_noiseamp = SiriusSpinbox(
                 self, self.device.substitute(propty='NoiseAmpl-SP'))
-            self.sb_noiseamp.showStepExponent = False
             self.sb_noiseamp.precisionFromPV = True
             self.lb_noiseamp = SiriusLabel(
                 self, self.device.substitute(propty='NoiseAmpl-RB'))

--- a/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
+++ b/pyqt-apps/siriushla/as_ps_control/SummaryWidgets.py
@@ -656,7 +656,6 @@ class SummaryWidget(QWidget):
             self.sofbmode_wid.layout().addWidget(self.sofbmode_led)
         elif name == 'accgain' and self._is_fofb:
             self.accgain_sp = SiriusSpinbox(self, self._accgain_sp)
-            self.accgain_sp.showStepExponent = False
             self.accgain_sp.precisionFromPV = False
             self.accgain_sp.precision = 6
             self.accgain_rb = SiriusLabel(self, self._accgain_rb)

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -924,19 +924,16 @@ class PSDetailWidget(QWidget):
 
         self.scope_src_label = QLabel('Source', self)
         self.scope_src_sp_sb = SiriusHexaSpinbox(self, src_sp)
-        self.scope_src_sp_sb.showStepExponent = False
         self.scope_src_rb_lb = SiriusLabel(self, src_rb)
         self.scope_src_rb_lb.displayFormat = SiriusLabel.DisplayFormat.Hex
 
         self.scope_freq_label = QLabel('Frequency [Hz]', self)
         self.scope_freq_sp_sb = SiriusSpinbox(self, freq_sp)
-        self.scope_freq_sp_sb.showStepExponent = False
         self.scope_freq_rb_label = SiriusLabel(self, freq_rb, keep_unit=True)
         self.scope_freq_rb_label.showUnits = True
 
         self.scope_dur_label = QLabel('Duration [s]', self)
         self.scope_dur_sp_sb = SiriusSpinbox(self, dur_sp)
-        self.scope_dur_sp_sb.showStepExponent = False
         self.scope_dur_rb_label = SiriusLabel(self, dur_rb)
         self.scope_dur_rb_label.showUnits = True
 
@@ -1695,7 +1692,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.ctlkp_sp.limitsFromChannel = False
         self.ctlkp_sp.setMinimum(0.0)
         self.ctlkp_sp.setMaximum(2**31 - 1)
-        self.ctlkp_sp.showStepExponent = False
         self.ctlkp_rb = SiriusLabel(
             self, self._prefixed_psname + ':CurrLoopKp-RB')
 
@@ -1706,7 +1702,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.ctlti_sp.limitsFromChannel = False
         self.ctlti_sp.setMinimum(0.0)
         self.ctlti_sp.setMaximum(2**31 - 1)
-        self.ctlti_sp.showStepExponent = False
         self.ctlti_rb = SiriusLabel(
             self, self._prefixed_psname + ':CurrLoopTi-RB')
 
@@ -1719,7 +1714,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.cgain_sp.limitsFromChannel = False
         self.cgain_sp.setMinimum(-1)
         self.cgain_sp.setMaximum(+1)
-        self.cgain_sp.showStepExponent = False
         self.cgain_rb = SiriusLabel(
             self, self._prefixed_psname + ':CurrGain-RB')
         self.cgain_rb.precisionFromPV = False
@@ -1734,7 +1728,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.coffs_sp.limitsFromChannel = False
         self.coffs_sp.setMinimum(-100)
         self.coffs_sp.setMaximum(+100)
-        self.coffs_sp.showStepExponent = False
         self.coffs_rb = SiriusLabel(
             self, self._prefixed_psname + ':CurrOffset-RB')
         self.coffs_rb.precisionFromPV = False
@@ -1749,7 +1742,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.vgain_sp.limitsFromChannel = False
         self.vgain_sp.setMinimum(-1)
         self.vgain_sp.setMaximum(+1)
-        self.vgain_sp.showStepExponent = False
         self.vgain_rb = SiriusLabel(
             self, self._prefixed_psname + ':VoltGain-RB')
         self.vgain_rb.precisionFromPV = False
@@ -1764,7 +1756,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
         self.voffs_sp.limitsFromChannel = False
         self.voffs_sp.setMinimum(-100)
         self.voffs_sp.setMaximum(+100)
-        self.voffs_sp.showStepExponent = False
         self.voffs_rb = SiriusLabel(
             self, self._prefixed_psname + ':VoltOffset-RB')
         self.voffs_rb.precisionFromPV = False
@@ -1800,7 +1791,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
             'Limit A', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.testlima_sp = SiriusSpinbox(
             self, self._prefixed_psname + ':TestLimA-SP')
-        self.testlima_sp.showStepExponent = False
         self.testlima_rb = SiriusLabel(
             self, self._prefixed_psname + ':TestLimA-RB')
 
@@ -1808,7 +1798,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
             'Limit B', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.testlimb_sp = SiriusSpinbox(
             self, self._prefixed_psname + ':TestLimB-SP')
-        self.testlimb_sp.showStepExponent = False
         self.testlimb_rb = SiriusLabel(
             self, self._prefixed_psname + ':TestLimB-RB')
 
@@ -1816,7 +1805,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
             'Wave Period', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.testwaveper_sp = SiriusSpinbox(
             self, self._prefixed_psname + ':TestWavePeriod-SP')
-        self.testwaveper_sp.showStepExponent = False
         self.testwaveper_rb = SiriusLabel(
             self, self._prefixed_psname + ':TestWavePeriod-RB')
 
@@ -1922,7 +1910,6 @@ class FastCorrPSDetailWidget(PSDetailWidget):
             'Acc Gain', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.fofbaccgain_sp = SiriusSpinbox(
             self, self._prefixed_psname + ':FOFBAccGain-SP')
-        self.fofbaccgain_sp.showStepExponent = False
         self.fofbaccgain_sp.precisionFromPV = False
         self.fofbaccgain_sp.precision = 8
         self.fofbaccgain_rb = SiriusLabel(

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -344,12 +344,10 @@ class RFMainControl(SiriusMainWindow):
             self._handle_ampl_unit_visibility)
         self.sb_amp1 = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-SP')
-        self.sb_amp1.showStepExponent = False
         self.lb_amp1 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-RB')
         self.sb_amp2 = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-SP')
-        self.sb_amp2.showStepExponent = False
         self.sb_amp2.setVisible(False)
         self.lb_amp2 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
@@ -360,7 +358,6 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+self.chs['SL']['AInc'])
         self.sb_phs = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['PSet']+':S')
-        self.sb_phs.showStepExponent = False
         self.lb_phs = SiriusLabel(
             self, self.prefix+self.chs['SL']['PSet'])
         self.cb_phsincrate = PyDMEnumComboBox(
@@ -472,7 +469,6 @@ class RFMainControl(SiriusMainWindow):
         lb_dtune = QLabel('DTune: ', self, alignment=Qt.AlignRight)
         self.sb_dtune = SiriusSpinbox(
             self, self.prefix+self.chs['Tun']['DTune'].replace('RB', 'SP'))
-        self.sb_dtune.showStepExponent = False
         self.lb_dtune = SiriusLabel(
             self, self.prefix+self.chs['Tun']['DTune'])
         self.lb_dtune.showUnits = True
@@ -590,15 +586,12 @@ class RFMainControl(SiriusMainWindow):
         lb_ffg2 = QLabel(f'Gain Cell {lb2:s}: ', self, alignment=Qt.AlignRight)
         self.sb_ffg1 = SiriusSpinbox(self, self.prefix+pvs['Gain1']+':S')
         self.sb_ffg2 = SiriusSpinbox(self, self.prefix+pvs['Gain2']+':S')
-        self.sb_ffg1.showStepExponent = False
-        self.sb_ffg2.showStepExponent = False
         self.lb_ffg1 = SiriusLabel(self, self.prefix+pvs['Gain1'])
         self.lb_ffg2 = SiriusLabel(self, self.prefix+pvs['Gain2'])
         self.lb_ffg1.showUnits = True
         self.lb_ffg2.showUnits = True
         lb_ffdb = QLabel('DeadBand: ', self, alignment=Qt.AlignRight)
         self.sb_ffdb = SiriusSpinbox(self, self.prefix+pvs['Deadband']+':S')
-        self.sb_ffdb.showStepExponent = False
         self.lb_ffdb = SiriusLabel(self, self.prefix+pvs['Deadband'])
         self.lb_ffdb.showUnits = True
         lb_ffcell1 = QLabel('Cell 2: ', self, alignment=Qt.AlignRight)
@@ -684,39 +677,33 @@ class RFMainControl(SiriusMainWindow):
 
         self.cb_rmpincts = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpIncTs-SP')
-        self.cb_rmpincts.showStepExponent = False
         self.lb_rmpincts = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpIncTs-RB')
         self.lb_rmpincts.showUnits = True
 
         self.sb_rmpts1 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs1-SP')
-        self.sb_rmpts1.showStepExponent = False
         self.lb_rmpts1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs1-RB')
         self.lb_rmpts1.showUnits = True
         self.sb_rmpts2 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs2-SP')
-        self.sb_rmpts2.showStepExponent = False
         self.lb_rmpts2 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs2-RB')
         self.lb_rmpts2.showUnits = True
         self.sb_rmpts3 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs3-SP')
-        self.sb_rmpts3.showStepExponent = False
         self.lb_rmpts3 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs3-RB')
         self.lb_rmpts3.showUnits = True
         self.sb_rmpts4 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs4-SP')
-        self.sb_rmpts4.showStepExponent = False
         self.lb_rmpts4 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs4-RB')
         self.lb_rmpts4.showUnits = True
 
         self.sb_rmpphstop = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsTop-SP')
-        self.sb_rmpphstop.showStepExponent = False
         self.lb_rmpphstop = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsTop-RB')
         self.lb_rmpphstop.showUnits = True
@@ -745,7 +732,6 @@ class RFMainControl(SiriusMainWindow):
 
         self.sb_rmpphsbot = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsBot-SP')
-        self.sb_rmpphsbot.showStepExponent = False
         self.lb_rmpphsbot = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsBot-RB')
         self.lb_rmpphsbot.showUnits = True

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -9,11 +9,12 @@ from qtpy.QtGui import QColor
 import qtawesome as qta
 from pyqtgraph import InfiniteLine, mkPen
 
-from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox, PyDMSpinbox
+from pydm.widgets import PyDMLineEdit, PyDMEnumComboBox
 
 from ..widgets import SiriusMainWindow, PyDMStateButton, PyDMLed, \
     SiriusLedAlert, SiriusLedState, PyDMLedMultiChannel, SiriusTimePlot, \
-    SiriusConnectionSignal, SiriusPushButton, SiriusLabel, SiriusWaveformPlot
+    SiriusConnectionSignal, SiriusPushButton, SiriusLabel, \
+    SiriusWaveformPlot, SiriusSpinbox
 from ..util import connect_window, get_appropriate_color
 from .details import TransmLineStatusDetails, CavityStatusDetails, \
     LLRFInterlockDetails, TempMonitor
@@ -119,7 +120,7 @@ class RFMainControl(SiriusMainWindow):
             QSpinBox, QPushButton, PyDMEnumComboBox{
                 min-width:5em; max-width:5em;
             }
-            PyDMLineEdit, PyDMSpinbox{
+            PyDMLineEdit, SiriusSpinbox{
                 min-width:7em; max-width:7em;
             }
             PyDMStateButton{
@@ -341,12 +342,12 @@ class RFMainControl(SiriusMainWindow):
             'QComboBox{max-width: 3.8em; font-weight: bold;}')
         self.cb_amp.currentTextChanged.connect(
             self._handle_ampl_unit_visibility)
-        self.sb_amp1 = PyDMSpinbox(
+        self.sb_amp1 = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-SP')
         self.sb_amp1.showStepExponent = False
         self.lb_amp1 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-RB')
-        self.sb_amp2 = PyDMSpinbox(
+        self.sb_amp2 = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-SP')
         self.sb_amp2.showStepExponent = False
         self.sb_amp2.setVisible(False)
@@ -357,7 +358,7 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+self.chs['SL']['AInc']+':S')
         self.lb_ampincrate = SiriusLabel(
             self, self.prefix+self.chs['SL']['AInc'])
-        self.sb_phs = PyDMSpinbox(
+        self.sb_phs = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['PSet']+':S')
         self.sb_phs.showStepExponent = False
         self.lb_phs = SiriusLabel(
@@ -469,7 +470,7 @@ class RFMainControl(SiriusMainWindow):
         self.lb_autotun = SiriusLedState(
             self, self.prefix+self.chs['Tun']['Auto'])
         lb_dtune = QLabel('DTune: ', self, alignment=Qt.AlignRight)
-        self.sb_dtune = PyDMSpinbox(
+        self.sb_dtune = SiriusSpinbox(
             self, self.prefix+self.chs['Tun']['DTune'].replace('RB', 'SP'))
         self.sb_dtune.showStepExponent = False
         self.lb_dtune = SiriusLabel(
@@ -587,8 +588,8 @@ class RFMainControl(SiriusMainWindow):
         self.lb_ffpos = SiriusLedState(self, self.prefix+pvs['Pos'])
         lb_ffg1 = QLabel('Gain Cell 2: ', self, alignment=Qt.AlignRight)
         lb_ffg2 = QLabel(f'Gain Cell {lb2:s}: ', self, alignment=Qt.AlignRight)
-        self.sb_ffg1 = PyDMSpinbox(self, self.prefix+pvs['Gain1']+':S')
-        self.sb_ffg2 = PyDMSpinbox(self, self.prefix+pvs['Gain2']+':S')
+        self.sb_ffg1 = SiriusSpinbox(self, self.prefix+pvs['Gain1']+':S')
+        self.sb_ffg2 = SiriusSpinbox(self, self.prefix+pvs['Gain2']+':S')
         self.sb_ffg1.showStepExponent = False
         self.sb_ffg2.showStepExponent = False
         self.lb_ffg1 = SiriusLabel(self, self.prefix+pvs['Gain1'])
@@ -596,7 +597,7 @@ class RFMainControl(SiriusMainWindow):
         self.lb_ffg1.showUnits = True
         self.lb_ffg2.showUnits = True
         lb_ffdb = QLabel('DeadBand: ', self, alignment=Qt.AlignRight)
-        self.sb_ffdb = PyDMSpinbox(self, self.prefix+pvs['Deadband']+':S')
+        self.sb_ffdb = SiriusSpinbox(self, self.prefix+pvs['Deadband']+':S')
         self.sb_ffdb.showStepExponent = False
         self.lb_ffdb = SiriusLabel(self, self.prefix+pvs['Deadband'])
         self.lb_ffdb.showUnits = True
@@ -681,39 +682,39 @@ class RFMainControl(SiriusMainWindow):
         self.led_rmptrig.onColor = PyDMLed.LightGreen
         self.led_rmptrig.offColor = PyDMLed.Red
 
-        self.cb_rmpincts = PyDMSpinbox(
+        self.cb_rmpincts = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpIncTs-SP')
         self.cb_rmpincts.showStepExponent = False
         self.lb_rmpincts = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpIncTs-RB')
         self.lb_rmpincts.showUnits = True
 
-        self.sb_rmpts1 = PyDMSpinbox(
+        self.sb_rmpts1 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs1-SP')
         self.sb_rmpts1.showStepExponent = False
         self.lb_rmpts1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs1-RB')
         self.lb_rmpts1.showUnits = True
-        self.sb_rmpts2 = PyDMSpinbox(
+        self.sb_rmpts2 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs2-SP')
         self.sb_rmpts2.showStepExponent = False
         self.lb_rmpts2 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs2-RB')
         self.lb_rmpts2.showUnits = True
-        self.sb_rmpts3 = PyDMSpinbox(
+        self.sb_rmpts3 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs3-SP')
         self.sb_rmpts3.showStepExponent = False
         self.lb_rmpts3 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs3-RB')
         self.lb_rmpts3.showUnits = True
-        self.sb_rmpts4 = PyDMSpinbox(
+        self.sb_rmpts4 = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs4-SP')
         self.sb_rmpts4.showStepExponent = False
         self.lb_rmpts4 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:RmpTs4-RB')
         self.lb_rmpts4.showUnits = True
 
-        self.sb_rmpphstop = PyDMSpinbox(
+        self.sb_rmpphstop = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsTop-SP')
         self.sb_rmpphstop.showStepExponent = False
         self.lb_rmpphstop = SiriusLabel(
@@ -742,7 +743,7 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop2.setVisible(False)
         self.lb_rmpvolttop2.showUnits = True
 
-        self.sb_rmpphsbot = PyDMSpinbox(
+        self.sb_rmpphsbot = SiriusSpinbox(
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsBot-SP')
         self.sb_rmpphsbot.showStepExponent = False
         self.lb_rmpphsbot = SiriusLabel(

--- a/pyqt-apps/siriushla/as_ti_control/base.py
+++ b/pyqt-apps/siriushla/as_ti_control/base.py
@@ -40,7 +40,6 @@ class BaseWidget(QWidget):
             chan1 = self.get_pvname(propty)
             if not_enum:
                 wid = SiriusSpinbox(self, init_channel=chan1)
-                wid.showStepExponent = False
                 wid.setAlignment(Qt.AlignCenter)
             else:
                 wid = SiriusEnumComboBox(self, init_channel=chan1)

--- a/pyqt-apps/siriushla/as_ti_control/hl_trigger.py
+++ b/pyqt-apps/siriushla/as_ti_control/hl_trigger.py
@@ -188,7 +188,6 @@ class HLTriggerDetailed(BaseWidget):
 
         init_channel = self.get_pvname('NrPulses-SP')
         sp = SiriusSpinbox(self, init_channel=init_channel)
-        sp.showStepExponent = False
         init_channel = self.get_pvname('NrPulses-RB')
         rb = SiriusLabel(self, init_channel=init_channel)
         gb = self._create_small_group('Nr Pulses', self.ll_list_wid, (sp, rb))
@@ -196,7 +195,6 @@ class HLTriggerDetailed(BaseWidget):
 
         init_channel = self.get_pvname('Duration-SP')
         sp = SiriusSpinbox(self, init_channel=init_channel)
-        sp.showStepExponent = False
         init_channel = self.get_pvname('Duration-RB')
         rb = SiriusLabel(self, init_channel=init_channel)
         gb = self._create_small_group(
@@ -205,14 +203,12 @@ class HLTriggerDetailed(BaseWidget):
 
         init_channel = self.get_pvname('Delay-SP')
         sp = SiriusSpinbox(self, init_channel=init_channel)
-        sp.showStepExponent = False
         init_channel = self.get_pvname('Delay-RB')
         rb = SiriusLabel(self, init_channel=init_channel)
         gbdel = self._create_small_group('[us]', self.ll_list_wid, (sp, rb))
 
         init_channel = self.get_pvname('DelayRaw-SP')
         sp = SiriusSpinbox(self, init_channel=init_channel)
-        sp.showStepExponent = False
         init_channel = self.get_pvname('DelayRaw-RB')
         rb = SiriusLabel(self, init_channel=init_channel)
         gbdelr = self._create_small_group('Raw', self.ll_list_wid, (sp, rb))
@@ -321,7 +317,6 @@ class _SpinBox(SiriusSpinbox):
     def __init__(self, parent=None, init_channel=None, index=0):
         self._index = index
         super().__init__(parent=parent, init_channel=init_channel)
-        self.showStepExponent = False
 
     def value_changed(self, value):
         self.valueBeingSet = True
@@ -502,13 +497,11 @@ class HLTriggerList(BaseList):
         elif prop == 'pulses':
             init_channel = device.substitute(propty='NrPulses-SP')
             sp = SiriusSpinbox(self, init_channel=init_channel)
-            sp.showStepExponent = False
             init_channel = device.substitute(propty='NrPulses-RB')
             rb = SiriusLabel(self, init_channel=init_channel)
         elif prop == 'duration':
             init_channel = device.substitute(propty='Duration-SP')
             sp = SiriusSpinbox(self, init_channel=init_channel)
-            sp.showStepExponent = False
             init_channel = device.substitute(propty='Duration-RB')
             rb = SiriusLabel(self, init_channel=init_channel)
         elif prop == 'polarity':
@@ -524,13 +517,11 @@ class HLTriggerList(BaseList):
         elif prop == 'delay':
             init_channel = device.substitute(propty='Delay-SP')
             sp = SiriusSpinbox(self, init_channel=init_channel)
-            sp.showStepExponent = False
             init_channel = device.substitute(propty='Delay-RB')
             rb = SiriusLabel(self, init_channel=init_channel)
         elif prop == 'delayraw':
             init_channel = device.substitute(propty='DelayRaw-SP')
             sp = SiriusSpinbox(self, init_channel=init_channel)
-            sp.showStepExponent = False
             init_channel = device.substitute(propty='DelayRaw-RB')
             rb = SiriusLabel(self, init_channel=init_channel)
         elif prop == 'total_delay':

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -181,7 +181,6 @@ class EVG(BaseWidget):
 
         pvname = self.get_pvname(propty='InjRate-SP')
         sp = SiriusSpinbox(self, init_channel=pvname)
-        sp.showStepExponent = False
         pvname = self.get_pvname(propty='InjRate-RB')
         rb = SiriusLabel(self, init_channel=pvname)
         pg = self._create_prop_widget('Pulse Rate [Hz]', configs_wid, (sp, rb))
@@ -224,7 +223,6 @@ class EVG(BaseWidget):
 
         pvname = self.get_pvname(propty='RFDiv-SP')
         sp = SiriusSpinbox(self, init_channel=pvname)
-        sp.showStepExponent = False
         pvname = self.get_pvname(propty='RFDiv-RB')
         rb = SiriusLabel(self, init_channel=pvname)
         pg = self._create_prop_widget('RF Divisor', configs_wid, (sp, rb))
@@ -855,7 +853,6 @@ class BucketList(BaseWidget):
 
         pvname = self.get_pvname("RepeatBucketList-SP")
         sp = SiriusSpinbox(wid, init_channel=pvname)
-        sp.showStepExponent = False
         pvname = self.get_pvname("RepeatBucketList-RB")
         rb = SiriusLabel(wid, init_channel=pvname)
         rb.setStyleSheet("min-width:4em; max-height:1.15em;")
@@ -887,7 +884,6 @@ class BucketList(BaseWidget):
             wid, inj_prefix.substitute(propty='BucketListStart-SP'))
         self._sb_start.setAlignment(Qt.AlignCenter)
         self._sb_start.setStyleSheet('max-width:5em;')
-        self._sb_start.showStepExponent = False
         self._lb_start = SiriusLabel(
             wid, inj_prefix.substitute(propty='BucketListStart-RB'))
 
@@ -895,7 +891,6 @@ class BucketList(BaseWidget):
             wid, inj_prefix.substitute(propty='BucketListStop-SP'))
         self._sb_stop.setAlignment(Qt.AlignCenter)
         self._sb_stop.setStyleSheet('max-width:5em;')
-        self._sb_stop.showStepExponent = False
         self._lb_stop = SiriusLabel(
             wid, inj_prefix.substitute(propty='BucketListStop-RB'))
 
@@ -903,7 +898,6 @@ class BucketList(BaseWidget):
             wid, inj_prefix.substitute(propty='BucketListStep-SP'))
         self._sb_step.setAlignment(Qt.AlignCenter)
         self._sb_step.setStyleSheet('max-width:5em;')
-        self._sb_step.showStepExponent = False
         self._lb_step = SiriusLabel(
             wid, inj_prefix.substitute(propty='BucketListStep-RB'))
 
@@ -984,13 +978,11 @@ class EventList(BaseList):
         elif prop == 'delay':
             pvname = device.substitute(propty=device.propty+'Delay-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = device.substitute(propty=device.propty+'Delay-RB')
             rb = SiriusLabel(self, init_channel=pvname)
         elif prop == 'delayraw':
             pvname = device.substitute(propty=device.propty+'DelayRaw-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = device.substitute(propty=device.propty+'DelayRaw-RB')
             rb = SiriusLabel(self, init_channel=pvname)
         elif prop == 'description':
@@ -1037,7 +1029,6 @@ class ClockList(BaseList):
         if prop == 'frequency':
             pvname = device.substitute(propty=device.propty+'Freq-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(1)
             sp.setMaximum(2**31 - 1)
@@ -1055,7 +1046,6 @@ class ClockList(BaseList):
         elif prop == 'mux_div':
             pvname = device.substitute(propty=device.propty+'MuxDiv-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = device.substitute(propty=device.propty+'MuxDiv-RB')
             rb = SiriusLabel(self, init_channel=pvname)
         return sp, rb
@@ -1438,7 +1428,6 @@ class AFC(BaseWidget):
         ld_phskp = QLabel('<b>Phase KP</b>', self, alignment=Qt.AlignCenter)
         sb_phskp = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'PhasePropGain-SP'))
-        sb_phskp.showStepExponent = False
         sb_phskp.limitsFromChannel = False
         sb_phskp.setMinimum(-2**31)
         sb_phskp.setMaximum(2**31-1)
@@ -1448,7 +1437,6 @@ class AFC(BaseWidget):
         ld_phski = QLabel('<b>Phase KI</b>', self, alignment=Qt.AlignCenter)
         sb_phski = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'PhaseIntgGain-SP'))
-        sb_phski.showStepExponent = False
         sb_phski.limitsFromChannel = False
         sb_phski.setMinimum(-2**31)
         sb_phski.setMaximum(2**31-1)
@@ -1458,7 +1446,6 @@ class AFC(BaseWidget):
         ld_frqkp = QLabel('<b>Freq. KP</b>', self, alignment=Qt.AlignCenter)
         sb_frqkp = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'FreqPropGain-SP'))
-        sb_frqkp.showStepExponent = False
         sb_frqkp.limitsFromChannel = False
         sb_frqkp.setMinimum(-2**31)
         sb_frqkp.setMaximum(2**31-1)
@@ -1468,7 +1455,6 @@ class AFC(BaseWidget):
         ld_frqki = QLabel('<b>Freq. KI</b>', self, alignment=Qt.AlignCenter)
         sb_frqki = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'FreqIntgGain-SP'))
-        sb_frqki.showStepExponent = False
         sb_frqki.limitsFromChannel = False
         sb_frqki.setMinimum(-2**31)
         sb_frqki.setMaximum(2**31-1)
@@ -1478,7 +1464,6 @@ class AFC(BaseWidget):
         ld_phnvg = QLabel('<b>Phs.Navg</b>', self, alignment=Qt.AlignCenter)
         sb_phnvg = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'PhaseNavg-SP'))
-        sb_phnvg.showStepExponent = False
         sb_phnvg.limitsFromChannel = False
         sb_phnvg.setMinimum(-2**31)
         sb_phnvg.setMaximum(2**31-1)
@@ -1489,7 +1474,6 @@ class AFC(BaseWidget):
             '<b>Phs.Div 2<sup>n</sup></b>', self, alignment=Qt.AlignCenter)
         sb_phdiv = SiriusSpinbox(
             self, self.get_pvname(propty=subdev+'PhaseDiv-SP'))
-        sb_phdiv.showStepExponent = False
         sb_phdiv.limitsFromChannel = False
         sb_phdiv.setMinimum(-2**31)
         sb_phdiv.setMaximum(2**31-1)
@@ -1499,7 +1483,6 @@ class AFC(BaseWidget):
         ld_rfrlo = QLabel('<b>RFReqLo</b>', self, alignment=Qt.AlignCenter)
         sb_rfrlo = SiriusHexaSpinbox(
             self, self.get_pvname(propty=subdev+'RFReqLo-SP'))
-        sb_rfrlo.showStepExponent = False
         sb_rfrlo.limitsFromChannel = False
         sb_rfrlo.setMinimum(-2**31)
         sb_rfrlo.setMaximum(2**31-1)
@@ -1510,7 +1493,6 @@ class AFC(BaseWidget):
         ld_rfrhi = QLabel('<b>RFReqHi</b>', self, alignment=Qt.AlignCenter)
         sb_rfrhi = SiriusHexaSpinbox(
             self, self.get_pvname(propty=subdev+'RFReqHi-SP'))
-        sb_rfrhi.showStepExponent = False
         sb_rfrhi.limitsFromChannel = False
         sb_rfrhi.setMinimum(-2**31)
         sb_rfrhi.setMaximum(2**31-1)
@@ -1523,7 +1505,6 @@ class AFC(BaseWidget):
         sb_n1 = SiriusHexaSpinbox(
             self, self.get_pvname(propty=subdev+'n1-SP'))
         sb_n1.setObjectName('n1')
-        sb_n1.showStepExponent = False
         sb_n1.limitsFromChannel = False
         sb_n1.setMinimum(-2**31)
         sb_n1.setMaximum(2**31-1)
@@ -2154,7 +2135,6 @@ class EVGFOUTOUTList(BaseList):
         elif prop == 'outdelay':
             pvname = device.substitute(propty='OUT'+str(idx)+'Delay-SP')
             sp = SiriusSpinbox(self, pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(0)
             sp.setMaximum(2**31 - 1)
@@ -2281,7 +2261,6 @@ class LLTriggerList(BaseList):
         elif prop == 'event':
             pvname = intlb.substitute(propty=intlb.propty+'Evt-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(0)
             sp.setMaximum(255)
@@ -2291,7 +2270,6 @@ class LLTriggerList(BaseList):
         elif prop == 'widthraw':
             pvname = intlb.substitute(propty=intlb.propty+'WidthRaw-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(1)
             sp.setMaximum(2**31 - 1)
@@ -2301,7 +2279,6 @@ class LLTriggerList(BaseList):
         elif prop == 'width':
             pvname = intlb.substitute(propty=intlb.propty+'Width-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = intlb.substitute(propty=intlb.propty+'Width-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
@@ -2314,7 +2291,6 @@ class LLTriggerList(BaseList):
         elif prop == 'pulses':
             pvname = intlb.substitute(propty=intlb.propty+'NrPulses-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(1)
             sp.setMaximum(2**31 - 1)
@@ -2324,7 +2300,6 @@ class LLTriggerList(BaseList):
         elif prop == 'delayraw':
             pvname = intlb.substitute(propty=intlb.propty+'DelayRaw-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(0)
             sp.setMaximum(2**31 - 1)
@@ -2334,7 +2309,6 @@ class LLTriggerList(BaseList):
         elif prop == 'delay':
             pvname = intlb.substitute(propty=intlb.propty+'Delay-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = intlb.substitute(propty=intlb.propty+'Delay-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
@@ -2352,21 +2326,18 @@ class LLTriggerList(BaseList):
         elif prop == 'trigger':
             pvname = outlb.substitute(propty=outlb.propty+'SrcTrig-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = outlb.substitute(propty=outlb.propty+'SrcTrig-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
         elif prop == 'rf_delayraw':
             pvname = outlb.substitute(propty=outlb.propty+'RFDelayRaw-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = outlb.substitute(propty=outlb.propty+'RFDelayRaw-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
         elif prop == 'rf_delay':
             pvname = outlb.substitute(propty=outlb.propty+'RFDelay-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = outlb.substitute(propty=outlb.propty+'RFDelay-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
@@ -2379,14 +2350,12 @@ class LLTriggerList(BaseList):
         elif prop == 'fine_delayraw':
             pvname = outlb.substitute(propty=outlb.propty+'FineDelayRaw-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = outlb.substitute(propty=outlb.propty+'FineDelayRaw-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
         elif prop == 'fine_delay':
             pvname = outlb.substitute(propty=outlb.propty+'FineDelay-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             pvname = outlb.substitute(propty=outlb.propty+'FineDelay-RB')
             rb = SiriusLabel(self, init_channel=pvname)
             rb.setAlignment(Qt.AlignCenter)
@@ -2485,7 +2454,6 @@ class EVREVEDIList(BaseList):
         elif prop == 'event':
             pvname = device.substitute(propty='DIEvent'+di_idx+'-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
-            sp.showStepExponent = False
             sp.limitsFromChannel = False
             sp.setMinimum(0)
             sp.setMaximum(255)

--- a/pyqt-apps/siriushla/common/cam_basler/base.py
+++ b/pyqt-apps/siriushla/common/cam_basler/base.py
@@ -6,11 +6,12 @@ import numpy as np
 from qtpy.QtWidgets import QHBoxLayout, QSizePolicy as QSzPlcy, QVBoxLayout, \
     QToolTip
 from qtpy.QtCore import Qt, Slot, Signal, Property
-from pydm.widgets import PyDMImageView, PyDMSpinbox, \
-    PyDMPushButton, PyDMEnumComboBox, PyDMLineEdit
+from pydm.widgets import PyDMImageView, PyDMPushButton, PyDMEnumComboBox, \
+    PyDMLineEdit
 from pydm.widgets.channel import PyDMChannel
 
-from siriushla.widgets import PyDMStateButton, SiriusLedState, SiriusLabel
+from siriushla.widgets import PyDMStateButton, SiriusLedState, SiriusLabel, \
+    SiriusSpinbox
 
 
 class SiriusImageView(PyDMImageView):
@@ -462,7 +463,7 @@ def create_propty_layout(parent, prefix, propty, propty_type='', cmd=dict(),
                 propty_name=propty, propty_suffix='SP'))
             setattr(parent, 'le_'+propty, sp)
         else:
-            sp = PyDMSpinbox(parent, prefix.substitute(
+            sp = SiriusSpinbox(parent, prefix.substitute(
                 propty_name=propty, propty_suffix='SP'))
             setattr(parent, 'sb_'+propty, sp)
             sp.showStepExponent = False

--- a/pyqt-apps/siriushla/common/cam_basler/base.py
+++ b/pyqt-apps/siriushla/common/cam_basler/base.py
@@ -466,7 +466,6 @@ def create_propty_layout(parent, prefix, propty, propty_type='', cmd=dict(),
             sp = SiriusSpinbox(parent, prefix.substitute(
                 propty_name=propty, propty_suffix='SP'))
             setattr(parent, 'sb_'+propty, sp)
-            sp.showStepExponent = False
         sp.setStyleSheet("""
             min-width:wvalem; max-width:wvalem; min-height:hvalem;
             max-height:hvalem;""".replace('wval', str(width)).replace(

--- a/pyqt-apps/siriushla/common/diff_ctrl/base.py
+++ b/pyqt-apps/siriushla/common/diff_ctrl/base.py
@@ -63,12 +63,10 @@ class DiffCtrlDevMonitor(QWidget):
         self.lb_descCtrl1 = QLabel(
             '', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.sb_Ctrl1 = SiriusSpinbox(self)
-        self.sb_Ctrl1.showStepExponent = False
         self.lb_Ctrl1 = SiriusLabel(self)
         self.lb_descCtrl2 = QLabel(
             '', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         self.sb_Ctrl2 = SiriusSpinbox(self)
-        self.sb_Ctrl2.showStepExponent = False
         self.lb_Ctrl2 = SiriusLabel(self)
 
         self.pb_open = PyDMPushButton(

--- a/pyqt-apps/siriushla/common/diff_ctrl/base.py
+++ b/pyqt-apps/siriushla/common/diff_ctrl/base.py
@@ -8,10 +8,10 @@ from qtpy.QtWidgets import QWidget, QVBoxLayout, QGroupBox, QPushButton, \
     QLabel, QGridLayout, QScrollArea
 import qtawesome as qta
 from pydm.utilities.macro import substitute_in_file as _substitute_in_file
-from pydm.widgets import PyDMSpinbox, PyDMPushButton
+from pydm.widgets import PyDMPushButton
 from siriuspy.envars import VACA_PREFIX as _VACA_PREFIX
 from siriuspy.namesys import SiriusPVName as _PVName
-from siriushla.widgets import PyDMLedMultiChannel, SiriusLabel
+from siriushla.widgets import PyDMLedMultiChannel, SiriusLabel, SiriusSpinbox
 from siriushla import util
 from .details import DiffCtrlDetails as _DiffCtrlDetails
 
@@ -37,7 +37,7 @@ class DiffCtrlDevMonitor(QWidget):
         self.updateDevWidget()
 
         self.setStyleSheet("""
-            PyDMSpinbox, SiriusLabel{
+            SiriusSpinbox, SiriusLabel{
                 min-width:5em; max-width: 5em;
             }""")
 
@@ -62,12 +62,12 @@ class DiffCtrlDevMonitor(QWidget):
 
         self.lb_descCtrl1 = QLabel(
             '', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        self.sb_Ctrl1 = PyDMSpinbox(self)
+        self.sb_Ctrl1 = SiriusSpinbox(self)
         self.sb_Ctrl1.showStepExponent = False
         self.lb_Ctrl1 = SiriusLabel(self)
         self.lb_descCtrl2 = QLabel(
             '', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        self.sb_Ctrl2 = PyDMSpinbox(self)
+        self.sb_Ctrl2 = SiriusSpinbox(self)
         self.sb_Ctrl2.showStepExponent = False
         self.lb_Ctrl2 = SiriusLabel(self)
 

--- a/pyqt-apps/siriushla/common/diff_ctrl/details.py
+++ b/pyqt-apps/siriushla/common/diff_ctrl/details.py
@@ -1,8 +1,8 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QFormLayout, QLabel, QGroupBox
-from pydm.widgets import PyDMPushButton, PyDMSpinbox
+from pydm.widgets import PyDMPushButton
 from siriuspy.namesys import SiriusPVName as _PVName
-from siriushla.widgets import SiriusDialog, PyDMLed, SiriusLabel
+from siriushla.widgets import SiriusDialog, PyDMLed, SiriusLabel, SiriusSpinbox
 
 
 class DiffCtrlDetails(SiriusDialog):
@@ -31,7 +31,7 @@ class DiffCtrlDetails(SiriusDialog):
         gbox_limits.setLayout(self._setupLimitsLayout())
 
         self.setStyleSheet("""
-            PyDMSpinbox, SiriusLabel{
+            SiriusSpinbox, SiriusLabel{
                 min-width: 5em; max-width: 5em;
             }""")
 
@@ -131,22 +131,22 @@ class DiffCtrlDetails(SiriusDialog):
         return flay
 
     def _setupLimitsLayout(self):
-        self.sb_PosEdgeInnerLim = PyDMSpinbox(
+        self.sb_PosEdgeInnerLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='PosEdgeInnerLim-SP'))
         self.sb_PosEdgeInnerLim.showStepExponent = False
         self.lb_PosEdgeInnerLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='PosEdgeInnerLim-RB'))
-        self.sb_NegEdgeInnerLim = PyDMSpinbox(
+        self.sb_NegEdgeInnerLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='NegEdgeInnerLim-SP'))
         self.sb_NegEdgeInnerLim.showStepExponent = False
         self.lb_NegEdgeInnerLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='NegEdgeInnerLim-RB'))
-        self.sb_LowOuterLim = PyDMSpinbox(
+        self.sb_LowOuterLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='LowOuterLim-SP'))
         self.sb_LowOuterLim.showStepExponent = False
         self.lb_LowOuterLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='LowOuterLim-RB'))
-        self.sb_HighOuterLim = PyDMSpinbox(
+        self.sb_HighOuterLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='HighOuterLim-SP'))
         self.sb_HighOuterLim.showStepExponent = False
         self.lb_HighOuterLim = SiriusLabel(

--- a/pyqt-apps/siriushla/common/diff_ctrl/details.py
+++ b/pyqt-apps/siriushla/common/diff_ctrl/details.py
@@ -133,22 +133,18 @@ class DiffCtrlDetails(SiriusDialog):
     def _setupLimitsLayout(self):
         self.sb_PosEdgeInnerLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='PosEdgeInnerLim-SP'))
-        self.sb_PosEdgeInnerLim.showStepExponent = False
         self.lb_PosEdgeInnerLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='PosEdgeInnerLim-RB'))
         self.sb_NegEdgeInnerLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='NegEdgeInnerLim-SP'))
-        self.sb_NegEdgeInnerLim.showStepExponent = False
         self.lb_NegEdgeInnerLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='NegEdgeInnerLim-RB'))
         self.sb_LowOuterLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='LowOuterLim-SP'))
-        self.sb_LowOuterLim.showStepExponent = False
         self.lb_LowOuterLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='LowOuterLim-RB'))
         self.sb_HighOuterLim = SiriusSpinbox(
             self, self.dev_prefix.substitute(propty='HighOuterLim-SP'))
-        self.sb_HighOuterLim.showStepExponent = False
         self.lb_HighOuterLim = SiriusLabel(
             self, self.dev_prefix.substitute(propty='HighOuterLim-RB'))
 

--- a/pyqt-apps/siriushla/li_ap_mps/main.py
+++ b/pyqt-apps/siriushla/li_ap_mps/main.py
@@ -3,12 +3,12 @@ from qtpy.QtCore import Qt, QEvent
 from qtpy.QtWidgets import QWidget, QGroupBox, QHBoxLayout, \
     QGridLayout, QLabel, QTabWidget, QPushButton
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox
+
 from .util import PV_MPS, MPS_PREFIX, CTRL_TYPE, GROUP_POS, \
     GROUP_POSALL, LBL_MPS, LBL_WATER, PV_TEMP_MPS, TEMP_TYPE, LBL_ALL
 from ..util import get_appropriate_color
 from ..widgets import PyDMLedMultiChannel, PyDMLed, SiriusLabel, \
-    SiriusPushButton
+    SiriusPushButton, SiriusSpinbox
 from .bypass_btn import BypassBtn
 
 
@@ -88,7 +88,7 @@ class MPSControl(QWidget):
         ''' Display the temperature label widget '''
         device_name = self.getDeviceName(pv_name)
         if temp_type == 'Thrd':
-            widget = PyDMSpinbox(
+            widget = SiriusSpinbox(
                 parent=self,
                 init_channel=device_name + pv_name + temp_type
             )

--- a/pyqt-apps/siriushla/li_ap_mps/main.py
+++ b/pyqt-apps/siriushla/li_ap_mps/main.py
@@ -92,7 +92,6 @@ class MPSControl(QWidget):
                 parent=self,
                 init_channel=device_name + pv_name + temp_type
             )
-            widget.showStepExponent = False
         else:
             widget = SiriusLabel(
                 parent=self,

--- a/pyqt-apps/siriushla/li_di_bpms/bpm_main.py
+++ b/pyqt-apps/siriushla/li_di_bpms/bpm_main.py
@@ -341,7 +341,6 @@ class DigBeamPosProc(SiriusMainWindow):
             channel_info = SiriusSpinbox(
                 parent=self,
                 init_channel=self.prefix + self.device_name + ':' + channel)
-            channel_info.showStepExponent = False
         else:
             channel_info = QLabel("Error", self)
 

--- a/pyqt-apps/siriushla/li_di_bpms/bpm_main.py
+++ b/pyqt-apps/siriushla/li_di_bpms/bpm_main.py
@@ -3,10 +3,11 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGroupBox, QVBoxLayout, QTabWidget, \
     QWidget, QLabel, QGridLayout
 import qtawesome as qta
-from pydm.widgets import enum_button, PyDMEnumComboBox, PyDMSpinbox
+from pydm.widgets import enum_button, PyDMEnumComboBox
 
 from ..util import get_appropriate_color
-from ..widgets import SiriusMainWindow, SiriusLedState, SiriusLabel
+from ..widgets import SiriusMainWindow, SiriusLedState, SiriusLabel, \
+    SiriusSpinbox
 from ..as_di_bpms.base import GraphWave
 
 
@@ -337,7 +338,7 @@ class DigBeamPosProc(SiriusMainWindow):
                 parent=self,
                 init_channel=self.prefix + self.device_name + ':' + channel)
         elif style in [1, 2, 4]:
-            channel_info = PyDMSpinbox(
+            channel_info = SiriusSpinbox(
                 parent=self,
                 init_channel=self.prefix + self.device_name + ':' + channel)
             channel_info.showStepExponent = False

--- a/pyqt-apps/siriushla/li_di_scrns/main.py
+++ b/pyqt-apps/siriushla/li_di_scrns/main.py
@@ -5,12 +5,11 @@ from qtpy.QtGui import QPixmap
 from qtpy.QtWidgets import QGroupBox, QHBoxLayout, QVBoxLayout, \
     QWidget, QLabel, QGridLayout, QRadioButton, QStackedWidget, \
     QSizePolicy
-from pydm.widgets import PyDMPushButton, \
-    PyDMSpinbox, PyDMImageView, PyDMLineEdit
+from pydm.widgets import PyDMPushButton, PyDMImageView, PyDMLineEdit
 import qtawesome as qta
 from ..util import get_appropriate_color
 from ..widgets import SiriusMainWindow, PyDMLedMultiChannel, \
-    SiriusWaveformPlot, SiriusLabel
+    SiriusWaveformPlot, SiriusLabel, SiriusSpinbox
 from .util import DEVICES, SCREENS_PANEL, SCREENS_INFO, HEADER, \
     GRAPH, SCREEN
 from .motorBtn import MotorBtn
@@ -72,7 +71,7 @@ class LiBeamProfile(SiriusMainWindow):
             widget = PyDMPushButton(self, init_channel=pv_name,
                                     label=label, pressValue=value)
         elif wid_type == 'spinBox':
-            widget = PyDMSpinbox(init_channel=pv_name)
+            widget = SiriusSpinbox(init_channel=pv_name)
             widget.showStepExponent = False
             widget.showUnits = True
         elif wid_type == 'lineEdit':
@@ -163,7 +162,7 @@ class LiBeamProfile(SiriusMainWindow):
                 device, graph_data['channel']['data']),
             color="#ff0000",
             lineWidth=1)
-            
+
         graph_plot.setPlotTitle(title)
         graph_plot.setLabel(
             'left',

--- a/pyqt-apps/siriushla/li_di_scrns/main.py
+++ b/pyqt-apps/siriushla/li_di_scrns/main.py
@@ -72,7 +72,6 @@ class LiBeamProfile(SiriusMainWindow):
                                     label=label, pressValue=value)
         elif wid_type == 'spinBox':
             widget = SiriusSpinbox(init_channel=pv_name)
-            widget.showStepExponent = False
             widget.showUnits = True
         elif wid_type == 'lineEdit':
             widget = PyDMLineEdit(

--- a/pyqt-apps/siriushla/li_eg_control/main.py
+++ b/pyqt-apps/siriushla/li_eg_control/main.py
@@ -134,7 +134,6 @@ class LIEgunWindow(SiriusMainWindow):
         self._ld_hvpsvoltsp = QLabel('Voltage SP [kV]', self)
         self._sb_hvpsvoltsp = SiriusSpinbox(
             self, self.prefix+self.dev_pref+':EG-HVPS:voltoutsoft')
-        self._sb_hvpsvoltsp.showStepExponent = False
 
         self._ld_hvpsvoltrb = QLabel('Voltage RB [kV]', self)
         self._lb_hvpsvoltrb = SiriusLabel(
@@ -151,7 +150,6 @@ class LIEgunWindow(SiriusMainWindow):
         self._ld_hvpscurrsp = QLabel('Current SP [mA]')
         self._sb_hvpscurrsp = SiriusSpinbox(
             self, self.prefix+self.dev_pref+':EG-HVPS:currentoutsoft')
-        self._sb_hvpscurrsp.showStepExponent = False
 
         self._ld_hvpscurrrb = QLabel('Current RB [mA]')
         self._lb_hvpscurrrb = SiriusLabel(
@@ -216,7 +214,6 @@ class LIEgunWindow(SiriusMainWindow):
         self._ld_filacurrsp = QLabel('Current SP [A]', self)
         self._sb_filacurrsp = SiriusSpinbox(
             self, self.prefix+self.dev_pref+':EG-FilaPS:currentoutsoft')
-        self._sb_filacurrsp.showStepExponent = False
 
         self._ld_filacurrrb = QLabel('Current RB [A]', self)
         self._lb_filacurrrb = SiriusLabel(
@@ -252,7 +249,6 @@ class LIEgunWindow(SiriusMainWindow):
         self._ld_biasvoltsp = QLabel('Voltage SP [V]', self)
         self._sb_biasvoltsp = SiriusSpinbox(
             self, self.prefix+self.dev_pref+':EG-BiasPS:voltoutsoft')
-        self._sb_biasvoltsp.showStepExponent = False
 
         self._ld_biasvoltrb = QLabel('Voltage RB [V]', self)
         self._lb_biasvoltrb = SiriusLabel(
@@ -327,7 +323,6 @@ class LIEgunWindow(SiriusMainWindow):
         self._sb_mpulspwrsp.limitsFromChannel = False
         self._sb_mpulspwrsp.setMinimum(0)
         self._sb_mpulspwrsp.setMaximum(300)
-        self._sb_mpulspwrsp.showStepExponent = False
         self._ld_mpulspwrrb = QLabel('Power RB [V]', self)
         self._lb_mpulspwrrb = SiriusLabel(
             self, self.prefix+self.dev_pref+':EG-PulsePS:powerinsoft')

--- a/pyqt-apps/siriushla/li_pu_modltr/main.py
+++ b/pyqt-apps/siriushla/li_pu_modltr/main.py
@@ -239,12 +239,10 @@ class LIModltrWindow(SiriusMainWindow):
         lbl_ma = QLabel('mA', self, alignment=Qt.AlignCenter)
 
         sb_volt = SiriusSpinbox(self, dev+':WRITE_V')
-        sb_volt.showStepExponent = False
         lb_volt = SiriusLabel(self, dev+':READV')
         lb_volt.setAlignment(Qt.AlignCenter)
 
         sb_curr = SiriusSpinbox(self, dev+':WRITE_I')
-        sb_curr.showStepExponent = False
         lb_curr = SiriusLabel(self, dev+':READI')
         lb_curr.setAlignment(Qt.AlignCenter)
 

--- a/pyqt-apps/siriushla/li_rf_llrf/controls.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/controls.py
@@ -100,7 +100,6 @@ class ControlBox(QWidget):
                 sppv = basename + ':SET_' + prop
                 rbpv = basename + ':GET_' + prop
                 spa = SiriusSpinbox(self, init_channel=sppv)
-                spa.showStepExponent = False
                 spa.precisionFromPV = False
                 spa.precision = 2
                 rba = SiriusLabel(self, init_channel=rbpv)

--- a/pyqt-apps/siriushla/li_rf_llrf/details.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/details.py
@@ -104,7 +104,6 @@ class DeviceParamSettingWindow(SiriusMainWindow):
             sppv = self.devpref + ':SET_' + prop
             rbpv = self.devpref + ':GET_' + prop
             spa = SiriusSpinbox(self, init_channel=sppv)
-            spa.showStepExponent = False
             rba = SiriusLabel(self, init_channel=rbpv)
             lay.addWidget(laba, row, 0)
             lay.addWidget(spa, row, 1)
@@ -138,7 +137,6 @@ class DeviceParamSettingWindow(SiriusMainWindow):
             sppv = self.devpref + ':SET_' + prop
             rbpv = self.devpref + ':GET_' + prop
             spa = SiriusSpinbox(self, init_channel=sppv)
-            spa.showStepExponent = False
             rba = SiriusLabel(self, init_channel=rbpv)
             lay.addWidget(laba, row, 0)
             lay.addWidget(spa, row, 1)
@@ -204,7 +202,6 @@ class DeviceParamSettingWindow(SiriusMainWindow):
             sppv = self.devpref + ':SET_' + prop
             rbpv = self.devpref + ':GET_' + prop
             spa = SiriusSpinbox(self, init_channel=sppv)
-            spa.showStepExponent = False
             spa.precisionFromPV = False
             spa.precision = 2
             lay.addWidget(spa, row, 2)
@@ -280,7 +277,6 @@ class DeviceParamSettingWindow(SiriusMainWindow):
             laba = QLabel(name, self)
             sppv = self.devpref + ':SET_' + prop
             spa = SiriusSpinbox(self, init_channel=sppv)
-            spa.showStepExponent = False
             dsc = QLabel('*'+str(factor))
             lay.addWidget(laba, row, 0)
             lay.addWidget(spa, row, 1)
@@ -326,7 +322,6 @@ class DeviceParamSettingWindow(SiriusMainWindow):
             laba = QLabel(name, self)
             sppv = self.devpref + ':SET_' + prop
             spa = SiriusSpinbox(self, init_channel=sppv)
-            spa.showStepExponent = False
             spa.precisionFromPV = False
             spa.precision = 2
             lay.addWidget(laba, row, 0)

--- a/pyqt-apps/siriushla/li_rf_llrf/motor_control.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/motor_control.py
@@ -51,7 +51,6 @@ class MotorControlWindow(SiriusMainWindow):
         elif wid_type == 'spinBox':
             widget = SiriusSpinbox(
                 init_channel=pv_name)
-            widget.showStepExponent = False
         elif wid_type == 'state':
             widget = PyDMStateButton(
                 init_channel=pv_name)

--- a/pyqt-apps/siriushla/li_rf_llrf/motor_control.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/motor_control.py
@@ -2,9 +2,9 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QHBoxLayout, QWidget, QLabel
-from pydm.widgets import PyDMSpinbox, PyDMLineEdit
-from ..widgets import SiriusLabel, SiriusMainWindow, \
-    PyDMLedMultiChannel, SiriusPushButton, PyDMStateButton
+from pydm.widgets import PyDMLineEdit
+from ..widgets import SiriusLabel, SiriusMainWindow, PyDMLedMultiChannel, \
+    SiriusPushButton, PyDMStateButton, SiriusSpinbox
 from .util import MOTOR_CONTROL
 
 
@@ -49,7 +49,7 @@ class MotorControlWindow(SiriusMainWindow):
                 init_channel=pv_name)
             widget.showUnits = True
         elif wid_type == 'spinBox':
-            widget = PyDMSpinbox(
+            widget = SiriusSpinbox(
                 init_channel=pv_name)
             widget.showStepExponent = False
         elif wid_type == 'state':

--- a/pyqt-apps/siriushla/si_ap_blanalysis/mvs2_view.py
+++ b/pyqt-apps/siriushla/si_ap_blanalysis/mvs2_view.py
@@ -54,21 +54,18 @@ class BeamLineMVS2View(SiriusMainWindow):
         self._ld_rate = QLabel('Acq. Rate: ')
         self._sb_rate = SiriusSpinbox(
             gbox_ctrl, self._device_analysis+':MeasureRate-SP')
-        self._sb_rate.showStepExponent = False
         self._lb_rate = SiriusLabel(
             gbox_ctrl, self._device_analysis+':MeasureRate-RB')
 
         self._ld_tgtx = QLabel('Target X: ')
         self._sb_tgtx = SiriusSpinbox(
             gbox_ctrl, self._device_analysis+':TargetPosX-SP')
-        self._sb_tgtx.showStepExponent = False
         self._lb_tgtx = SiriusLabel(
             gbox_ctrl, self._device_analysis+':TargetPosX-RB')
 
         self._ld_tgty = QLabel('Target Y: ')
         self._sb_tgty = SiriusSpinbox(
             gbox_ctrl, self._device_analysis+':TargetPosY-SP')
-        self._sb_tgty.showStepExponent = False
         self._lb_tgty = SiriusLabel(
             gbox_ctrl, self._device_analysis+':TargetPosY-RB')
 
@@ -132,7 +129,6 @@ class BeamLineMVS2View(SiriusMainWindow):
         self._ld_acqtime = QLabel('Acquire Time: ')
         self._sb_acqtime = SiriusSpinbox(
             gbox_ctrl, self._device_cam + ':cam1:AcquireTime')
-        self._sb_acqtime.showStepExponent = False
         self._sb_acqtime.limitsFromChannel = False
         self._sb_acqtime.setRange(0.001, 10)
         self._lb_acqtime = SiriusLabel(
@@ -142,7 +138,6 @@ class BeamLineMVS2View(SiriusMainWindow):
         self._ld_acqperd = QLabel('Acquire Period: ')
         self._sb_acqperd = SiriusSpinbox(
             gbox_ctrl, self._device_cam + ':cam1:AcquirePeriod')
-        self._sb_acqperd.showStepExponent = False
         self._sb_acqperd.limitsFromChannel = False
         self._sb_acqperd.setRange(0.001, 10)
         self._lb_acqperd = SiriusLabel(

--- a/pyqt-apps/siriushla/si_ap_fofb/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/custom_widgets.py
@@ -312,7 +312,6 @@ class AuxCommDialog(BaseObject, SiriusDialog):
                     pref = self.devpref
                     spw = SiriusSpinbox(
                         self, pref.substitute(propty=dev+'AccSatMax-SP'))
-                    spw.showStepExponent = False
                     rbw = SiriusLabel(
                         self, pref.substitute(propty=dev+'AccSatMax-RB'))
                     hlay = QHBoxLayout()
@@ -328,7 +327,6 @@ class AuxCommDialog(BaseObject, SiriusDialog):
                 pref = self.devpref
                 spw = SiriusSpinbox(
                     self, pref.substitute(propty='TimeFrameLen-SP'))
-                spw.showStepExponent = False
                 rbw = SiriusLabel(
                     self, pref.substitute(propty='TimeFrameLen-RB'))
                 hlay = QHBoxLayout()

--- a/pyqt-apps/siriushla/si_ap_fofb/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/graphics.py
@@ -340,7 +340,6 @@ class KickWidget(BaseObject, QWidget):
         pvname = self.devpref.substitute(
             prefix=self.prefix, propty='KickBufferSize-SP')
         sbbuff = SiriusSpinbox(self, pvname)
-        sbbuff.showStepExponent = False
         lbbuffmon = SiriusLabel(self, pvname.substitute(propty_suffix='Mon'))
         lbbuff = SiriusLabel(self, pvname.substitute(propty_suffix='RB'))
         laybuff = QHBoxLayout()

--- a/pyqt-apps/siriushla/si_ap_fofb/main.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/main.py
@@ -174,7 +174,6 @@ class MainWindow(BaseObject, SiriusMainWindow):
             'Gain H: ', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_gain_h = SiriusSpinbox(
             self, self.devpref.substitute(propty='LoopGainH-SP'))
-        sb_gain_h.showStepExponent = False
         lb_gain_h = SiriusLabel(
             self, self.devpref.substitute(propty='LoopGainH-RB'))
         lb_gain_mon_h = SiriusLabel(
@@ -184,7 +183,6 @@ class MainWindow(BaseObject, SiriusMainWindow):
             'Gain V: ', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_gain_v = SiriusSpinbox(
             self, self.devpref.substitute(propty='LoopGainV-SP'))
-        sb_gain_v.showStepExponent = False
         lb_gain_v = SiriusLabel(
             self, self.devpref.substitute(propty='LoopGainV-RB'))
         lb_gain_mon_v = SiriusLabel(

--- a/pyqt-apps/siriushla/si_ap_orbintlk/bpmdetail.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/bpmdetail.py
@@ -112,7 +112,6 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignVCenter)
         self._sb_minsumlim = SiriusSpinbox(
             self, self.devpref.substitute(propty='IntlkLmtMinSum-SP'))
-        self._sb_minsumlim.showStepExponent = False
         self._sb_minsumlim.limitsFromChannel = False
         self._sb_minsumlim.setMinimum(-1e12)
         self._sb_minsumlim.setMaximum(+1e12)
@@ -164,7 +163,6 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_minx = SiriusSpinbox(
             self, self.devpref.substitute(propty='IntlkLmt'+intlk+'MinX-SP'))
-        sb_minx.showStepExponent = False
         sb_minx.limitsFromChannel = False
         sb_minx.setMinimum(-1e9)
         sb_minx.setMaximum(+1e9)
@@ -176,7 +174,6 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_maxx = SiriusSpinbox(
             self, self.devpref.substitute(propty='IntlkLmt'+intlk+'MaxX-SP'))
-        sb_maxx.showStepExponent = False
         sb_maxx.limitsFromChannel = False
         sb_maxx.setMinimum(-1e9)
         sb_maxx.setMaximum(+1e9)
@@ -188,7 +185,6 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_miny = SiriusSpinbox(
             self, self.devpref.substitute(propty='IntlkLmt'+intlk+'MinY-SP'))
-        sb_miny.showStepExponent = False
         sb_miny.limitsFromChannel = False
         sb_miny.setMinimum(-1e9)
         sb_miny.setMaximum(+1e9)
@@ -200,7 +196,6 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
             alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_maxy = SiriusSpinbox(
             self, self.devpref.substitute(propty='IntlkLmt'+intlk+'MaxY-SP'))
-        sb_maxy.showStepExponent = False
         sb_maxy.limitsFromChannel = False
         sb_maxy.setMinimum(-1e9)
         sb_maxy.setMaximum(+1e9)

--- a/pyqt-apps/siriushla/si_di_bbb/acquisition.py
+++ b/pyqt-apps/siriushla/si_di_bbb/acquisition.py
@@ -6,14 +6,14 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor, QPixmap
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QPushButton, \
     QGroupBox, QVBoxLayout, QSizePolicy as QSzPlcy, QSpacerItem
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, PyDMLineEdit
+from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
 from ..util import connect_window
 from ..widgets import SiriusFrame, PyDMStateButton, SiriusLedState, \
-    SiriusLabel
+    SiriusLabel, SiriusSpinbox
 from ..widgets.windows import create_window_from_widget
 
 from .custom_widgets import WfmGraph
@@ -70,21 +70,21 @@ class _BbBModalAnalysis(QWidget):
         cb_sel = PyDMEnumComboBox(self, self.prop_pref+'MD_SMODE')
 
         ld_sbnd = QLabel('Sideband', self, alignment=Qt.AlignRight)
-        sb_sbnd = PyDMSpinbox(self, self.prop_pref+'MD_FTUNE')
+        sb_sbnd = SiriusSpinbox(self, self.prop_pref+'MD_FTUNE')
         sb_sbnd.showStepExponent = False
         sb_sbnd.showUnits = True
 
         ld_span = QLabel('Span', self, alignment=Qt.AlignRight)
-        sb_span = PyDMSpinbox(self, self.prop_pref+'MD_FSPAN')
+        sb_span = SiriusSpinbox(self, self.prop_pref+'MD_FSPAN')
         sb_span.showStepExponent = False
         sb_span.showUnits = True
 
         ld_mode = QLabel('Mode', self, alignment=Qt.AlignRight)
-        sb_mode = PyDMSpinbox(self, self.prop_pref+'MD_MSEL')
+        sb_mode = SiriusSpinbox(self, self.prop_pref+'MD_MSEL')
         sb_mode.showStepExponent = False
 
         ld_avg = QLabel('Sample Avg', self, alignment=Qt.AlignRight)
-        sb_avg = PyDMSpinbox(self, self.prop_pref+'MD_AVG')
+        sb_avg = SiriusSpinbox(self, self.prop_pref+'MD_AVG')
         sb_avg.showStepExponent = False
 
         gb_ctrl = QGroupBox('Acquisition control', self)
@@ -186,24 +186,24 @@ class _BbBAcqBase(QWidget):
         cb_growenbl = PyDMEnumComboBox(self, self.dev_pref+':GDEN')
 
         ld_down = QLabel('Rec. Downsample ', self)
-        sb_down = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_REC_DS')
+        sb_down = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_REC_DS')
         sb_down.showStepExponent = False
 
         ld_rawdata = QLabel('Raw Data', self)
         cb_rawdata = PyDMStateButton(self, self.dev_pref+':'+self.TYPE+'_DUMP')
 
         ld_acqtime = QLabel('Acquisition Time', self)
-        sb_acqtime = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_ACQTIME')
+        sb_acqtime = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_ACQTIME')
         sb_acqtime.showStepExponent = False
         sb_acqtime.showUnits = True
 
         ld_holdoff = QLabel('Hold-Off Time', self)
-        sb_holdoff = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_HOLDTIME')
+        sb_holdoff = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_HOLDTIME')
         sb_holdoff.showStepExponent = False
         sb_holdoff.showUnits = True
 
         ld_posttrg = QLabel('Post Trigger', self)
-        sb_posttrg = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_POSTTIME')
+        sb_posttrg = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_POSTTIME')
         sb_posttrg.showStepExponent = False
         sb_posttrg.showUnits = True
         fr_posttrg = SiriusFrame(
@@ -211,7 +211,7 @@ class _BbBAcqBase(QWidget):
         fr_posttrg.add_widget(sb_posttrg)
 
         ld_growtime = QLabel('Growth Time', self)
-        sb_growtime = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_GDTIME')
+        sb_growtime = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_GDTIME')
         sb_growtime.showStepExponent = False
         sb_growtime.showUnits = True
         fr_growtime = SiriusFrame(
@@ -410,7 +410,7 @@ class _BbBAcqBase(QWidget):
             self, self.dev_pref+':'+self.TYPE+'_ACQ_PATTERN')
 
         ld_avg = QLabel('Sample Avg', self)
-        sb_avg = PyDMSpinbox(self, self.dev_pref+':'+self.TYPE+'_SP_AVG')
+        sb_avg = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_SP_AVG')
         sb_avg.showStepExponent = False
 
         gbox_acqctrl = QGroupBox('Acquisition control', self)
@@ -531,11 +531,11 @@ class BbBAcqSB(QWidget):
 
     def _setupControlsWidget(self):
         ld_acqtime = QLabel('Acquisition Time [ms]', self)
-        sb_acqtime = PyDMSpinbox(self, self.dev_pref+':SB_ACQTIME')
+        sb_acqtime = SiriusSpinbox(self, self.dev_pref+':SB_ACQTIME')
         sb_acqtime.showStepExponent = False
 
         ld_bunid = QLabel('Bunch Number', self)
-        sb_bunid = PyDMSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
+        sb_bunid = SiriusSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
         sb_bunid.showStepExponent = False
 
         ld_acqsmpl = QLabel('Acq Samples', self)
@@ -584,23 +584,23 @@ class BbBAcqSB(QWidget):
             '<h4>Controls</h4>', self, alignment=Qt.AlignCenter)
 
         ld_bunnr = QLabel('Bunch Number', self)
-        sb_bunnr = PyDMSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
+        sb_bunnr = SiriusSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
         sb_bunnr.showStepExponent = False
 
         ld_gain = QLabel('Gain', self)
-        sb_gain = PyDMSpinbox(self, self.dev_pref+':PHTRK_GAIN')
+        sb_gain = SiriusSpinbox(self, self.dev_pref+':PHTRK_GAIN')
         sb_gain.showStepExponent = False
 
         ld_sp = QLabel('Setpoint [deg]', self)
-        sb_sp = PyDMSpinbox(self, self.dev_pref+':PHTRK_SETPT')
+        sb_sp = SiriusSpinbox(self, self.dev_pref+':PHTRK_SETPT')
         sb_sp.showStepExponent = False
 
         ld_range = QLabel('Range [kHz]', self)
-        sb_range = PyDMSpinbox(self, self.dev_pref+':PHTRK_RANGE')
+        sb_range = SiriusSpinbox(self, self.dev_pref+':PHTRK_RANGE')
         sb_range.showStepExponent = False
 
         ld_dec = QLabel('Decimation', self)
-        sb_dec = PyDMSpinbox(self, self.dev_pref+':PHTRK_DECIM')
+        sb_dec = SiriusSpinbox(self, self.dev_pref+':PHTRK_DECIM')
         sb_dec.showStepExponent = False
 
         ld_rate = QLabel('Rate', self)
@@ -758,7 +758,7 @@ class BbBAcqSB(QWidget):
         le_delaycal = PyDMLineEdit(self, self.dev_pref+':SB_DEL_CAL')
 
         ld_avg = QLabel('Averaging', self)
-        sb_avg = PyDMSpinbox(self, self.dev_pref+':SB_SP_AVG')
+        sb_avg = SiriusSpinbox(self, self.dev_pref+':SB_SP_AVG')
         sb_avg.showStepExponent = False
 
         gbox_fftsett = QGroupBox(self)

--- a/pyqt-apps/siriushla/si_di_bbb/acquisition.py
+++ b/pyqt-apps/siriushla/si_di_bbb/acquisition.py
@@ -71,21 +71,17 @@ class _BbBModalAnalysis(QWidget):
 
         ld_sbnd = QLabel('Sideband', self, alignment=Qt.AlignRight)
         sb_sbnd = SiriusSpinbox(self, self.prop_pref+'MD_FTUNE')
-        sb_sbnd.showStepExponent = False
         sb_sbnd.showUnits = True
 
         ld_span = QLabel('Span', self, alignment=Qt.AlignRight)
         sb_span = SiriusSpinbox(self, self.prop_pref+'MD_FSPAN')
-        sb_span.showStepExponent = False
         sb_span.showUnits = True
 
         ld_mode = QLabel('Mode', self, alignment=Qt.AlignRight)
         sb_mode = SiriusSpinbox(self, self.prop_pref+'MD_MSEL')
-        sb_mode.showStepExponent = False
 
         ld_avg = QLabel('Sample Avg', self, alignment=Qt.AlignRight)
         sb_avg = SiriusSpinbox(self, self.prop_pref+'MD_AVG')
-        sb_avg.showStepExponent = False
 
         gb_ctrl = QGroupBox('Acquisition control', self)
         lay_ctrl = QGridLayout(gb_ctrl)
@@ -187,24 +183,20 @@ class _BbBAcqBase(QWidget):
 
         ld_down = QLabel('Rec. Downsample ', self)
         sb_down = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_REC_DS')
-        sb_down.showStepExponent = False
 
         ld_rawdata = QLabel('Raw Data', self)
         cb_rawdata = PyDMStateButton(self, self.dev_pref+':'+self.TYPE+'_DUMP')
 
         ld_acqtime = QLabel('Acquisition Time', self)
         sb_acqtime = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_ACQTIME')
-        sb_acqtime.showStepExponent = False
         sb_acqtime.showUnits = True
 
         ld_holdoff = QLabel('Hold-Off Time', self)
         sb_holdoff = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_HOLDTIME')
-        sb_holdoff.showStepExponent = False
         sb_holdoff.showUnits = True
 
         ld_posttrg = QLabel('Post Trigger', self)
         sb_posttrg = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_POSTTIME')
-        sb_posttrg.showStepExponent = False
         sb_posttrg.showUnits = True
         fr_posttrg = SiriusFrame(
             self, self.dev_pref+':'+self.TYPE+'_POSTREG_SUBWR')
@@ -212,7 +204,6 @@ class _BbBAcqBase(QWidget):
 
         ld_growtime = QLabel('Growth Time', self)
         sb_growtime = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_GDTIME')
-        sb_growtime.showStepExponent = False
         sb_growtime.showUnits = True
         fr_growtime = SiriusFrame(
             self, self.dev_pref+':'+self.TYPE+'_GDREG_SUBWR')
@@ -411,7 +402,6 @@ class _BbBAcqBase(QWidget):
 
         ld_avg = QLabel('Sample Avg', self)
         sb_avg = SiriusSpinbox(self, self.dev_pref+':'+self.TYPE+'_SP_AVG')
-        sb_avg.showStepExponent = False
 
         gbox_acqctrl = QGroupBox('Acquisition control', self)
         lay_acqctrl = QGridLayout(gbox_acqctrl)
@@ -532,11 +522,9 @@ class BbBAcqSB(QWidget):
     def _setupControlsWidget(self):
         ld_acqtime = QLabel('Acquisition Time [ms]', self)
         sb_acqtime = SiriusSpinbox(self, self.dev_pref+':SB_ACQTIME')
-        sb_acqtime.showStepExponent = False
 
         ld_bunid = QLabel('Bunch Number', self)
         sb_bunid = SiriusSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
-        sb_bunid.showStepExponent = False
 
         ld_acqsmpl = QLabel('Acq Samples', self)
         lb_acqsmpl = SiriusLabel(self, self.dev_pref+':SB_ACQ_SAMPLES')
@@ -585,23 +573,18 @@ class BbBAcqSB(QWidget):
 
         ld_bunnr = QLabel('Bunch Number', self)
         sb_bunnr = SiriusSpinbox(self, self.dev_pref+':SB_BUNCH_ID')
-        sb_bunnr.showStepExponent = False
 
         ld_gain = QLabel('Gain', self)
         sb_gain = SiriusSpinbox(self, self.dev_pref+':PHTRK_GAIN')
-        sb_gain.showStepExponent = False
 
         ld_sp = QLabel('Setpoint [deg]', self)
         sb_sp = SiriusSpinbox(self, self.dev_pref+':PHTRK_SETPT')
-        sb_sp.showStepExponent = False
 
         ld_range = QLabel('Range [kHz]', self)
         sb_range = SiriusSpinbox(self, self.dev_pref+':PHTRK_RANGE')
-        sb_range.showStepExponent = False
 
         ld_dec = QLabel('Decimation', self)
         sb_dec = SiriusSpinbox(self, self.dev_pref+':PHTRK_DECIM')
-        sb_dec.showStepExponent = False
 
         ld_rate = QLabel('Rate', self)
         lb_rate = SiriusLabel(self, self.dev_pref+':PHTRK_RATE')
@@ -759,7 +742,6 @@ class BbBAcqSB(QWidget):
 
         ld_avg = QLabel('Averaging', self)
         sb_avg = SiriusSpinbox(self, self.dev_pref+':SB_SP_AVG')
-        sb_avg.showStepExponent = False
 
         gbox_fftsett = QGroupBox(self)
         lay_fftsett = QGridLayout(gbox_fftsett)

--- a/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
+++ b/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
@@ -63,25 +63,21 @@ class BbBGeneralSettingsWidget(QWidget):
         # # Delay Lines
         ld_adcclock = QLabel('ADC Clock', self)
         sb_adcclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL0')
-        sb_adcclock.showStepExponent = False
         fr_adcclock = SiriusFrame(self, self.dev_pref+':ECLDEL0_SUBWR')
         fr_adcclock.add_widget(sb_adcclock)
 
         ld_fidclock = QLabel('Fiducial Clock', self)
         sb_fidclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL1')
-        sb_fidclock.showStepExponent = False
         fr_fidclock = SiriusFrame(self, self.dev_pref+':ECLDEL1_SUBWR')
         fr_fidclock.add_widget(sb_fidclock)
 
         ld_fiducial = QLabel('Fiducial', self)
         sb_fiducial = SiriusSpinbox(self, self.dev_pref+':ECLDEL2')
-        sb_fiducial.showStepExponent = False
         fr_fiducial = SiriusFrame(self, self.dev_pref+':ECLDEL2_SUBWR')
         fr_fiducial.add_widget(sb_fiducial)
 
         ld_dacclock = QLabel('DAC Clock', self)
         sb_dacclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL3')
-        sb_dacclock.showStepExponent = False
         fr_dacclock = SiriusFrame(self, self.dev_pref+':ECLDEL3_SUBWR')
         fr_dacclock.add_widget(sb_dacclock)
 
@@ -108,7 +104,6 @@ class BbBGeneralSettingsWidget(QWidget):
             self, self.dev_pref+':LEVEL_FID_ENABLE')
         cb_fidlvlenbl.setStyleSheet('max-width:3em;')
         sb_fidv = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH9')
-        sb_fidv.showStepExponent = False
         sb_fidv.showUnits = True
         fr_fidv = SiriusFrame(self, self.dev_pref+':AD5644CH9_SUBWR')
         fr_fidv.add_widget(sb_fidv)
@@ -119,7 +114,6 @@ class BbBGeneralSettingsWidget(QWidget):
             self, self.dev_pref+':LEVEL_TRIG1_ENABLE')
         cb_trg1lvlenbl.setStyleSheet('max-width:3em;')
         sb_trg1lvlv = SiriusSpinbox(self, self.dev_pref+':LEVEL_VTRIG1')
-        sb_trg1lvlv.showStepExponent = False
         sb_trg1lvlv.showUnits = True
         fr_trg1lvlv = SiriusFrame(
             self, self.dev_pref+':AD5644CH10_SUBWR')
@@ -133,7 +127,6 @@ class BbBGeneralSettingsWidget(QWidget):
             self, self.dev_pref+':LEVEL_TRIG2_ENABLE')
         cb_trg2lvlenbl.setStyleSheet('max-width:3em;')
         sb_trg2lvlv = SiriusSpinbox(self, self.dev_pref+':LEVEL_VTRIG2')
-        sb_trg2lvlv.showStepExponent = False
         sb_trg2lvlv.showUnits = True
         fr_trg2lvlv = SiriusFrame(self, self.dev_pref+':AD5644CH8_SUBWR')
         fr_trg2lvlv.add_widget(sb_trg2lvlv)
@@ -142,7 +135,6 @@ class BbBGeneralSettingsWidget(QWidget):
 
         ld_dacoff = QLabel('DAC Offset', self)
         sb_dacoff = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH11')
-        sb_dacoff.showStepExponent = False
         sb_dacoff.showUnits = True
         fr_dacoff = SiriusFrame(self, self.dev_pref+':AD5644CH11_SUBWR')
         fr_dacoff.add_widget(sb_dacoff)
@@ -180,13 +172,11 @@ class BbBGeneralSettingsWidget(QWidget):
 
         ld_firc0 = QLabel('C0', self)
         sb_firc0 = SiriusSpinbox(self, self.dev_pref+':SHAPE_C0')
-        sb_firc0.showStepExponent = False
         fr_firc0 = SiriusFrame(self, self.dev_pref+':SHAPE_C0_SUBWR')
         fr_firc0.add_widget(sb_firc0)
 
         ld_firc2 = QLabel('C2', self)
         sb_firc2 = SiriusSpinbox(self, self.dev_pref+':SHAPE_C2')
-        sb_firc2.showStepExponent = False
         fr_firc2 = SiriusFrame(self, self.dev_pref+':SHAPE_C2_SUBWR')
         fr_firc2.add_widget(sb_firc2)
 
@@ -232,7 +222,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch0 = QLabel('0', self, alignment=Qt.AlignCenter)
         ld_dacch0.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch0 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH0')
-        sb_dacch0.showStepExponent = False
         sb_dacch0.showUnits = True
         fr_dacch0 = SiriusFrame(self, self.dev_pref+':AD5644CH0_SUBWR')
         fr_dacch0.add_widget(sb_dacch0)
@@ -240,7 +229,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch1 = QLabel('1', self, alignment=Qt.AlignCenter)
         ld_dacch1.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch1 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH1')
-        sb_dacch1.showStepExponent = False
         sb_dacch1.showUnits = True
         fr_dacch1 = SiriusFrame(self, self.dev_pref+':AD5644CH1_SUBWR')
         fr_dacch1.add_widget(sb_dacch1)
@@ -248,7 +236,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch2 = QLabel('2', self, alignment=Qt.AlignCenter)
         ld_dacch2.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch2 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH2')
-        sb_dacch2.showStepExponent = False
         sb_dacch2.showUnits = True
         fr_dacch2 = SiriusFrame(self, self.dev_pref+':AD5644CH2_SUBWR')
         fr_dacch2.add_widget(sb_dacch2)
@@ -256,7 +243,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch3 = QLabel('3', self, alignment=Qt.AlignCenter)
         ld_dacch3.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch3 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH3')
-        sb_dacch3.showStepExponent = False
         sb_dacch3.showUnits = True
         fr_dacch3 = SiriusFrame(self, self.dev_pref+':AD5644CH3_SUBWR')
         fr_dacch3.add_widget(sb_dacch3)
@@ -268,7 +254,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch4 = QLabel('4', self, alignment=Qt.AlignCenter)
         ld_dacch4.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch4 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH4')
-        sb_dacch4.showStepExponent = False
         sb_dacch4.showUnits = True
         fr_dacch4 = SiriusFrame(self, self.dev_pref+':AD5644CH4_SUBWR')
         fr_dacch4.add_widget(sb_dacch4)
@@ -276,7 +261,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch5 = QLabel('5', self, alignment=Qt.AlignCenter)
         ld_dacch5.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch5 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH5')
-        sb_dacch5.showStepExponent = False
         sb_dacch5.showUnits = True
         fr_dacch5 = SiriusFrame(self, self.dev_pref+':AD5644CH5_SUBWR')
         fr_dacch5.add_widget(sb_dacch5)
@@ -284,7 +268,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch6 = QLabel('6', self, alignment=Qt.AlignCenter)
         ld_dacch6.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch6 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH6')
-        sb_dacch6.showStepExponent = False
         sb_dacch6.showUnits = True
         fr_dacch6 = SiriusFrame(self, self.dev_pref+':AD5644CH6_SUBWR')
         fr_dacch6.add_widget(sb_dacch6)
@@ -292,7 +275,6 @@ class BbBSlowDACsWidget(QWidget):
         ld_dacch7 = QLabel('7', self, alignment=Qt.AlignCenter)
         ld_dacch7.setStyleSheet('font-weight: bold; max-width: 3em;')
         sb_dacch7 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH7')
-        sb_dacch7.showStepExponent = False
         sb_dacch7.showUnits = True
         fr_dacch7 = SiriusFrame(self, self.dev_pref+':AD5644CH7_SUBWR')
         fr_dacch7.add_widget(sb_dacch7)
@@ -449,14 +431,12 @@ class BbBInterlock(QWidget):
 
         ld_sat = QLabel('Saturation Time', self)
         sb_sat = SiriusSpinbox(self, self.dev_pref+':ILOCK_TSAT')
-        sb_sat.showStepExponent = False
         sb_sat.showUnits = True
         lb_sat = SiriusLabel(self, self.dev_pref+':ILOCK_TSAT_T2C')
         lb_sat.setAlignment(Qt.AlignCenter)
 
         ld_tim = QLabel('Timeout', self)
         sb_tim = SiriusSpinbox(self, self.dev_pref+':ILOCK_TOUT')
-        sb_tim.showStepExponent = False
         sb_tim.showUnits = True
         lb_tim = SiriusLabel(self, self.dev_pref+':ILOCK_TOUT_T2C')
         lb_tim.setAlignment(Qt.AlignCenter)
@@ -487,27 +467,22 @@ class BbBInterlock(QWidget):
 
         ld_tun = QLabel('Fractional Tune', self)
         sb_tun = SiriusSpinbox(self, self.dev_pref+':ILOCK_TUNE')
-        sb_tun.showStepExponent = False
         sb_tun.showUnits = True
 
         ld_tap = QLabel('Filter Taps', self)
         sb_tap = SiriusSpinbox(self, self.dev_pref+':ILOCK_TAPS')
-        sb_tap.showStepExponent = False
         sb_tap.showUnits = True
 
         ld_cal = QLabel('Calibration', self)
         sb_cal = SiriusSpinbox(self, self.dev_pref+':ILOCK_FE_CAL')
-        sb_cal.showStepExponent = False
         sb_cal.showUnits = True
 
         ld_ncur = QLabel('Nominal Current', self)
         sb_ncur = SiriusSpinbox(self, self.dev_pref+':ILOCK_CURRENT')
-        sb_ncur.showStepExponent = False
         sb_ncur.showUnits = True
 
         ld_thr = QLabel('Threshold', self)
         sb_thr = SiriusSpinbox(self, self.dev_pref+':ILOCK_THRESH')
-        sb_thr.showStepExponent = False
         sb_thr.showUnits = True
 
         pb_upt = SiriusPushButton(

--- a/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
+++ b/pyqt-apps/siriushla/si_di_bbb/advanced_settings.py
@@ -3,12 +3,12 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, QHBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
+from pydm.widgets import PyDMEnumComboBox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import SiriusFrame, SiriusLabel, SiriusPushButton
+from ..widgets import SiriusFrame, SiriusLabel, SiriusPushButton, SiriusSpinbox
 
 from .custom_widgets import MyScaleIndicator
 from .util import set_bbb_color
@@ -62,25 +62,25 @@ class BbBGeneralSettingsWidget(QWidget):
 
         # # Delay Lines
         ld_adcclock = QLabel('ADC Clock', self)
-        sb_adcclock = PyDMSpinbox(self, self.dev_pref+':ECLDEL0')
+        sb_adcclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL0')
         sb_adcclock.showStepExponent = False
         fr_adcclock = SiriusFrame(self, self.dev_pref+':ECLDEL0_SUBWR')
         fr_adcclock.add_widget(sb_adcclock)
 
         ld_fidclock = QLabel('Fiducial Clock', self)
-        sb_fidclock = PyDMSpinbox(self, self.dev_pref+':ECLDEL1')
+        sb_fidclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL1')
         sb_fidclock.showStepExponent = False
         fr_fidclock = SiriusFrame(self, self.dev_pref+':ECLDEL1_SUBWR')
         fr_fidclock.add_widget(sb_fidclock)
 
         ld_fiducial = QLabel('Fiducial', self)
-        sb_fiducial = PyDMSpinbox(self, self.dev_pref+':ECLDEL2')
+        sb_fiducial = SiriusSpinbox(self, self.dev_pref+':ECLDEL2')
         sb_fiducial.showStepExponent = False
         fr_fiducial = SiriusFrame(self, self.dev_pref+':ECLDEL2_SUBWR')
         fr_fiducial.add_widget(sb_fiducial)
 
         ld_dacclock = QLabel('DAC Clock', self)
-        sb_dacclock = PyDMSpinbox(self, self.dev_pref+':ECLDEL3')
+        sb_dacclock = SiriusSpinbox(self, self.dev_pref+':ECLDEL3')
         sb_dacclock.showStepExponent = False
         fr_dacclock = SiriusFrame(self, self.dev_pref+':ECLDEL3_SUBWR')
         fr_dacclock.add_widget(sb_dacclock)
@@ -107,7 +107,7 @@ class BbBGeneralSettingsWidget(QWidget):
         cb_fidlvlenbl = PyDMEnumComboBox(
             self, self.dev_pref+':LEVEL_FID_ENABLE')
         cb_fidlvlenbl.setStyleSheet('max-width:3em;')
-        sb_fidv = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH9')
+        sb_fidv = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH9')
         sb_fidv.showStepExponent = False
         sb_fidv.showUnits = True
         fr_fidv = SiriusFrame(self, self.dev_pref+':AD5644CH9_SUBWR')
@@ -118,7 +118,7 @@ class BbBGeneralSettingsWidget(QWidget):
         cb_trg1lvlenbl = PyDMEnumComboBox(
             self, self.dev_pref+':LEVEL_TRIG1_ENABLE')
         cb_trg1lvlenbl.setStyleSheet('max-width:3em;')
-        sb_trg1lvlv = PyDMSpinbox(self, self.dev_pref+':LEVEL_VTRIG1')
+        sb_trg1lvlv = SiriusSpinbox(self, self.dev_pref+':LEVEL_VTRIG1')
         sb_trg1lvlv.showStepExponent = False
         sb_trg1lvlv.showUnits = True
         fr_trg1lvlv = SiriusFrame(
@@ -132,7 +132,7 @@ class BbBGeneralSettingsWidget(QWidget):
         cb_trg2lvlenbl = PyDMEnumComboBox(
             self, self.dev_pref+':LEVEL_TRIG2_ENABLE')
         cb_trg2lvlenbl.setStyleSheet('max-width:3em;')
-        sb_trg2lvlv = PyDMSpinbox(self, self.dev_pref+':LEVEL_VTRIG2')
+        sb_trg2lvlv = SiriusSpinbox(self, self.dev_pref+':LEVEL_VTRIG2')
         sb_trg2lvlv.showStepExponent = False
         sb_trg2lvlv.showUnits = True
         fr_trg2lvlv = SiriusFrame(self, self.dev_pref+':AD5644CH8_SUBWR')
@@ -141,7 +141,7 @@ class BbBGeneralSettingsWidget(QWidget):
         cb_trg2edge.setStyleSheet('max-width:3.2em;')
 
         ld_dacoff = QLabel('DAC Offset', self)
-        sb_dacoff = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH11')
+        sb_dacoff = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH11')
         sb_dacoff.showStepExponent = False
         sb_dacoff.showUnits = True
         fr_dacoff = SiriusFrame(self, self.dev_pref+':AD5644CH11_SUBWR')
@@ -179,13 +179,13 @@ class BbBGeneralSettingsWidget(QWidget):
         ld_sfir = QLabel('Shaper FIR ([C0 2^17 C2])', self)
 
         ld_firc0 = QLabel('C0', self)
-        sb_firc0 = PyDMSpinbox(self, self.dev_pref+':SHAPE_C0')
+        sb_firc0 = SiriusSpinbox(self, self.dev_pref+':SHAPE_C0')
         sb_firc0.showStepExponent = False
         fr_firc0 = SiriusFrame(self, self.dev_pref+':SHAPE_C0_SUBWR')
         fr_firc0.add_widget(sb_firc0)
 
         ld_firc2 = QLabel('C2', self)
-        sb_firc2 = PyDMSpinbox(self, self.dev_pref+':SHAPE_C2')
+        sb_firc2 = SiriusSpinbox(self, self.dev_pref+':SHAPE_C2')
         sb_firc2.showStepExponent = False
         fr_firc2 = SiriusFrame(self, self.dev_pref+':SHAPE_C2_SUBWR')
         fr_firc2.add_widget(sb_firc2)
@@ -231,7 +231,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch0 = QLabel('0', self, alignment=Qt.AlignCenter)
         ld_dacch0.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch0 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH0')
+        sb_dacch0 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH0')
         sb_dacch0.showStepExponent = False
         sb_dacch0.showUnits = True
         fr_dacch0 = SiriusFrame(self, self.dev_pref+':AD5644CH0_SUBWR')
@@ -239,7 +239,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch1 = QLabel('1', self, alignment=Qt.AlignCenter)
         ld_dacch1.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch1 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH1')
+        sb_dacch1 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH1')
         sb_dacch1.showStepExponent = False
         sb_dacch1.showUnits = True
         fr_dacch1 = SiriusFrame(self, self.dev_pref+':AD5644CH1_SUBWR')
@@ -247,7 +247,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch2 = QLabel('2', self, alignment=Qt.AlignCenter)
         ld_dacch2.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch2 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH2')
+        sb_dacch2 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH2')
         sb_dacch2.showStepExponent = False
         sb_dacch2.showUnits = True
         fr_dacch2 = SiriusFrame(self, self.dev_pref+':AD5644CH2_SUBWR')
@@ -255,7 +255,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch3 = QLabel('3', self, alignment=Qt.AlignCenter)
         ld_dacch3.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch3 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH3')
+        sb_dacch3 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH3')
         sb_dacch3.showStepExponent = False
         sb_dacch3.showUnits = True
         fr_dacch3 = SiriusFrame(self, self.dev_pref+':AD5644CH3_SUBWR')
@@ -267,7 +267,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch4 = QLabel('4', self, alignment=Qt.AlignCenter)
         ld_dacch4.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch4 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH4')
+        sb_dacch4 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH4')
         sb_dacch4.showStepExponent = False
         sb_dacch4.showUnits = True
         fr_dacch4 = SiriusFrame(self, self.dev_pref+':AD5644CH4_SUBWR')
@@ -275,7 +275,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch5 = QLabel('5', self, alignment=Qt.AlignCenter)
         ld_dacch5.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch5 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH5')
+        sb_dacch5 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH5')
         sb_dacch5.showStepExponent = False
         sb_dacch5.showUnits = True
         fr_dacch5 = SiriusFrame(self, self.dev_pref+':AD5644CH5_SUBWR')
@@ -283,7 +283,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch6 = QLabel('6', self, alignment=Qt.AlignCenter)
         ld_dacch6.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch6 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH6')
+        sb_dacch6 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH6')
         sb_dacch6.showStepExponent = False
         sb_dacch6.showUnits = True
         fr_dacch6 = SiriusFrame(self, self.dev_pref+':AD5644CH6_SUBWR')
@@ -291,7 +291,7 @@ class BbBSlowDACsWidget(QWidget):
 
         ld_dacch7 = QLabel('7', self, alignment=Qt.AlignCenter)
         ld_dacch7.setStyleSheet('font-weight: bold; max-width: 3em;')
-        sb_dacch7 = PyDMSpinbox(self, self.dev_pref+':AD5644_V_CH7')
+        sb_dacch7 = SiriusSpinbox(self, self.dev_pref+':AD5644_V_CH7')
         sb_dacch7.showStepExponent = False
         sb_dacch7.showUnits = True
         fr_dacch7 = SiriusFrame(self, self.dev_pref+':AD5644CH7_SUBWR')
@@ -448,14 +448,14 @@ class BbBInterlock(QWidget):
         # ld_cyc.setStyleSheet('font-weight: bold; max-width: 3em;')
 
         ld_sat = QLabel('Saturation Time', self)
-        sb_sat = PyDMSpinbox(self, self.dev_pref+':ILOCK_TSAT')
+        sb_sat = SiriusSpinbox(self, self.dev_pref+':ILOCK_TSAT')
         sb_sat.showStepExponent = False
         sb_sat.showUnits = True
         lb_sat = SiriusLabel(self, self.dev_pref+':ILOCK_TSAT_T2C')
         lb_sat.setAlignment(Qt.AlignCenter)
 
         ld_tim = QLabel('Timeout', self)
-        sb_tim = PyDMSpinbox(self, self.dev_pref+':ILOCK_TOUT')
+        sb_tim = SiriusSpinbox(self, self.dev_pref+':ILOCK_TOUT')
         sb_tim.showStepExponent = False
         sb_tim.showUnits = True
         lb_tim = SiriusLabel(self, self.dev_pref+':ILOCK_TOUT_T2C')
@@ -486,27 +486,27 @@ class BbBInterlock(QWidget):
             '<h3>Sensitivity Controls</h3>', self, alignment=Qt.AlignCenter)
 
         ld_tun = QLabel('Fractional Tune', self)
-        sb_tun = PyDMSpinbox(self, self.dev_pref+':ILOCK_TUNE')
+        sb_tun = SiriusSpinbox(self, self.dev_pref+':ILOCK_TUNE')
         sb_tun.showStepExponent = False
         sb_tun.showUnits = True
 
         ld_tap = QLabel('Filter Taps', self)
-        sb_tap = PyDMSpinbox(self, self.dev_pref+':ILOCK_TAPS')
+        sb_tap = SiriusSpinbox(self, self.dev_pref+':ILOCK_TAPS')
         sb_tap.showStepExponent = False
         sb_tap.showUnits = True
 
         ld_cal = QLabel('Calibration', self)
-        sb_cal = PyDMSpinbox(self, self.dev_pref+':ILOCK_FE_CAL')
+        sb_cal = SiriusSpinbox(self, self.dev_pref+':ILOCK_FE_CAL')
         sb_cal.showStepExponent = False
         sb_cal.showUnits = True
 
         ld_ncur = QLabel('Nominal Current', self)
-        sb_ncur = PyDMSpinbox(self, self.dev_pref+':ILOCK_CURRENT')
+        sb_ncur = SiriusSpinbox(self, self.dev_pref+':ILOCK_CURRENT')
         sb_ncur.showStepExponent = False
         sb_ncur.showUnits = True
 
         ld_thr = QLabel('Threshold', self)
-        sb_thr = PyDMSpinbox(self, self.dev_pref+':ILOCK_THRESH')
+        sb_thr = SiriusSpinbox(self, self.dev_pref+':ILOCK_THRESH')
         sb_thr.showStepExponent = False
         sb_thr.showUnits = True
 

--- a/pyqt-apps/siriushla/si_di_bbb/bbb.py
+++ b/pyqt-apps/siriushla/si_di_bbb/bbb.py
@@ -158,15 +158,12 @@ class BbBMainSettingsWidget(QWidget):
 
         ld_sftgain = QLabel('Shift Gain', self)
         sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
-        sb_sftgain.showStepExponent = False
 
         ld_downspl = QLabel('Downsampling', self)
         sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
-        sb_downspl.showStepExponent = False
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
         sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
-        sb_satthrs.showStepExponent = False
 
         lay = QGridLayout()
         lay.addWidget(ld_fbenbl, 1, 0)

--- a/pyqt-apps/siriushla/si_di_bbb/bbb.py
+++ b/pyqt-apps/siriushla/si_di_bbb/bbb.py
@@ -4,7 +4,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, \
     QGroupBox, QSpacerItem, QSizePolicy as QSzPlcy, QPushButton, QHBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
+from pydm.widgets import PyDMEnumComboBox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
@@ -12,7 +12,8 @@ from siriuspy.namesys import SiriusPVName as _PVName
 from ..util import connect_window, connect_newprocess
 from ..widgets.windows import create_window_from_widget
 from ..widgets import SiriusMainWindow, SiriusLedAlert, PyDMStateButton, \
-    PyDMLedMultiChannel, DetachableTabWidget, SiriusLabel, SiriusPushButton
+    PyDMLedMultiChannel, DetachableTabWidget, SiriusLabel, SiriusPushButton, \
+    SiriusSpinbox
 
 from .acquisition import BbBAcqSRAM, BbBAcqBRAM, BbBAcqSB
 from .coefficients import BbBCoefficientsWidget
@@ -156,15 +157,15 @@ class BbBMainSettingsWidget(QWidget):
         cb_coefsel = PyDMEnumComboBox(self, self.dev_pref+':SETSEL')
 
         ld_sftgain = QLabel('Shift Gain', self)
-        sb_sftgain = PyDMSpinbox(self, self.dev_pref+':SHIFTGAIN')
+        sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
         sb_sftgain.showStepExponent = False
 
         ld_downspl = QLabel('Downsampling', self)
-        sb_downspl = PyDMSpinbox(self, self.dev_pref+':PROC_DS')
+        sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
         sb_downspl.showStepExponent = False
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
-        sb_satthrs = PyDMSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
+        sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
         sb_satthrs.showStepExponent = False
 
         lay = QGridLayout()

--- a/pyqt-apps/siriushla/si_di_bbb/coefficients.py
+++ b/pyqt-apps/siriushla/si_di_bbb/coefficients.py
@@ -5,14 +5,13 @@ from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, QTabWidget
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, \
-    PyDMLineEdit, PyDMPushButton
+from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit, PyDMPushButton
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
 from ..widgets import SiriusLedAlert, SiriusLabel, PyDMStateButton, \
-    SiriusLedState
+    SiriusLedState, SiriusSpinbox
 from .custom_widgets import WfmGraph
 from .util import set_bbb_color
 
@@ -98,7 +97,7 @@ class BbBCoefficientsWidget(QWidget):
             '<h4> Marker:</h4>', wid, alignment=Qt.AlignLeft | Qt.AlignVCenter)
         ld_ftval = QLabel(
             'Frequency [0-1]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        sb_ftval = PyDMSpinbox(wid, self.dev_pref+':FTF_TUNE')
+        sb_ftval = SiriusSpinbox(wid, self.dev_pref+':FTF_TUNE')
         sb_ftval.showStepExponent = False
         ld_ftgain = QLabel(
             'Gain [dB]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
@@ -156,18 +155,18 @@ class BbBCoefficientsWidget(QWidget):
             '<h4>Generate Coefficients</h4>', self, alignment=Qt.AlignCenter)
         ld_gengain = QLabel(
             'Gain [0-1]', self, alignment=Qt.AlignRight)
-        sb_gengain = PyDMSpinbox(self, self.dev_pref+':FLT_GAIN')
+        sb_gengain = SiriusSpinbox(self, self.dev_pref+':FLT_GAIN')
         sb_gengain.showStepExponent = False
         ld_genphs = QLabel('Phase [°]', self, alignment=Qt.AlignRight)
-        sb_genphs = PyDMSpinbox(self, self.dev_pref+':FLT_PHASE')
+        sb_genphs = SiriusSpinbox(self, self.dev_pref+':FLT_PHASE')
         sb_genphs.showStepExponent = False
         ld_genfreq = QLabel(
             'Frequency [0-1]', self, alignment=Qt.AlignRight)
-        sb_genfreq = PyDMSpinbox(self, self.dev_pref+':FLT_FREQ')
+        sb_genfreq = SiriusSpinbox(self, self.dev_pref+':FLT_FREQ')
         sb_genfreq.showStepExponent = False
         ld_genntap = QLabel(
             'Number of taps', self, alignment=Qt.AlignRight)
-        sb_genntap = PyDMSpinbox(self, self.dev_pref+':FLT_TAPS')
+        sb_genntap = SiriusSpinbox(self, self.dev_pref+':FLT_TAPS')
         sb_genntap.showStepExponent = False
 
         wid = QWidget(self)
@@ -215,15 +214,15 @@ class BbBCoefficientsWidget(QWidget):
         cb_coefsel = PyDMEnumComboBox(self, self.dev_pref+':SETSEL')
 
         ld_sftgain = QLabel('Shift Gain', self)
-        sb_sftgain = PyDMSpinbox(self, self.dev_pref+':SHIFTGAIN')
+        sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
         sb_sftgain.showStepExponent = False
 
         ld_downspl = QLabel('Downsampling', self)
-        sb_downspl = PyDMSpinbox(self, self.dev_pref+':PROC_DS')
+        sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
         sb_downspl.showStepExponent = False
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
-        sb_satthrs = PyDMSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
+        sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
         sb_satthrs.showStepExponent = False
 
         lay_patt = QGridLayout()
@@ -261,12 +260,12 @@ class BbBCoefficientsWidget(QWidget):
         cb_bcenbl = PyDMStateButton(self, self.dev_pref+':CLEAN_ENABLE')
 
         ld_bcamp = QLabel('Amplitude', self)
-        sb_bcamp = PyDMSpinbox(self, self.dev_pref+':CLEAN_AMPL')
+        sb_bcamp = SiriusSpinbox(self, self.dev_pref+':CLEAN_AMPL')
         sb_bcamp.showStepExponent = False
         lb_svamp = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_AMPL')
 
         ld_bctune = QLabel('Tune', self)
-        sb_bctune = PyDMSpinbox(self, self.dev_pref+':CLEAN_TUNE')
+        sb_bctune = SiriusSpinbox(self, self.dev_pref+':CLEAN_TUNE')
         sb_bctune.showStepExponent = False
         lb_svfreq = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_FREQ')
 

--- a/pyqt-apps/siriushla/si_di_bbb/coefficients.py
+++ b/pyqt-apps/siriushla/si_di_bbb/coefficients.py
@@ -98,7 +98,6 @@ class BbBCoefficientsWidget(QWidget):
         ld_ftval = QLabel(
             'Frequency [0-1]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
         sb_ftval = SiriusSpinbox(wid, self.dev_pref+':FTF_TUNE')
-        sb_ftval.showStepExponent = False
         ld_ftgain = QLabel(
             'Gain [dB]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
         lb_ftgain = Label(wid, self.dev_pref+':FTF_GTUNE')
@@ -156,18 +155,14 @@ class BbBCoefficientsWidget(QWidget):
         ld_gengain = QLabel(
             'Gain [0-1]', self, alignment=Qt.AlignRight)
         sb_gengain = SiriusSpinbox(self, self.dev_pref+':FLT_GAIN')
-        sb_gengain.showStepExponent = False
         ld_genphs = QLabel('Phase [°]', self, alignment=Qt.AlignRight)
         sb_genphs = SiriusSpinbox(self, self.dev_pref+':FLT_PHASE')
-        sb_genphs.showStepExponent = False
         ld_genfreq = QLabel(
             'Frequency [0-1]', self, alignment=Qt.AlignRight)
         sb_genfreq = SiriusSpinbox(self, self.dev_pref+':FLT_FREQ')
-        sb_genfreq.showStepExponent = False
         ld_genntap = QLabel(
             'Number of taps', self, alignment=Qt.AlignRight)
         sb_genntap = SiriusSpinbox(self, self.dev_pref+':FLT_TAPS')
-        sb_genntap.showStepExponent = False
 
         wid = QWidget(self)
         lay_genset = QGridLayout(wid)
@@ -215,15 +210,12 @@ class BbBCoefficientsWidget(QWidget):
 
         ld_sftgain = QLabel('Shift Gain', self)
         sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
-        sb_sftgain.showStepExponent = False
 
         ld_downspl = QLabel('Downsampling', self)
         sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
-        sb_downspl.showStepExponent = False
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
         sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
-        sb_satthrs.showStepExponent = False
 
         lay_patt = QGridLayout()
         lay_patt.addWidget(ld_fbpatt, 0, 0)
@@ -261,12 +253,10 @@ class BbBCoefficientsWidget(QWidget):
 
         ld_bcamp = QLabel('Amplitude', self)
         sb_bcamp = SiriusSpinbox(self, self.dev_pref+':CLEAN_AMPL')
-        sb_bcamp.showStepExponent = False
         lb_svamp = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_AMPL')
 
         ld_bctune = QLabel('Tune', self)
         sb_bctune = SiriusSpinbox(self, self.dev_pref+':CLEAN_TUNE')
-        sb_bctune.showStepExponent = False
         lb_svfreq = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_FREQ')
 
         ld_bcspan = QLabel('Span', self)

--- a/pyqt-apps/siriushla/si_di_bbb/drive.py
+++ b/pyqt-apps/siriushla/si_di_bbb/drive.py
@@ -57,11 +57,9 @@ class BbBSingleDriveSettingsWidget(QWidget):
 
         ld_amp = QLabel('Amplitude', self)
         sb_amp = SiriusSpinbox(self, self.dev_pref+'AMPL')
-        sb_amp.showStepExponent = False
 
         ld_freq = QLabel('Frequency', self)
         sb_freq = SiriusSpinbox(self, self.dev_pref+'FREQ')
-        sb_freq.showStepExponent = False
 
         ld_wav = QLabel('Waveform', self)
         cb_wav = PyDMEnumComboBox(self, self.dev_pref+'WAVEFORM')
@@ -71,11 +69,9 @@ class BbBSingleDriveSettingsWidget(QWidget):
 
         ld_span = QLabel('Span', self)
         sb_span = SiriusSpinbox(self, self.dev_pref+'SPAN')
-        sb_span.showStepExponent = False
 
         ld_perd = QLabel('Period', self)
         sb_perd = SiriusSpinbox(self, self.dev_pref+'PERIOD')
-        sb_perd.showStepExponent = False
 
         ld_patt = QLabel('Drive Pattern', self)
         le_patt = PyDMLineEdit(self, self.dev_pref+'PATTERN')

--- a/pyqt-apps/siriushla/si_di_bbb/drive.py
+++ b/pyqt-apps/siriushla/si_di_bbb/drive.py
@@ -6,12 +6,12 @@ from qtpy.QtGui import QPixmap, QColor
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QSpacerItem, \
     QHBoxLayout
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox, PyDMLineEdit
+from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import PyDMStateButton, SiriusFrame, SiriusLabel
+from ..widgets import PyDMStateButton, SiriusFrame, SiriusLabel, SiriusSpinbox
 
 from .util import set_bbb_color
 from .custom_widgets import WfmGraph
@@ -56,11 +56,11 @@ class BbBSingleDriveSettingsWidget(QWidget):
             ld_drive.layout().addStretch()
 
         ld_amp = QLabel('Amplitude', self)
-        sb_amp = PyDMSpinbox(self, self.dev_pref+'AMPL')
+        sb_amp = SiriusSpinbox(self, self.dev_pref+'AMPL')
         sb_amp.showStepExponent = False
 
         ld_freq = QLabel('Frequency', self)
-        sb_freq = PyDMSpinbox(self, self.dev_pref+'FREQ')
+        sb_freq = SiriusSpinbox(self, self.dev_pref+'FREQ')
         sb_freq.showStepExponent = False
 
         ld_wav = QLabel('Waveform', self)
@@ -70,11 +70,11 @@ class BbBSingleDriveSettingsWidget(QWidget):
         cb_tmod = PyDMStateButton(self, self.dev_pref+'MOD')
 
         ld_span = QLabel('Span', self)
-        sb_span = PyDMSpinbox(self, self.dev_pref+'SPAN')
+        sb_span = SiriusSpinbox(self, self.dev_pref+'SPAN')
         sb_span.showStepExponent = False
 
         ld_perd = QLabel('Period', self)
-        sb_perd = PyDMSpinbox(self, self.dev_pref+'PERIOD')
+        sb_perd = SiriusSpinbox(self, self.dev_pref+'PERIOD')
         sb_perd.showStepExponent = False
 
         ld_patt = QLabel('Drive Pattern', self)

--- a/pyqt-apps/siriushla/si_di_bbb/gpio.py
+++ b/pyqt-apps/siriushla/si_di_bbb/gpio.py
@@ -3,12 +3,12 @@
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, \
     QHBoxLayout, QVBoxLayout
-from pydm.widgets import PyDMSpinbox, PyDMEnumComboBox
+from pydm.widgets import PyDMEnumComboBox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import PyDMStateButton, SiriusLabel
+from ..widgets import PyDMStateButton, SiriusLabel, SiriusSpinbox
 
 from .custom_widgets import MyScaleIndicator
 
@@ -62,28 +62,28 @@ class BbBGPIOWidget(QWidget):
     def _setupFrontBackEndRegsWidget(self):
         # # Front/back end registers
         ld_gpiohph = QLabel('Horiz. Phase', self)
-        sb_gpiohph = PyDMSpinbox(self, self.dev_pref+':FBELT_X_PHASE_SETPT')
+        sb_gpiohph = SiriusSpinbox(self, self.dev_pref+':FBELT_X_PHASE_SETPT')
         sb_gpiohph.showStepExponent = False
         ld_gpiohat = QLabel('Horiz. Atten.', self)
-        sb_gpiohat = PyDMSpinbox(self, self.dev_pref+':FBE_X_ATT')
+        sb_gpiohat = SiriusSpinbox(self, self.dev_pref+':FBE_X_ATT')
         sb_gpiohat.showStepExponent = False
         ld_gpiovph = QLabel('Vert. Phase', self)
-        sb_gpiovph = PyDMSpinbox(self, self.dev_pref+':FBELT_Y_PHASE_SETPT')
+        sb_gpiovph = SiriusSpinbox(self, self.dev_pref+':FBELT_Y_PHASE_SETPT')
         sb_gpiovph.showStepExponent = False
         ld_gpiovat = QLabel('Vert. Atten.', self)
-        sb_gpiovat = PyDMSpinbox(self, self.dev_pref+':FBE_Y_ATT')
+        sb_gpiovat = SiriusSpinbox(self, self.dev_pref+':FBE_Y_ATT')
         sb_gpiovat.showStepExponent = False
         ld_gpiolph = QLabel('Long. Phase', self)
-        sb_gpiolph = PyDMSpinbox(self, self.dev_pref+':FBELT_SERVO_SETPT')
+        sb_gpiolph = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_SETPT')
         sb_gpiolph.showStepExponent = False
         ld_gpiolat = QLabel('Long. Atten.', self)
-        sb_gpiolat = PyDMSpinbox(self, self.dev_pref+':FBE_Z_ATT')
+        sb_gpiolat = SiriusSpinbox(self, self.dev_pref+':FBE_Z_ATT')
         sb_gpiolat.showStepExponent = False
         ld_gpiobeph = QLabel('Back-end Phase', self)
-        sb_gpiobeph = PyDMSpinbox(self, self.dev_pref+':FBE_BE_PHASE')
+        sb_gpiobeph = SiriusSpinbox(self, self.dev_pref+':FBE_BE_PHASE')
         sb_gpiobeph.showStepExponent = False
         ld_gpiobeat = QLabel('Back-end Atten.', self)
-        sb_gpiobeat = PyDMSpinbox(self, self.dev_pref+':FBE_BE_ATT')
+        sb_gpiobeat = SiriusSpinbox(self, self.dev_pref+':FBE_BE_ATT')
         sb_gpiobeat.showStepExponent = False
         # # Phases
         ld_gpiophss = QLabel('<h4>Phases</h4>', self, alignment=Qt.AlignCenter)
@@ -134,11 +134,11 @@ class BbBGPIOWidget(QWidget):
             self, self.dev_pref+':FBELT_SERVO_SIGN')
 
         ld_gpiogain = QLabel('Gain', self)
-        sb_gpiogain = PyDMSpinbox(self, self.dev_pref+':FBELT_SERVO_GAIN')
+        sb_gpiogain = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_GAIN')
         sb_gpiogain.showStepExponent = False
 
         ld_gpiooff = QLabel('Offset', self)
-        sb_gpiooff = PyDMSpinbox(self, self.dev_pref+':FBELT_SERVO_OFFSET')
+        sb_gpiooff = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_OFFSET')
         sb_gpiooff.showStepExponent = False
 
         ld_gpiohtrk = QLabel('Hor. Trk.', self)
@@ -214,7 +214,7 @@ class BbBGPIOWidget(QWidget):
         lb_gpiofanspd.showUnits = True
 
         ld_gpiotempsp = QLabel('Temperature Setpoint', self)
-        sb_gpiotempsp = PyDMSpinbox(self, self.dev_pref+':FBELT_FAN_SETPT')
+        sb_gpiotempsp = SiriusSpinbox(self, self.dev_pref+':FBELT_FAN_SETPT')
         sb_gpiotempsp.showStepExponent = False
 
         gbox_fbe = QGroupBox('Fan Control', self)
@@ -242,7 +242,7 @@ class BbBGPIOWidget(QWidget):
             self, self.dev_pref+':FBELT_SERVO_DELTA')
         ld_gpioservomax = QLabel(
             '<h4>Max</h4>', self, alignment=Qt.AlignCenter)
-        sb_gpioservomax = PyDMSpinbox(
+        sb_gpioservomax = SiriusSpinbox(
             self, self.dev_pref+':FBELT_SERVO_MAXDELTA')
         sb_gpioservomax.showStepExponent = False
 

--- a/pyqt-apps/siriushla/si_di_bbb/gpio.py
+++ b/pyqt-apps/siriushla/si_di_bbb/gpio.py
@@ -63,28 +63,20 @@ class BbBGPIOWidget(QWidget):
         # # Front/back end registers
         ld_gpiohph = QLabel('Horiz. Phase', self)
         sb_gpiohph = SiriusSpinbox(self, self.dev_pref+':FBELT_X_PHASE_SETPT')
-        sb_gpiohph.showStepExponent = False
         ld_gpiohat = QLabel('Horiz. Atten.', self)
         sb_gpiohat = SiriusSpinbox(self, self.dev_pref+':FBE_X_ATT')
-        sb_gpiohat.showStepExponent = False
         ld_gpiovph = QLabel('Vert. Phase', self)
         sb_gpiovph = SiriusSpinbox(self, self.dev_pref+':FBELT_Y_PHASE_SETPT')
-        sb_gpiovph.showStepExponent = False
         ld_gpiovat = QLabel('Vert. Atten.', self)
         sb_gpiovat = SiriusSpinbox(self, self.dev_pref+':FBE_Y_ATT')
-        sb_gpiovat.showStepExponent = False
         ld_gpiolph = QLabel('Long. Phase', self)
         sb_gpiolph = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_SETPT')
-        sb_gpiolph.showStepExponent = False
         ld_gpiolat = QLabel('Long. Atten.', self)
         sb_gpiolat = SiriusSpinbox(self, self.dev_pref+':FBE_Z_ATT')
-        sb_gpiolat.showStepExponent = False
         ld_gpiobeph = QLabel('Back-end Phase', self)
         sb_gpiobeph = SiriusSpinbox(self, self.dev_pref+':FBE_BE_PHASE')
-        sb_gpiobeph.showStepExponent = False
         ld_gpiobeat = QLabel('Back-end Atten.', self)
         sb_gpiobeat = SiriusSpinbox(self, self.dev_pref+':FBE_BE_ATT')
-        sb_gpiobeat.showStepExponent = False
         # # Phases
         ld_gpiophss = QLabel('<h4>Phases</h4>', self, alignment=Qt.AlignCenter)
         lb_gpiohph = SiriusLabel(self, self.dev_pref+':FBE_X_PHASE')
@@ -135,11 +127,9 @@ class BbBGPIOWidget(QWidget):
 
         ld_gpiogain = QLabel('Gain', self)
         sb_gpiogain = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_GAIN')
-        sb_gpiogain.showStepExponent = False
 
         ld_gpiooff = QLabel('Offset', self)
         sb_gpiooff = SiriusSpinbox(self, self.dev_pref+':FBELT_SERVO_OFFSET')
-        sb_gpiooff.showStepExponent = False
 
         ld_gpiohtrk = QLabel('Hor. Trk.', self)
         cb_gpiohtrk = PyDMStateButton(
@@ -215,7 +205,6 @@ class BbBGPIOWidget(QWidget):
 
         ld_gpiotempsp = QLabel('Temperature Setpoint', self)
         sb_gpiotempsp = SiriusSpinbox(self, self.dev_pref+':FBELT_FAN_SETPT')
-        sb_gpiotempsp.showStepExponent = False
 
         gbox_fbe = QGroupBox('Fan Control', self)
         lay_fbe = QGridLayout(gbox_fbe)
@@ -244,7 +233,6 @@ class BbBGPIOWidget(QWidget):
             '<h4>Max</h4>', self, alignment=Qt.AlignCenter)
         sb_gpioservomax = SiriusSpinbox(
             self, self.dev_pref+':FBELT_SERVO_MAXDELTA')
-        sb_gpioservomax.showStepExponent = False
 
         gbox_phsout = QGroupBox('Phase Servo Output', self)
         lay_phsout = QGridLayout(gbox_phsout)

--- a/pyqt-apps/siriushla/si_di_bbb/pwr_amps.py
+++ b/pyqt-apps/siriushla/si_di_bbb/pwr_amps.py
@@ -306,12 +306,10 @@ class BbBPwrAmpsWidget(QWidget):
 
         ld_gain_db = QLabel('Gain [dB]', self)
         sp_gain_db = SiriusSpinbox(self, pref+':Gain-SP')
-        sp_gain_db.showStepExponent = False
         lb_gain_db = SiriusLabel(self, init_channel=pref+':Gain-RB')
 
         ld_gain_st = QLabel('Gain [steps]', self)
         sp_gain_st = SiriusSpinbox(self, pref+':GainStep-SP')
-        sp_gain_st.showStepExponent = False
         lb_gain_st = SiriusLabel(self, init_channel=pref+':GainStep-RB')
 
         wid = QWidget()

--- a/pyqt-apps/siriushla/si_di_bbb/timing.py
+++ b/pyqt-apps/siriushla/si_di_bbb/timing.py
@@ -32,13 +32,10 @@ class BbBTimingWidget(QWidget):
         # Feedback Timing
         ld_adcdelay = QLabel('ADC Delay [ps]', self)
         sb_adcdelay = SiriusSpinbox(self, self.dev_pref+':TADC')
-        sb_adcdelay.showStepExponent = False
         ld_dacdelay = QLabel('DAC Delay [ps]', self)
         sb_dacdelay = SiriusSpinbox(self, self.dev_pref+':TDAC')
-        sb_dacdelay.showStepExponent = False
         ld_outdelay = QLabel('Output Delay', self)
         sb_outdelay = SiriusSpinbox(self, self.dev_pref+':DELAY')
-        sb_outdelay.showStepExponent = False
 
         gbox_fbti = QGroupBox('Feedback Timing', self)
         lay_fbti = QGridLayout(gbox_fbti)
@@ -61,13 +58,11 @@ class BbBTimingWidget(QWidget):
 
         ld_fidsigoff = QLabel('FID Signal Offset [ps]', self)
         sb_fidsigoff = SiriusSpinbox(self, self.dev_pref+':OFF_FIDS')
-        sb_fidsigoff.showStepExponent = False
         sb_fidsigoff.limitsFromChannel = False
         sb_fidsigoff.setMinimum(0)
         sb_fidsigoff.setMaximum(3000)
         ld_fiddelay = QLabel('Fiducial Delay', self)
         sb_fiddelay = SiriusSpinbox(self, self.dev_pref+':FID_DELAY')
-        sb_fiddelay.showStepExponent = False
         fr_fiddelay = SiriusFrame(self, self.dev_pref+':FID_DELAY_SUBWR')
         fr_fiddelay.add_widget(sb_fiddelay)
 

--- a/pyqt-apps/siriushla/si_di_bbb/timing.py
+++ b/pyqt-apps/siriushla/si_di_bbb/timing.py
@@ -4,12 +4,12 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, \
     QGroupBox
 import qtawesome as qta
-from pydm.widgets import PyDMSpinbox
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import SiriusFrame, SiriusSpinbox, SiriusLabel, SiriusPushButton
+from ..widgets import SiriusFrame, SiriusSpinbox, SiriusLabel, \
+    SiriusPushButton, SiriusSpinbox
 from .util import set_bbb_color
 
 
@@ -31,13 +31,13 @@ class BbBTimingWidget(QWidget):
 
         # Feedback Timing
         ld_adcdelay = QLabel('ADC Delay [ps]', self)
-        sb_adcdelay = PyDMSpinbox(self, self.dev_pref+':TADC')
+        sb_adcdelay = SiriusSpinbox(self, self.dev_pref+':TADC')
         sb_adcdelay.showStepExponent = False
         ld_dacdelay = QLabel('DAC Delay [ps]', self)
-        sb_dacdelay = PyDMSpinbox(self, self.dev_pref+':TDAC')
+        sb_dacdelay = SiriusSpinbox(self, self.dev_pref+':TDAC')
         sb_dacdelay.showStepExponent = False
         ld_outdelay = QLabel('Output Delay', self)
-        sb_outdelay = PyDMSpinbox(self, self.dev_pref+':DELAY')
+        sb_outdelay = SiriusSpinbox(self, self.dev_pref+':DELAY')
         sb_outdelay.showStepExponent = False
 
         gbox_fbti = QGroupBox('Feedback Timing', self)
@@ -66,7 +66,7 @@ class BbBTimingWidget(QWidget):
         sb_fidsigoff.setMinimum(0)
         sb_fidsigoff.setMaximum(3000)
         ld_fiddelay = QLabel('Fiducial Delay', self)
-        sb_fiddelay = PyDMSpinbox(self, self.dev_pref+':FID_DELAY')
+        sb_fiddelay = SiriusSpinbox(self, self.dev_pref+':FID_DELAY')
         sb_fiddelay.showStepExponent = False
         fr_fiddelay = SiriusFrame(self, self.dev_pref+':FID_DELAY_SUBWR')
         fr_fiddelay.add_widget(sb_fiddelay)

--- a/pyqt-apps/siriushla/si_id_control/apu_control.py
+++ b/pyqt-apps/siriushla/si_id_control/apu_control.py
@@ -5,7 +5,7 @@ from qtpy.QtWidgets import QWidget, QGroupBox, QGridLayout, QLabel, \
     QHBoxLayout, QSizePolicy as QSzPlcy, QSpacerItem, QPushButton, \
     QVBoxLayout
 import qtawesome as qta
-from pydm.widgets import PyDMPushButton, PyDMSpinbox
+from pydm.widgets import PyDMPushButton
 
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
@@ -13,7 +13,8 @@ from siriuspy.search import IDSearch
 
 from siriushla.util import connect_window, connect_newprocess
 from siriushla.widgets import SiriusMainWindow, PyDMLed, SiriusLedAlert, \
-    SiriusLedState, PyDMLedMultiChannel, PyDMStateButton, SiriusLabel
+    SiriusLedState, PyDMLedMultiChannel, PyDMStateButton, SiriusLabel, \
+    SiriusSpinbox
 
 from .auxiliary_dialogs import APUAlarmDetails, APUInterlockDetails, \
     APUHardLLDetails
@@ -63,21 +64,21 @@ class APUControlWindow(SiriusMainWindow):
 
     def _mainControlsWidget(self):
         self._ld_phs = QLabel('Phase [mm]', self)
-        self._sb_phs = PyDMSpinbox(
+        self._sb_phs = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Phase-SP'))
         self._sb_phs.showStepExponent = False
         self._lb_phs = SiriusLabel(
             self, self.dev_pref.substitute(propty='Phase-Mon'))
 
         self._ld_kx = QLabel('Kx', self)
-        self._sb_kx = PyDMSpinbox(
+        self._sb_kx = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Kx-SP'))
         self._sb_kx.showStepExponent = False
         self._lb_kx = SiriusLabel(
             self, self.dev_pref.substitute(propty='Kx-Mon'))
 
         self._ld_phsspd = QLabel('Phase Speed\n[mm/s]', self)
-        self._sb_phsspd = PyDMSpinbox(
+        self._sb_phsspd = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
         self._sb_phsspd.showStepExponent = False
         self._lb_phsspd = SiriusLabel(
@@ -239,7 +240,7 @@ class APUControlWindow(SiriusMainWindow):
 
     def _auxCommandsWidget(self):
         self._ld_speedlim = QLabel('Max Phase Speed\n[mm/s]', self)
-        self._sb_speedlim = PyDMSpinbox(
+        self._sb_speedlim = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='MaxPhaseSpeed-SP'))
         self._sb_speedlim.showStepExponent = False
         self._sb_speedlim.setStyleSheet('max-width:4.5em;')
@@ -363,19 +364,19 @@ class APUSummaryWidget(APUSummaryBase):
             self._pb_dev,
             ['sirius-hla-si-id-control.py', '-dev', self._device])
 
-        self._sb_phs = PyDMSpinbox(
+        self._sb_phs = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Phase-SP'))
         self._sb_phs.showStepExponent = False
         self._lb_phs = SiriusLabel(
             self, self.dev_pref.substitute(propty='Phase-Mon'))
 
-        self._sb_kx = PyDMSpinbox(
+        self._sb_kx = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Kx-SP'))
         self._sb_kx.showStepExponent = False
         self._lb_kx = SiriusLabel(
             self, self.dev_pref.substitute(propty='Kx-Mon'))
 
-        self._sb_phsspd = PyDMSpinbox(
+        self._sb_phsspd = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
         self._sb_phsspd.showStepExponent = False
         self._lb_phsspd = SiriusLabel(

--- a/pyqt-apps/siriushla/si_id_control/apu_control.py
+++ b/pyqt-apps/siriushla/si_id_control/apu_control.py
@@ -66,21 +66,18 @@ class APUControlWindow(SiriusMainWindow):
         self._ld_phs = QLabel('Phase [mm]', self)
         self._sb_phs = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Phase-SP'))
-        self._sb_phs.showStepExponent = False
         self._lb_phs = SiriusLabel(
             self, self.dev_pref.substitute(propty='Phase-Mon'))
 
         self._ld_kx = QLabel('Kx', self)
         self._sb_kx = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Kx-SP'))
-        self._sb_kx.showStepExponent = False
         self._lb_kx = SiriusLabel(
             self, self.dev_pref.substitute(propty='Kx-Mon'))
 
         self._ld_phsspd = QLabel('Phase Speed\n[mm/s]', self)
         self._sb_phsspd = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
-        self._sb_phsspd.showStepExponent = False
         self._lb_phsspd = SiriusLabel(
             self, self.dev_pref.substitute(propty='PhaseSpeed-Mon'))
 
@@ -242,7 +239,6 @@ class APUControlWindow(SiriusMainWindow):
         self._ld_speedlim = QLabel('Max Phase Speed\n[mm/s]', self)
         self._sb_speedlim = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='MaxPhaseSpeed-SP'))
-        self._sb_speedlim.showStepExponent = False
         self._sb_speedlim.setStyleSheet('max-width:4.5em;')
         self._lb_speedlim = SiriusLabel(
             self, self.dev_pref.substitute(propty='MaxPhaseSpeed-RB'))
@@ -366,19 +362,16 @@ class APUSummaryWidget(APUSummaryBase):
 
         self._sb_phs = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Phase-SP'))
-        self._sb_phs.showStepExponent = False
         self._lb_phs = SiriusLabel(
             self, self.dev_pref.substitute(propty='Phase-Mon'))
 
         self._sb_kx = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='Kx-SP'))
-        self._sb_kx.showStepExponent = False
         self._lb_kx = SiriusLabel(
             self, self.dev_pref.substitute(propty='Kx-Mon'))
 
         self._sb_phsspd = SiriusSpinbox(
             self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
-        self._sb_phsspd.showStepExponent = False
         self._lb_phsspd = SiriusLabel(
             self, self.dev_pref.substitute(propty='PhaseSpeed-Mon'))
 

--- a/pyqt-apps/siriushla/widgets/process_image.py
+++ b/pyqt-apps/siriushla/widgets/process_image.py
@@ -104,7 +104,6 @@ class SiriusProcessImage(QWidget):
         nrpt_ld = QLabel('Num. Pts.', gb_pos)
         nrpt_sp = SiriusSpinbox(
             gb_pos, init_channel=self._dev+':NrAverages-SP')
-        nrpt_sp.showStepExponent = False
         rdb = SiriusLabel(gb_pos, init_channel=self._dev+':NrAverages-RB')
         rdb.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
         slsh = QLabel('/', gb_pos, alignment=Qt.AlignCenter)
@@ -128,12 +127,10 @@ class SiriusProcessImage(QWidget):
         hbl.addWidget(rdb)
 
         rsx_sp = SiriusSpinbox(gb_pos, init_channel=self._dev+':ROISizeX-SP')
-        rsx_sp.showStepExponent = False
         rsx_lb = SiriusLabel(gb_pos, init_channel=self._dev+':ROISizeX-RB')
         rsx_ld = QLabel('ROI Size X', gb_pos)
 
         rsy_sp = SiriusSpinbox(gb_pos, init_channel=self._dev+':ROISizeY-SP')
-        rsy_sp.showStepExponent = False
         rsy_lb = SiriusLabel(gb_pos, init_channel=self._dev+':ROISizeY-RB')
         rsy_ld = QLabel('ROI Size Y', gb_pos)
 
@@ -144,12 +141,10 @@ class SiriusProcessImage(QWidget):
         ra_ld = QLabel('Auto Center:', gb_pos)
 
         rcx_sp = SiriusSpinbox(gb_pos, init_channel=self._dev+':ROICenterX-SP')
-        rcx_sp.showStepExponent = False
         rcx_lb = SiriusLabel(gb_pos, init_channel=self._dev+':ROICenterX-RB')
         rcx_ld = QLabel('ROI Center X', gb_pos)
 
         rcy_sp = SiriusSpinbox(gb_pos, init_channel=self._dev+':ROICenterY-SP')
-        rcy_sp.showStepExponent = False
         rcy_lb = SiriusLabel(gb_pos, init_channel=self._dev+':ROICenterY-RB')
         rcy_ld = QLabel('ROI Center Y', gb_pos)
 
@@ -374,7 +369,6 @@ class _DetailedWidget(QWidget):
         wid.setLayout(QHBoxLayout())
         spnbox = SiriusSpinbox(wid, init_channel=self._dev+':ImgCropLow-SP')
         lbl = SiriusLabel(wid, init_channel=self._dev+':ImgCropLow-RB')
-        spnbox.showStepExponent = False
         wid.layout().addWidget(spnbox)
         wid.layout().addWidget(lbl)
         self.layout().addRow(QLabel(
@@ -393,7 +387,6 @@ class _DetailedWidget(QWidget):
         wid.setLayout(QHBoxLayout())
         spnbox = SiriusSpinbox(wid, init_channel=self._dev+':ImgCropHigh-SP')
         lbl = SiriusLabel(wid, init_channel=self._dev+':ImgCropHigh-RB')
-        spnbox.showStepExponent = False
         wid.layout().addWidget(spnbox)
         wid.layout().addWidget(lbl)
         self.layout().addRow(QLabel(
@@ -404,7 +397,6 @@ class _DetailedWidget(QWidget):
         if self._conv_set:
             spb = SiriusSpinbox(wid, init_channel=self._dev+':Px2mmScaleX-SP')
             lbl = SiriusLabel(wid, init_channel=self._dev+':Px2mmScaleX-RB')
-            spb.showStepExponent = False
             wid.layout().addWidget(spb)
             wid.layout().addWidget(lbl)
         else:
@@ -418,7 +410,6 @@ class _DetailedWidget(QWidget):
         if self._conv_set:
             spb = SiriusSpinbox(wid, init_channel=self._dev+':Px2mmScaleY-SP')
             lbl = SiriusLabel(wid, init_channel=self._dev+':Px2mmScaleY-RB')
-            spb.showStepExponent = False
             wid.layout().addWidget(spb)
             wid.layout().addWidget(lbl)
         else:
@@ -442,7 +433,6 @@ class _DetailedWidget(QWidget):
         wid.setLayout(QHBoxLayout())
         spnbox = SiriusSpinbox(wid, init_channel=self._dev+':Px2mmCenterX-SP')
         lbl = SiriusLabel(wid, init_channel=self._dev+':Px2mmCenterX-RB')
-        spnbox.showStepExponent = False
         wid.layout().addWidget(spnbox)
         wid.layout().addWidget(lbl)
         self.layout().addRow(QLabel(
@@ -452,7 +442,6 @@ class _DetailedWidget(QWidget):
         wid.setLayout(QHBoxLayout())
         spnbox = SiriusSpinbox(wid, init_channel=self._dev+':Px2mmCenterY-SP')
         lbl = SiriusLabel(wid, init_channel=self._dev+':Px2mmCenterY-RB')
-        spnbox.showStepExponent = False
         wid.layout().addWidget(spnbox)
         wid.layout().addWidget(lbl)
         self.layout().addRow(QLabel(

--- a/pyqt-apps/siriushla/widgets/spinbox.py
+++ b/pyqt-apps/siriushla/widgets/spinbox.py
@@ -22,6 +22,7 @@ class SiriusSpinbox(PyDMSpinbox):
         self._limits_from_channel = True
         self._user_lower_limit = self.minimum()
         self._user_upper_limit = self.maximum()
+        self.showStepExponent = False
         self.setFocusPolicy(Qt.StrongFocus)
 
     def ctrl_limit_changed(self, which, new_limit):

--- a/pyqt-apps/siriushla/widgets/spinbox_scrollbar.py
+++ b/pyqt-apps/siriushla/widgets/spinbox_scrollbar.py
@@ -21,7 +21,6 @@ class PyDMSpinboxScrollbar(QWidget):
         self.spinbox = SiriusSpinbox(
             parent=self, init_channel=init_channel)
         self.spinbox.setAlignment(Qt.AlignCenter)
-        self.spinbox.showStepExponent = False
         self.spinbox.setStyleSheet("SiriusSpinbox{min-height:1.29em;}")
         self.spinbox.setSizePolicy(QSzPol.Expanding, QSzPol.Preferred)
 


### PR DESCRIPTION
 - Remove usage of PyDMSpinbox, replacing it with `SiriusSpinbox`.
 - Make property `showStepExponent = False` by default in `SiriusSpinbox`.

This PR should be merged after #569.