### PR TITLE
Adapt SOFB Interface

### DIFF
--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/base.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/base.py
@@ -472,7 +472,7 @@ class UpdateGraph(QObject):
             'ref': {
                 'x': _part(self._update_vectors, 'ref', 'x'),
                 'y': _part(self._update_vectors, 'ref', 'y')}}
-        nbpms = self._csorb.nr_bpms * self._csorb.MAX_RINGSZ
+        nbpms = self._csorb.nr_bpms
         szx = nbpms if self.is_orb else self._csorb.nr_ch
         szy = nbpms if self.is_orb else self._csorb.nr_cv
         self.vectors = {

--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/orbit.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/orbit.py
@@ -80,13 +80,14 @@ class OrbitWidget(BaseWidget):
                 btn, Window, self, device=self.device, prefix=self.prefix,
                 csorb=self._csorb)
 
-        btn = QPushButton('SingPass Sum', grpbx)
-        gdl.addWidget(btn, 0, 3)
-        Window = create_window_from_widget(
-            SinglePassSumWidget, title='Single Pass Sum')
-        _util.connect_window(
-            btn, Window, self, device=self.device, prefix=self.prefix,
-            csorb=self._csorb)
+        if self.acc != 'BO':
+            btn = QPushButton('SingPass Sum', grpbx)
+            gdl.addWidget(btn, 0, 3)
+            Window = create_window_from_widget(
+                SinglePassSumWidget, title='Single Pass Sum')
+            _util.connect_window(
+                btn, Window, self, device=self.device, prefix=self.prefix,
+                csorb=self._csorb)
 
     def channels(self):
         """."""
@@ -97,12 +98,11 @@ class OrbitWidget(BaseWidget):
     @staticmethod
     def get_default_ctrls(device, prefix='', acc='SI'):
         """."""
-        pvs = [
-            'SPassOrbX-Mon', 'SPassOrbY-Mon',
-            'OfflineOrbX-RB', 'OfflineOrbY-RB',
-            'RefOrbX-RB', 'RefOrbY-RB']
-        orbs = [
-            'IOC-SPassOrb', 'IOC-OfflineOrb', 'IOC-RefOrb']
+        pvs = ['RefOrbX-RB', 'RefOrbY-RB']
+        orbs = ['IOC-RefOrb', ]
+        if acc.upper() != 'BO':
+            pvs.extend(['SPassOrbX-Mon', 'SPassOrbY-Mon'])
+            orbs.append('IOC-SPassOrb')
         if acc.upper() == 'SI':
             pvs.extend(['SlowOrbX-Mon', 'SlowOrbY-Mon'])
             orbs.append('IOC-SlowOrb')

--- a/pyqt-apps/siriushla/as_ap_sofb/graphics/respmat.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/graphics/respmat.py
@@ -28,8 +28,6 @@ class ShowMatrixWidget(QWidget):
         self.setupui()
         self.mat = _ConnSig(self.devpref.substitute(propty='RespMat-Mon'))
         self.mat.new_value_signal[_np.ndarray].connect(self._update_graph)
-        self.rsize = _ConnSig(self.devpref.substitute(propty='RingSize-RB'))
-        self.rsize.new_value_signal[int].connect(self._update_horizontal)
         self._update_horizontal(None)
         self._update_graph(None)
 
@@ -112,9 +110,7 @@ class ShowMatrixWidget(QWidget):
             cur.receiveYWaveform(sep*i + val[:, i])
 
     def _update_horizontal(self, _):
-        val = self.rsize.getvalue()
-        if val is None:
-            val = 1
+        val = 1
         bpm_pos = _np.array(self._csorb.bpm_pos)
         bpm_pos = [bpm_pos + i*self._csorb.circum for i in range(2*val)]
         bpm_pos = _np.hstack(bpm_pos)

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
@@ -110,20 +110,21 @@ class KicksConfigWidget(BaseWidget):
 
     def get_status_widget(self, parent):
         """."""
