### PR TITLE
Fix Bug in LI-LLRF

### DIFF
--- a/pyqt-apps/siriushla/li_rf_llrf/widgets.py
+++ b/pyqt-apps/siriushla/li_rf_llrf/widgets.py
@@ -238,7 +238,6 @@ class GraphTime(QWidget):
             y_channel=chname,
             name='Data',
             color='black',
-            redraw_mode=2,
             lineStyle=1,
             lineWidth=3,
             symbol='o',


### PR DESCRIPTION
Remove `redraw_mode` from options, which is not allowed for `SiriusTimePlot`.

This bug was probably created here: 4f3aaf0f7611e9cee87697dfb6dd9cdf6c3adf0a

![image](https://user-images.githubusercontent.com/5638331/204573720-9ce55755-c198-4864-a9d2-bed398a2d33f.png)
