### PR TITLE
Improvements and fixes 

### DIFF
--- a/pyqt-apps/siriushla/as_ap_launcher/menu.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/menu.py
@@ -158,6 +158,10 @@ def get_object(ismenubar=True, parent=None):
             util.connect_newprocess(
                 lidiict, ['gvncviewer', Scopes.LI_DI_ICTOSC],
                 is_window=False)
+            lipumodltr = QAction('LI-PU-MODLTR', osci)
+            util.connect_newprocess(
+                lipumodltr, ['gvncviewer', Scopes.LI_PU_OSC_MODLTR],
+                is_window=False)
             tbpuinjbo = QAction('TB-PU-InjBO', osci)
             util.connect_newprocess(
                 tbpuinjbo, ['gvncviewer', Scopes.TB_PU_OSC_INJBO],
@@ -178,6 +182,7 @@ def get_object(ismenubar=True, parent=None):
             osci.addAction(asdifctdig)
             osci.addAction(asdifpmdig)
             osci.addAction(lidiict)
+            osci.addAction(lipumodltr)
             osci.addAction(tbpuinjbo)
             osci.addAction(tspuejebo)
             osci.addAction(tspuinjsi)

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/base.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/base.py
@@ -4,7 +4,7 @@ from functools import partial as _part
 import numpy as _np
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QWidget, QHBoxLayout, QSizePolicy, QComboBox, \
-    QLabel, QVBoxLayout
+    QLabel, QVBoxLayout, QPushButton
 from pydm.widgets import PyDMEnumComboBox
 from pydm.widgets.base import PyDMPrimitiveWidget
 from siriuspy.namesys import SiriusPVName as _PVName
@@ -50,7 +50,8 @@ class BaseWidget(BaseObject, QWidget):
         QWidget.__init__(self, parent)
         self.setObjectName(acc.upper()+'App')
 
-    def create_pair(self, parent, pvname, device=None, is_vert=False):
+    def create_pair(
+            self, parent, pvname, device=None, is_vert=False, rules=None):
         """."""
         device = device or self.device
         basename = _PVName(device).substitute(
@@ -62,6 +63,8 @@ class BaseWidget(BaseObject, QWidget):
             lay = QHBoxLayout(wid)
         lay.setContentsMargins(0, 0, 0, 0)
         pdm_spbx = SiriusSpinbox(wid, basename.substitute(propty_suffix='SP'))
+        if rules is not None:
+            pdm_spbx.rules = rules
         pdm_lbl = SiriusLabel(wid, basename.substitute(propty_suffix='RB'))
         pdm_lbl.setAlignment(Qt.AlignCenter)
         lay.addWidget(pdm_spbx)
@@ -70,7 +73,8 @@ class BaseWidget(BaseObject, QWidget):
         wid.rb_wid = pdm_lbl
         return wid
 
-    def create_pair_sel(self, parent, pvname, device=None, is_vert=False):
+    def create_pair_sel(
+            self, parent, pvname, device=None, is_vert=False, rules=None):
         """."""
         device = device or self.device
         basename = _PVName(device).substitute(
@@ -83,6 +87,8 @@ class BaseWidget(BaseObject, QWidget):
         lay.setContentsMargins(0, 0, 0, 0)
         pdm_cbbx = PyDMEnumComboBox(
             wid, basename.substitute(propty_suffix='Sel'))
+        if rules is not None:
+            pdm_cbbx.rules = rules
         pdm_lbl = SiriusLabel(wid, basename.substitute(propty_suffix='Sts'))
         pdm_lbl.setAlignment(Qt.AlignCenter)
         lay.addWidget(pdm_cbbx)
@@ -91,7 +97,8 @@ class BaseWidget(BaseObject, QWidget):
         wid.rb_wid = pdm_lbl
         return wid
 
-    def create_pair_butled(self, parent, pvname, device=None, is_vert=False):
+    def create_pair_butled(
+            self, parent, pvname, device=None, is_vert=False, rules=None):
         """."""
         device = device or self.device
         basename = _PVName(device).substitute(
@@ -103,6 +110,8 @@ class BaseWidget(BaseObject, QWidget):
             lay = QHBoxLayout(wid)
         lay.setContentsMargins(0, 0, 0, 0)
         spnt = PyDMStateButton(wid, basename.substitute(propty_suffix='Sel'))
+        if rules is not None:
+            spnt.rules = rules
         rdb = SiriusLedState(wid, basename.substitute(propty_suffix='Sts'))
         lay.addWidget(spnt)
         lay.addWidget(rdb)
@@ -237,4 +246,8 @@ class BaseCombo(QComboBox, PyDMPrimitiveWidget):
 
 
 class CALabel(QLabel, PyDMPrimitiveWidget):
-    """."""
+    """QLabel with rules."""
+
+
+class CAPushButton(QPushButton, PyDMPrimitiveWidget):
+    """QPushButton with rules."""

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
@@ -78,18 +78,18 @@ class KicksConfigWidget(BaseWidget):
         gdl.addWidget(syn_wid, 0, 0)
 
         pssofb_grp = QGroupBox('PSSOFB', det_wid)
-        enbl_lbl = QLabel('Enable:', pssofb_grp)
-        enbl_wid = self.create_pair_butled(pssofb_grp, 'CorrPSSOFBEnbl')
-        enbl_wid.layout().setContentsMargins(0, 0, 0, 0)
         wait_lbl = QLabel('Wait:', pssofb_grp)
         wait_wid = self.create_pair_butled(pssofb_grp, 'CorrPSSOFBWait')
         wait_wid.layout().setContentsMargins(0, 0, 0, 0)
+        enbl_lbl = QLabel('Enable:', pssofb_grp)
+        enbl_wid = self.create_pair_butled(pssofb_grp, 'CorrPSSOFBEnbl')
+        enbl_wid.layout().setContentsMargins(0, 0, 0, 0)
         gdl = QGridLayout(pssofb_grp)
         gdl.setSpacing(1)
-        gdl.addWidget(enbl_lbl, 0, 0)
-        gdl.addWidget(wait_lbl, 1, 0)
-        gdl.addWidget(enbl_wid, 0, 1)
-        gdl.addWidget(wait_wid, 1, 1)
+        gdl.addWidget(wait_lbl, 0, 0)
+        gdl.addWidget(wait_wid, 0, 1)
+        gdl.addWidget(enbl_lbl, 1, 0)
+        gdl.addWidget(enbl_wid, 1, 1)
 
         del_grp = QGroupBox('Trigger Delay', det_wid)
         del_wid = self.create_pair(
@@ -111,9 +111,9 @@ class KicksConfigWidget(BaseWidget):
         del_lay.addWidget(del_det)
         del_lay.addStretch()
 
-        det_lay.addWidget(pssofb_grp, 0, 0)
-        det_lay.addWidget(syn_grp, 0, 2)
-        det_lay.addWidget(del_grp, 2, 0, 1, 3)
+        det_lay.addWidget(syn_grp, 0, 0)
+        det_lay.addWidget(pssofb_grp, 0, 2)
+        det_lay.addWidget(del_grp, 1, 0, 1, 3)
         det_lay.setColumnStretch(1, 10)
         det_lay.setRowStretch(1, 10)
         return det_wid

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
@@ -123,6 +123,12 @@ class KicksConfigWidget(BaseWidget):
         conf = PyDMPushButton(
             parent, pressValue=1,
             init_channel=self.devpref.substitute(propty='CorrConfig-Cmd'))
+        rules = (
+            '[{"name": "EnblRule", "property": "Enable", ' +
+            '"expression": "not ch[0]", "channels": [{"channel": "' +
+            self.devpref.substitute(propty='LoopState-Sts') +
+            '", "trigger": true}]}]')
+        conf.rules = rules
         conf.setToolTip('Refresh Configurations')
         conf.setIcon(qta.icon('fa5s.sync'))
         conf.setObjectName('conf')

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -271,21 +271,22 @@ class SOFBControl(BaseWidget):
         wid = QWidget(parent)
         wid.setObjectName('grp')
         gdl = QGridLayout(wid)
-        gdl.setSpacing(9)
+        gdl.setAlignment(Qt.AlignTop)
 
-        gdl.setColumnStretch(0, 2)
+        headers = [
+            'Description', 'Setpoint', 'Status', 'Monitor', '%']
+        for col, text in enumerate(headers):
+            lbl = QLabel(text, wid, alignment=Qt.AlignHCenter)
+            lbl.setStyleSheet('QLabel{max-height: 1.2em;}')
+            gdl.addWidget(lbl, 0, col)
 
-        gdl.addWidget(QLabel('Description', wid), 0, 0)
-        gdl.addWidget(QLabel('Setpoint', wid), 0, 1)
-        gdl.addWidget(QLabel('Status', wid), 0, 2)
-        gdl.addWidget(QLabel('Monitor', wid), 0, 3)
-        gdl.addWidget(QLabel('%', wid), 0, 4, alignment=Qt.AlignCenter)
         props = [
             'FOFBDownloadKicks', 'FOFBUpdateRefOrb',
             'FOFBNullSpaceProj', 'FOFBZeroDistortionAtBPMs']
         desc = [
             'Download Kicks', 'Update RefOrb',
             'Project in Kernel', 'Zero Distortion']
+        vislist = list()
         for i, (prop, des) in enumerate(zip(props, desc)):
             lbl = QLabel(des, wid)
             spt = PyDMStateButton(
@@ -294,32 +295,37 @@ class SOFBControl(BaseWidget):
                 wid, self.devpref.substitute(propty=prop+'-Sts'))
             mon = SiriusLedState(
                 wid, self.devpref.substitute(propty=prop+'-Mon'))
+            wids = [lbl, spt, rdb, mon]
             gdl.addWidget(lbl, i+1, 0)
             gdl.addWidget(spt, i+1, 1)
             gdl.addWidget(rdb, i+1, 2)
             gdl.addWidget(mon, i+1, 3)
+            if prop in ['FOFBDownloadKicks', 'FOFBUpdateRefOrb']:
+                sbp = SiriusSpinbox(
+                    wid, self.devpref.substitute(propty=prop+'Perc-SP'))
+                rbp = SiriusLabel(
+                    wid, self.devpref.substitute(propty=prop+'Perc-RB'))
+                rbp.showUnits = False
+                gdl2 = QGridLayout()
+                gdl2.setContentsMargins(0, 0, 0, 0)
+                gdl2.addWidget(sbp, 0, 0)
+                gdl2.addWidget(rbp, 1, 0)
+                gdl.addLayout(gdl2, i+1, 4)
+                wids.extend([sbp, rbp])
+            if prop != 'FOFBDownloadKicks':
+                vislist.extend(wids)
+                for w in wids:
+                    w.setVisible(False)
 
-        spb = SiriusSpinbox(
-            wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-SP'))
-        lbl = SiriusLabel(
-            wid, self.devpref.substitute(propty='FOFBDownloadKicksPerc-RB'))
-        lbl.showUnits = False
-        gdl2 = QGridLayout()
-        gdl2.addWidget(spb, 0, 0)
-        gdl2.addWidget(lbl, 1, 0)
-        gdl.addLayout(gdl2, 1, 4)
+        btmore = QPushButton(qta.icon('fa5s.angle-down'), '', self)
+        btmore.setToolTip('Show advanced SOFB <-> FOFB interaction options')
+        btmore.setStyleSheet(
+            'QPushButton{max-height:0.8em; max-width:1.6em;}')
+        btmore.clicked.connect(self._handle_fofb_options_vis)
+        btmore.visItems = vislist
+        btmore.setFlat(True)
+        gdl.addWidget(btmore, 5, 0, alignment=Qt.AlignLeft)
 
-        spb = SiriusSpinbox(
-            wid, self.devpref.substitute(propty='FOFBUpdateRefOrbPerc-SP'))
-        lbl = SiriusLabel(
-            wid, self.devpref.substitute(propty='FOFBUpdateRefOrbPerc-RB'))
-        lbl.showUnits = False
-        gdl2 = QGridLayout()
-        gdl2.addWidget(spb, 0, 0)
-        gdl2.addWidget(lbl, 1, 0)
-        gdl.addLayout(gdl2, 2, 4)
-
-        gdl.setRowStretch(5, 3)
         return wid
 
     def get_manual_correction_widget(self, parent):
@@ -511,6 +517,21 @@ class SOFBControl(BaseWidget):
             pbc.toggled.connect(pair.sp_wid.setHidden)
         gpbx_lay.setRowStretch(4, 2)
         return auto_wid
+
+    def _handle_fofb_options_vis(self):
+        btn = self.sender()
+        tooltip = btn.toolTip()
+        vis = 'Hide' in tooltip
+        if vis:
+            tooltip = tooltip.replace('Hide', 'Show')
+        else:
+            tooltip = tooltip.replace('Show', 'Hide')
+        iconname = 'fa5s.angle-down' if vis else 'fa5s.angle-up'
+        btn.setIcon(qta.icon(iconname))
+        btn.setToolTip(tooltip)
+        for item in btn.visItems:
+            item.setVisible(not vis)
+        self.adjustSize()
 
 
 class RefControl(BaseCombo):

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -257,8 +257,9 @@ class SOFBControl(BaseWidget):
             parent, self.device, prefix=self.prefix, acc=self.acc)
         corr_tab.addTab(kicks_wid, 'Kicks')
 
-        fofb_wid = self.get_fofb_widget(corr_tab)
-        corr_tab.addTab(fofb_wid, 'FOFB')
+        if self.acc == 'SI':
+            fofb_wid = self.get_fofb_widget(corr_tab)
+            corr_tab.addTab(fofb_wid, 'FOFB')
 
         if self.acc != 'BO':
             hbl = kicks_wid.get_status_widget(corr_wid)

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/main.py
@@ -77,6 +77,12 @@ class SOFBControl(BaseWidget):
 
     def get_orbit_widget(self, parent):
         """."""
+        rules = (
+            '[{"name": "EnblRule", "property": "Enable", ' +
+            '"expression": "not ch[0]", "channels": [{"channel": "' +
+            self.devpref.substitute(propty='LoopState-Sts') +
+            '", "trigger": true}]}]')
+
         orb_wid = QWidget(parent)
         orb_wid.setObjectName('grp')
         orb_wid.setStyleSheet('#grp{min-height: 11em; max-height: 15em;}')
@@ -85,6 +91,7 @@ class SOFBControl(BaseWidget):
         conf = PyDMPushButton(
             orb_wid, pressValue=1,
             init_channel=self.devpref.substitute(propty='TrigAcqConfig-Cmd'))
+        conf.rules = rules
         conf.setToolTip('Refresh Configurations')
         conf.setIcon(qta.icon('fa5s.sync'))
         conf.setObjectName('conf')
@@ -119,13 +126,14 @@ class SOFBControl(BaseWidget):
         orb_wid.layout().addLayout(hbl, 0, 0, 1, 2)
 
         lbl = QLabel('SOFB Mode', orb_wid)
-        wid = self.create_pair_sel(orb_wid, 'SOFBMode')
+        wid = self.create_pair_sel(orb_wid, 'SOFBMode', rules=rules)
         orb_wid.layout().addWidget(lbl, 1, 0, alignment=Qt.AlignVCenter)
         orb_wid.layout().addWidget(wid, 1, 1)
 
         lbl = QLabel('RefOrb:', orb_wid)
         combo = RefControl(
             self, self.device, self.ctrls, prefix=self.prefix, acc=self.acc)
+        combo.rules = rules
         lbl2 = QLabel('', orb_wid)
         combo.configname.connect(lbl2.setText)
         vbl_ref = QVBoxLayout()
@@ -175,7 +183,7 @@ class SOFBControl(BaseWidget):
         combo = OfflineOrbControl(
             grp_bx, self.device, self.ctrls, prefix=self.prefix, acc=self.acc)
         rules = (
-            '[{"name": "EnblRule", "property": "Visible", ' +
+            '[{"name": "VisRule", "property": "Visible", ' +
             '"expression": "not ch[0]", "channels": [{"channel": "' +
             self.devpref.substitute(propty='SOFBMode-Sts') +
             '", "trigger": true}]}]')
@@ -186,15 +194,20 @@ class SOFBControl(BaseWidget):
         fbl.addRow(lbl, combo)
         grp_bx.layout().addStretch()
 
+        rules = (
+            '[{"name": "EnblRule", "property": "Enable", ' +
+            '"expression": "not ch[0]", "channels": [{"channel": "' +
+            self.devpref.substitute(propty='LoopState-Sts') +
+            '", "trigger": true}]}]')
         hbl = QHBoxLayout()
         grp_bx.layout().addLayout(hbl)
         fbl = QFormLayout()
         hbl.addLayout(fbl)
         lbl = QLabel('Orbit [Hz]', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair(grp_bx, 'OrbAcqRate')
+        wid = self.create_pair(grp_bx, 'OrbAcqRate', rules=rules)
         fbl.addRow(lbl, wid)
         lbl = QLabel('Kicks [Hz]', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair(grp_bx, 'KickAcqRate')
+        wid = self.create_pair(grp_bx, 'KickAcqRate', rules=rules)
         fbl.addRow(lbl, wid)
 
         wid = QWidget(grp_bx)
@@ -209,6 +222,7 @@ class SOFBControl(BaseWidget):
         vbl.addLayout(hbl)
         spt = PyDMStateButton(
             wid, self.devpref.substitute(propty='SyncWithInjection-Sel'))
+        spt.rules = rules
         rdb = SiriusLedState(
             wid, self.devpref.substitute(propty='SyncWithInjection-Sts'))
         hbl.addWidget(spt)
@@ -218,11 +232,11 @@ class SOFBControl(BaseWidget):
         fbl = QFormLayout()
         grp_bx.layout().addLayout(fbl)
         lbl = QLabel('Smooth Method', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_sel(grp_bx, 'SmoothMethod')
+        wid = self.create_pair_sel(grp_bx, 'SmoothMethod', rules=rules)
         fbl.addRow(lbl, wid)
         if self.isring:
             lbl = QLabel('Extend Ring', grp_bx, alignment=Qt.AlignCenter)
-            wid = self.create_pair(grp_bx, 'RingSize')
+            wid = self.create_pair(grp_bx, 'RingSize', rules=rules)
             fbl.addRow(lbl, wid)
 
         return grp_bx

--- a/pyqt-apps/siriushla/si_ap_fofb/main.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/main.py
@@ -212,6 +212,34 @@ class MainWindow(BaseObject, SiriusMainWindow):
         return wid
 
     def _setupAuxCommWidget(self):
+        ld_orbdist = QLabel(
+            'Orbit Dist. Detec.: ', self,
+            alignment=Qt.AlignRight | Qt.AlignVCenter)
+        sb_orbdist = PyDMStateButton(
+            self, self.devpref.substitute(
+                propty='LoopMaxOrbDistortionEnbl-Sel'))
+        lb_orbdist = SiriusLedState(
+            self, self.devpref.substitute(
+                propty='LoopMaxOrbDistortionEnbl-Sts'))
+
+        btn_corrzero = PyDMPushButton(
+            self, label='Set Correctors current to zero', pressValue=1,
+            init_channel=self.devpref.substitute(propty='CorrSetCurrZero-Cmd'))
+        btn_corrzero.setDefault(False)
+        btn_corrzero.setAutoDefault(False)
+
+        wid = QGroupBox('Aux. Commands')
+        lay = QGridLayout(wid)
+        lay.addWidget(btn_corrzero, 0, 0, 1, 3)
+        lay.addWidget(ld_orbdist, 1, 0)
+        lay.addWidget(sb_orbdist, 1, 1)
+        lay.addWidget(lb_orbdist, 1, 2)
+        lay.setColumnStretch(0, 2)
+        lay.setColumnStretch(1, 1)
+        lay.setColumnStretch(2, 1)
+        return wid
+
+    def _setupDetailsWidget(self):
         group2cmd = {
             'Correctors': {
                 'Set all current to zero': 'CorrSetCurrZero-Cmd',
@@ -346,27 +374,30 @@ class MainWindow(BaseObject, SiriusMainWindow):
         # tab main
         self.status = self._setupStatusWidget()
 
+        self.loop = self._setupLoopWidget()
+
+        self.auxcmd = self._setupAuxCommWidget()
+
         self.reforb = self._setupRefOrbWidget()
 
         self.respmat = RespMatWidget(self, self.device, self.prefix)
-
-        self.loop = self._setupLoopWidget()
 
         maintab = QWidget()
         lay = QVBoxLayout(maintab)
         lay.addWidget(self.status)
         lay.addWidget(self.loop)
+        lay.addWidget(self.auxcmd)
         lay.addWidget(self.reforb)
         lay.addWidget(self.respmat)
         self.controltabs.addTab(maintab, 'Main')
 
         # tab aux
-        self.auxcmd = self._setupAuxCommWidget()
+        self.details = self._setupDetailsWidget()
 
-        auxtab = QWidget()
-        lay = QVBoxLayout(auxtab)
-        lay.addWidget(self.auxcmd)
-        self.controltabs.addTab(auxtab, 'Auxiliary commands')
+        dettab = QWidget()
+        lay = QVBoxLayout(dettab)
+        lay.addWidget(self.details)
+        self.controltabs.addTab(dettab, 'Details')
 
         wid = QWidget()
         lay = QVBoxLayout(wid)

--- a/pyqt-apps/siriushla/si_ap_fofb/main.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/main.py
@@ -2,7 +2,7 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QPushButton, QWidget, QGridLayout, QMenu, \
-    QLabel, QVBoxLayout, QGroupBox, QMenuBar, QAction, QHBoxLayout, \
+    QLabel, QVBoxLayout, QGroupBox, QMenuBar, QAction, \
     QSizePolicy as QSzPlcy, QDockWidget, QTabWidget
 import qtawesome as qta
 
@@ -137,6 +137,15 @@ class MainWindow(BaseObject, SiriusMainWindow):
             sts_ctrl, StatusDialog, parent=self, pvname=pvname, labels=labels,
             cmds=cmds, title='FOFB Controller Status', detail_button=dtl_ctrl)
 
+        cnf_ctrl = PyDMPushButton(
+            self, pressValue=1,
+            init_channel=self.devpref.substitute(propty='CtrlrReset-Cmd'))
+        cnf_ctrl.setToolTip('Send Reset command to controllers')
+        cnf_ctrl.setIcon(qta.icon('fa5s.sync'))
+        cnf_ctrl.setObjectName('conf')
+        cnf_ctrl.setStyleSheet(
+            '#conf{min-width:25px; max-width:25px; icon-size:20px;}')
+
         wid = QGroupBox('Status')
         lay = QGridLayout(wid)
         lay.setAlignment(Qt.AlignCenter)
@@ -147,6 +156,7 @@ class MainWindow(BaseObject, SiriusMainWindow):
         lay.addWidget(lbl_ctrl, 1, 0)
         lay.addWidget(led_ctrl, 1, 1)
         lay.addWidget(sts_ctrl, 1, 2)
+        lay.addWidget(cnf_ctrl, 1, 3)
         return wid
 
     def _setupRefOrbWidget(self):

--- a/pyqt-apps/siriushla/si_ap_fofb/respmat.py
+++ b/pyqt-apps/siriushla/si_ap_fofb/respmat.py
@@ -21,6 +21,7 @@ from ..widgets import SiriusConnectionSignal as _ConnSignal, \
 from ..as_ap_sofb.ioc_control.respmat import RespMatWidget as _RespMatWidget
 from ..as_ap_sofb.ioc_control.respmat_enbllist import \
     SingleSelMatrix as _SingleSelMatrix
+from ..as_ap_sofb.ioc_control.base import CAPushButton
 
 from .base import BaseObject, BaseWidget, get_fofb_icon
 from .graphics import CorrGainWidget
@@ -32,6 +33,11 @@ class RespMatWidget(_RespMatWidget, BaseWidget):
     def __init__(self, parent, device, prefix=''):
         BaseWidget.__init__(self, parent, device, prefix=prefix)
         self.setWindowTitle('SI - FOFB')
+        self._enblrule = (
+            '[{"name": "EnblRule", "property": "Enable", ' +
+            '"expression": "not ch[0]", "channels": [{"channel": "' +
+            self.devpref.substitute(propty='LoopState-Sts') +
+            '", "trigger": true}]}]')
         self.setupui()
         self.layout().setContentsMargins(0, 0, 0, 0)
         self._config_type = 'si_fastorbcorr_respm'
@@ -59,6 +65,7 @@ class RespMatWidget(_RespMatWidget, BaseWidget):
         norm_gp = QGroupBox('Norm.Mode')
         pdm_cbb = SiriusEnumComboBox(
             self, self.devpref.substitute(propty='InvRespMatNormMode-Sel'))
+        pdm_cbb.rules = self._enblrule
         pdm_lbl = SiriusLabel(
             self, self.devpref.substitute(propty='InvRespMatNormMode-Sts'))
         nlay = QHBoxLayout(norm_gp)
@@ -85,7 +92,8 @@ class RespMatWidget(_RespMatWidget, BaseWidget):
         icon = get_fofb_icon()
         window = create_window_from_widget(
             SelectionMatrix, title='Corrs and BPMs selection', icon=icon)
-        btn = QPushButton('', sel_wid)
+        btn = CAPushButton('', sel_wid)
+        btn.rules = self._enblrule
         btn.setObjectName('btn')
         btn.setIcon(qta.icon('fa5s.tasks'))
         btn.setToolTip('Open window to select BPMs and correctors')
@@ -98,6 +106,7 @@ class RespMatWidget(_RespMatWidget, BaseWidget):
 
         pdm_chbx = PyDMCheckbox(
             sel_wid, self.devpref.substitute(propty='UseRF-Sel'))
+        pdm_chbx.rules = self._enblrule
         pdm_chbx.setText('use RF')
         pdm_led = SiriusLedState(
             sel_wid, self.devpref.substitute(propty='UseRF-Sts'))

--- a/pyqt-apps/siriushla/si_id_control/epu.py
+++ b/pyqt-apps/siriushla/si_id_control/epu.py
@@ -213,7 +213,7 @@ class EPUControlWindow(IDCommonControlWindow):
         ld_pwrenbl = QLabel('Enable All Drives Power', self)
         pvname = self.dev_pref.substitute(propty='EnblPwrAll-Cmd')
         pb_pwrenbl = PyDMPushButton(
-            parent=self,  label='', icon=qta.icon('fa5s.plug'),
+            parent=self, label='', icon=qta.icon('fa5s.plug'),
             init_channel=pvname, pressValue=1)
         pb_pwrenbl.setObjectName('btn')
         pb_pwrenbl.setStyleSheet(
@@ -222,10 +222,23 @@ class EPUControlWindow(IDCommonControlWindow):
             self.dev_pref.substitute(propty='PwrPhase-Mon'): 1,
             self.dev_pref.substitute(propty='PwrGap-Mon'): 1}
         led_pwrsts = PyDMLedMultiChannel(self, channels2values=c2v)
-
         lay.addWidget(ld_pwrenbl, row, 0)
         lay.addWidget(pb_pwrenbl, row, 1)
         lay.addWidget(led_pwrsts, row, 2, alignment=Qt.AlignLeft)
+        row += 1
+
+        ld_clrerr = QLabel('Clear Drive Errors', self)
+        pvname = self.dev_pref.substitute(propty='ClearErr-Cmd')
+        pb_clrerr = PyDMPushButton(
+            parent=self, label='', icon=qta.icon('fa5s.sync'),
+            init_channel=pvname, pressValue=1)
+        pb_clrerr.setObjectName('btn')
+        pb_clrerr.setStyleSheet(
+            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+        lay.addWidget(ld_clrerr, row, 0)
+        lay.addWidget(pb_clrerr, row, 1)
+        row += 1
+
         gbox.setStyleSheet(
             '.QLabel{qproperty-alignment: "AlignRight | AlignVCenter";}')
         return gbox
@@ -372,6 +385,7 @@ class EPUDriveDetails(IDCommonDialog):
             pvname = self.dev_pref.substitute(
                 propty='Drive'+drive+'DiagMsg-Mon')
             lb_diagmsg = SiriusLabel(self, pvname)
+            lb_diagmsg.displayFormat = lb_diagmsg.DisplayFormat.String
 
             pvname = self.dev_pref.substitute(
                 propty='Drive'+drive+'Moving-Mon')


### PR DESCRIPTION
Hi guys, this PR implements improvements and fixes that were pointed during last machine studies:
- EPU window:
  -  fixes DiagMsg label formatting and add new PV ClearErr-Cmd
- SOFB windows:
  - changes order of commands in Kicks Details tab to make order more user friendly
  - improves bump window in orbit register: show confirmation popup when current is above 10mA and show only 10 items in subsection combobox
  - removes FOFB tab in other accelerators than SI
  - defines loop state based enable rules in orbit and matrix settings
- FOFB window:
  - adds button to reset controllers in main tab
  - defines loop state based enable rules in matrix settings
  - improves RefOrbWidget: removes "Send" button and add response status icon
  - adds Aux.Commands group in main control tab and renames "Auxiliary commands" tab to "Details"