-        conf = PyDMPushButton(
-            parent, pressValue=1,
-            init_channel=self.devpref.substitute(propty='CorrConfig-Cmd'))
-        rules = (
-            '[{"name": "EnblRule", "property": "Enable", ' +
-            '"expression": "not ch[0]", "channels": [{"channel": "' +
-            self.devpref.substitute(propty='LoopState-Sts') +
-            '", "trigger": true}]}]')
-        conf.rules = rules
-        conf.setToolTip('Refresh Configurations')
-        conf.setIcon(qta.icon('fa5s.sync'))
-        conf.setObjectName('conf')
-        conf.setStyleSheet(
-            '#conf{min-width:25px; max-width:25px; icon-size:20px;}')
+        if self.acc not in {'TS', 'TB'}:
+            conf = PyDMPushButton(
+                parent, pressValue=1,
+                init_channel=self.devpref.substitute(propty='CorrConfig-Cmd'))
+            rules = (
+                '[{"name": "EnblRule", "property": "Enable", ' +
+                '"expression": "not ch[0]", "channels": [{"channel": "' +
+                self.devpref.substitute(propty='LoopState-Sts') +
+                '", "trigger": true}]}]')
+            conf.rules = rules
+            conf.setToolTip('Refresh Configurations')
+            conf.setIcon(qta.icon('fa5s.sync'))
+            conf.setObjectName('conf')
+            conf.setStyleSheet(
+                '#conf{min-width:25px; max-width:25px; icon-size:20px;}')
 
         sts = QPushButton('', parent)
         sts.setIcon(qta.icon('fa5s.list-ul'))
@@ -147,5 +148,6 @@ class KicksConfigWidget(BaseWidget):
         hbl.addStretch()
         hbl.addWidget(pdm_led)
         hbl.addWidget(sts)
-        hbl.addWidget(conf)
+        if self.acc not in {'TS', 'TB'}:
+            hbl.addWidget(conf)
         return hbl

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/kicks_config.py
@@ -7,7 +7,7 @@ import qtawesome as qta
 from pydm.widgets import PyDMPushButton
 
 from ...util import connect_window
-from ...widgets import SiriusLedAlert
+from ...widgets import SiriusLedAlert, SiriusLabel, SiriusLedState
 from ...widgets.windows import create_window_from_widget
 from ...as_ti_control import HLTriggerDetailed
 
@@ -64,6 +64,7 @@ class KicksConfigWidget(BaseWidget):
         if self.acc == 'SI':
             det_wid = self.get_details_widget(tabw)
             tabw.addTab(det_wid, 'Details')
+            tabw.setCurrentIndex(2)
 
     def get_details_widget(self, parent):
         """."""
@@ -71,30 +72,24 @@ class KicksConfigWidget(BaseWidget):
         det_wid.setObjectName('gbx')
         det_lay = QGridLayout(det_wid)
 
-        syn_grp = QGroupBox('Sync.', det_wid)
-        syn_wid = self.create_pair_sel(syn_grp, 'CorrSync', is_vert=True)
+        syn_wid = self.create_pair_butled(det_wid, 'CorrSync', is_vert=False)
+        syn_lab = SiriusLabel(det_wid, self.device+':CorrSync-Sts')
         syn_wid.layout().setContentsMargins(0, 1, 0, 1)
-        gdl = QGridLayout(syn_grp)
-        gdl.addWidget(syn_wid, 0, 0)
+        det_lay.addWidget(QLabel('Synchronization', det_wid), 0, 0)
+        det_lay.addWidget(syn_wid, 0, 1)
+        det_lay.addWidget(syn_lab, 0, 2)
 
-        pssofb_grp = QGroupBox('PSSOFB', det_wid)
-        wait_lbl = QLabel('Wait:', pssofb_grp)
-        wait_wid = self.create_pair_butled(pssofb_grp, 'CorrPSSOFBWait')
-        wait_wid.layout().setContentsMargins(0, 0, 0, 0)
-        enbl_lbl = QLabel('Enable:', pssofb_grp)
-        enbl_wid = self.create_pair_butled(pssofb_grp, 'CorrPSSOFBEnbl')
+        enbl_wid = self.create_pair_butled(
+            det_wid, 'CorrPSSOFBEnbl', is_vert=False)
+        enbl_led = SiriusLedState(det_wid, self.device+':CorrPSSOFBEnbl-Mon')
         enbl_wid.layout().setContentsMargins(0, 0, 0, 0)
-        gdl = QGridLayout(pssofb_grp)
-        gdl.setSpacing(1)
-        gdl.addWidget(wait_lbl, 0, 0)
-        gdl.addWidget(wait_wid, 0, 1)
-        gdl.addWidget(enbl_lbl, 1, 0)
-        gdl.addWidget(enbl_wid, 1, 1)
+        det_lay.addWidget(QLabel('PSSOFB Enable:', det_wid), 1, 0)
+        det_lay.addWidget(enbl_wid, 1, 1)
+        det_lay.addWidget(enbl_led, 1, 2)
 
-        del_grp = QGroupBox('Trigger Delay', det_wid)
         del_wid = self.create_pair(
-            del_grp, 'Delay', device='SI-Glob:TI-Mags-Corrs', is_vert=False)
-        del_det = QPushButton(qta.icon('fa5s.ellipsis-h'), '', del_grp)
+            det_wid, 'Delay', device='SI-Glob:TI-Mags-Corrs', is_vert=False)
+        del_det = QPushButton(qta.icon('fa5s.ellipsis-h'), '', det_wid)
         del_det.setToolTip('Open details')
         del_det.setObjectName('detail')
         del_det.setStyleSheet(
@@ -105,17 +100,12 @@ class KicksConfigWidget(BaseWidget):
         connect_window(
             del_det, trg_w, parent=None, device='SI-Glob:TI-Mags-Corrs',
             prefix=self.prefix)
-        del_lay = QHBoxLayout(del_grp)
-        del_lay.addStretch()
-        del_lay.addWidget(del_wid)
-        del_lay.addWidget(del_det)
-        del_lay.addStretch()
+        del_lay = QGridLayout()
+        del_lay.addWidget(QLabel('Trigger Delay', det_wid), 0, 0)
+        del_lay.addWidget(del_wid, 0, 1)
+        del_lay.addWidget(del_det, 0, 2)
+        det_lay.addLayout(del_lay, 2, 0, 1, 3)
 
-        det_lay.addWidget(syn_grp, 0, 0)
-        det_lay.addWidget(pssofb_grp, 0, 2)
-        det_lay.addWidget(del_grp, 1, 0, 1, 3)
-        det_lay.setColumnStretch(1, 10)
-        det_lay.setRowStretch(1, 10)
         return det_wid
 
     def get_status_widget(self, parent):

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/orbit_acquisition.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/orbit_acquisition.py
@@ -63,8 +63,6 @@ class AcqControlWidget(BaseWidget):
             parent=tabw, device=self._csorb.trigger_acq_name,
             prefix=self.prefix, src=True)
         tabw.addTab(grp_bx, 'External Trigger')
-        grp_bx = self._get_trigdata_params_grpbx()
-        tabw.addTab(grp_bx, 'Data-Driven Trigger')
         vbl.addWidget(tabw)
 
     def _set_detailed(self, wids):
@@ -84,14 +82,14 @@ class AcqControlWidget(BaseWidget):
         fbl.addRow(lbl, wid)
         self._set_detailed([lbl, wid])
 
+        lab = QLabel('Sync. Injection', grp_bx, alignment=Qt.AlignCenter)
+        wid = self.create_pair_butled(grp_bx, 'SyncWithInjection-Sel')
+        fbl.addRow(lab, wid)
+        self._set_detailed([lab, wid])
+
         lbl = QLabel('Channel Rate', grp_bx, alignment=Qt.AlignCenter)
         wid = self.create_pair_sel(grp_bx, 'TrigAcqChan')
         fbl.addRow(lbl, wid)
-
-        lbl = QLabel('Trigger Type', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_sel(grp_bx, 'TrigAcqTrigger')
-        fbl.addRow(lbl, wid)
-        self._set_detailed([lbl, wid])
 
         lbl = QLabel('Repeat', grp_bx, alignment=Qt.AlignCenter)
         wid = self.create_pair_butled(grp_bx, 'TrigAcqRepeat')
@@ -191,26 +189,6 @@ class AcqControlWidget(BaseWidget):
 
         return grp_bx
 
-    def _get_trigdata_params_grpbx(self):
-        grp_bx = QWidget(self)
-        fbl = QFormLayout(grp_bx)
-        lbl = QLabel('Channel', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_sel(grp_bx, 'TrigDataChan')
-        fbl.addRow(lbl, wid)
-        lbl = QLabel('Selection', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_sel(grp_bx, 'TrigDataSel')
-        fbl.addRow(lbl, wid)
-        lbl = QLabel('Threshold', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair(grp_bx, 'TrigDataThres')
-        fbl.addRow(lbl, wid)
-        lbl = QLabel('Hysteresis', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair(grp_bx, 'TrigDataHyst')
-        fbl.addRow(lbl, wid)
-        lbl = QLabel('Polarity', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_sel(grp_bx, 'TrigDataPol')
-        fbl.addRow(lbl, wid)
-        return grp_bx
-
     def _get_multturn_acq_grpbx(self):
         grp_bx = QWidget(self)
         fbl = QFormLayout(grp_bx)
@@ -278,24 +256,4 @@ class AcqControlWidget(BaseWidget):
         wid = self.create_pair(grp_bx, 'SPassMaskSplEnd')
         fbl.addRow(lbl, wid)
         self._set_detailed([lbl, wid])
-
-        wid = QWidget(grp_bx)
-        self._set_detailed(wid)
-        hbl = QHBoxLayout(wid)
-        pdm_btn1 = PyDMPushButton(
-            init_channel=self.devpref.substitute(propty='SPassBgCtrl-Cmd'),
-            pressValue=0, label='Acquire')
-        pdm_btn2 = PyDMPushButton(
-            init_channel=self.devpref.substitute(propty='SPassBgCtrl-Cmd'),
-            pressValue=1, label='Reset')
-        pdm_lbl = SiriusLabel(
-            wid, self.devpref.substitute(propty='SPassBgSts-Mon'))
-        hbl.addWidget(pdm_btn1)
-        hbl.addWidget(pdm_btn2)
-        hbl.addWidget(pdm_lbl)
-        lbl = QLabel('BG acq.:', grp_bx, alignment=Qt.AlignCenter)
-        fbl.addRow(lbl, wid)
-        lbl = QLabel('Use BG', grp_bx, alignment=Qt.AlignCenter)
-        wid = self.create_pair_butled(grp_bx, 'SPassUseBg')
-        fbl.addRow(lbl, wid)
         return grp_bx

--- a/pyqt-apps/siriushla/as_ap_sofb/ioc_control/respmat_enbllist.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/ioc_control/respmat_enbllist.py
@@ -25,12 +25,9 @@ class SingleSelMatrix(BaseObject, SelectionWidget, PyDMWidget):
         # initialize BaseObject
         BaseObject.__init__(self, device, prefix=prefix, acc=acc)
         self.dev = dev
-        max_rz = self._csorb.MAX_RINGSZ
-        bpms = np.array(self._csorb.bpm_pos)
-        bpm_pos = [bpms + i*self._csorb.circum for i in range(max_rz)]
-        bpm_pos = np.hstack(bpm_pos)
-        bpm_name = self._csorb.bpm_names * max_rz
-        bpm_nknm = self._csorb.bpm_nicknames * max_rz
+        bpm_pos = np.array(self._csorb.bpm_pos)
+        bpm_name = self._csorb.bpm_names
+        bpm_nknm = self._csorb.bpm_nicknames
         self.devpos = {
             'BPMX': bpm_pos,
             'BPMY': bpm_pos,
@@ -85,8 +82,6 @@ class SingleSelMatrix(BaseObject, SelectionWidget, PyDMWidget):
         else:
             top_headers = nicks
             side_headers = [' ']
-        if self.dev.lower().startswith('bpm'):
-            side_headers *= self._csorb.MAX_RINGSZ
         return top_headers, side_headers
 
     def get_widgets(self):
@@ -113,8 +108,6 @@ class SingleSelMatrix(BaseObject, SelectionWidget, PyDMWidget):
             _, nicks = self.devnames[self.dev]
             rsize, hsize, i = len(nicks), len(side_headers), 0
             if self.dev.lower().startswith('bpm'):
-                rsize //= self._csorb.MAX_RINGSZ
-                hsize //= self._csorb.MAX_RINGSZ
                 i = (idx // rsize) * hsize
             if self.acc == 'BO':
                 sec = int(nicks[idx][:2])

--- a/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
@@ -425,18 +425,22 @@ class OrbitRegister(QWidget):
         lay.addWidget(orbcombo, row, 1)
 
         row += 1
-        lay.addWidget(QLabel('Subsection', wid), row, 0)
+        lay.addWidget(QLabel('Section', wid), row, 0)
         sscombo = QComboBox(wid)
-        sub = ['SA', 'SB', 'SP', 'SB']
-        ssnames = [f'{d+1:02d}{sub[d%len(sub)]}' for d in range(20)]
-        bcnames = [f'{d+1:02d}BC' for d in range(20)]
-        names = []
-        for aaa, bbb in zip(ssnames, bcnames):
-            names.extend([aaa, bbb])
-        sscombo.addItems(names)
-        sscombo.setMaxVisibleItems(10)
+        ssnames = [f'{d:02d}' for d in range(1, 21)]
+        sscombo.addItems(ssnames)
+        sscombo.setMaxVisibleItems(7)
         sscombo.setStyleSheet('QComboBox{combobox-popup: 0;}')
         lay.addWidget(sscombo, row, 1)
+
+        row += 1
+        lay.addWidget(QLabel('Subsection', wid), row, 0)
+        sbcombo = QComboBox(wid)
+        names = ['SS', 'C1', 'C2', 'BC']
+        sbcombo.addItems(names)
+        sbcombo.setMaxVisibleItems(5)
+        sbcombo.setStyleSheet('QComboBox{combobox-popup: 0;}')
+        lay.addWidget(sbcombo, row, 1)
 
         row += 1
         lay.addWidget(QLabel('\u03B8<sub>x</sub> [urad]', wid), row, 0)
@@ -507,10 +511,17 @@ class OrbitRegister(QWidget):
         agy = float(angy.text())
         psx = float(posx.text())
         psy = float(posy.text())
-        sub = sscombo.currentText()
-        orbx, orby = _calculate_bump(orbx, orby, sub, agx, agy, psx, psy)
+        sec = sscombo.currentText()
+        sub = sbcombo.currentText()
+        if sub == 'SS':
+            sub = 'SA'
+            if not int(sec) % 2:
+                sub = 'SB'
+            elif not (int(sec)+1) % 4:
+                sub = 'SP'
+        orbx, orby = _calculate_bump(orbx, orby, sec+sub, agx, agy, psx, psy)
 
-        txt = f'Bump@{sub}: ref={confname}\n'
+        txt = f'Bump@{sec+sub}; ref={confname}; '
         txt += f'ax={agx:.1f} ay={agy:.1f} dx={psx:.1f} dy={psy:.1f}'
         self._update_and_emit(txt, orbx, orby)
 

--- a/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
+++ b/pyqt-apps/siriushla/as_ap_sofb/orbit_register.py
@@ -34,25 +34,24 @@ class OrbitRegisters(QWidget):
             'ref': [
                 _ConnSig(self.devpref.substitute(propty='RefOrbX-RB')),
                 _ConnSig(self.devpref.substitute(propty='RefOrbY-RB'))],
-            'sp': [
-                _ConnSig(self.devpref.substitute(propty='SPassOrbX-Mon')),
-                _ConnSig(self.devpref.substitute(propty='SPassOrbY-Mon'))],
-            'off': [
-                _ConnSig(self.devpref.substitute(propty='OfflineOrbX-SP')),
-                _ConnSig(self.devpref.substitute(propty='OfflineOrbY-SP'))],
             'bpm': [
                 _ConnSig(self.devpref.substitute(propty='BPMOffsetX-Mon')),
                 _ConnSig(self.devpref.substitute(propty='BPMOffsetY-Mon'))],
             'mat': _ConnSig(self.devpref.substitute(propty='RespMat-RB')),
             }
-        if self.acc == 'SI':
-            self._orbits['orb'] = [
-                _ConnSig(self.devpref.substitute(propty='SlowOrbX-Mon')),
-                _ConnSig(self.devpref.substitute(propty='SlowOrbY-Mon'))]
+        if self.acc in {'TB', 'TS', 'SI'}:
+            self._orbits['sp'] = [
+                _ConnSig(self.devpref.substitute(propty='SPassOrbX-Mon')),
+                _ConnSig(self.devpref.substitute(propty='SPassOrbY-Mon'))]
         if self.acc in {'SI', 'BO'}:
             self._orbits['mti'] = [
                 _ConnSig(self.devpref.substitute(propty='MTurnIdxOrbX-Mon')),
                 _ConnSig(self.devpref.substitute(propty='MTurnIdxOrbY-Mon'))]
+        if self.acc == 'SI':
+            self._orbits['orb'] = [
+                _ConnSig(self.devpref.substitute(propty='SlowOrbX-Mon')),
+                _ConnSig(self.devpref.substitute(propty='SlowOrbY-Mon'))]
+
         self.setupui()
 
     def channels(self):
@@ -206,14 +205,12 @@ class OrbitRegister(QWidget):
             act = menu2.addAction('&MTurnOrb')
             act.setIcon(qta.icon('mdi.alarm-multiple'))
             act.triggered.connect(_part(self._register_orbit, 'mti'))
-        act = menu2.addAction('S&PassOrb')
-        act.setIcon(qta.icon('mdi.clock-fast'))
-        act.triggered.connect(_part(self._register_orbit, 'sp'))
+        if self._csorb.acc.upper() != 'BO':
+            act = menu2.addAction('S&PassOrb')
+            act.setIcon(qta.icon('mdi.clock-fast'))
+            act.triggered.connect(_part(self._register_orbit, 'sp'))
         act = menu2.addAction('&RefOrb')
         act.triggered.connect(_part(self._register_orbit, 'ref'))
-        act = menu2.addAction('&OfflineOrb')
-        act.setIcon(qta.icon('mdi.signal-off'))
-        act.triggered.connect(_part(self._register_orbit, 'off'))
         act = menu2.addAction('&BPM Offsets')
         act.setIcon(qta.icon('mdi.currency-sign'))
         act.triggered.connect(_part(self._register_orbit, 'bpm'))


### PR DESCRIPTION
This PR adapts the SOFB control window for the new IOC interface defined in lnls-sirius/dev-packages#886.
It also improves the create bump functionality to allow creation of bumps in B1 and B2 dipoles too.

depends on #587 