### PR TITLE
Improve PS detail window

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-as-ps-detail.py
+++ b/pyqt-apps/scripts/sirius-hla-as-ps-detail.py
@@ -13,13 +13,24 @@ from siriushla.util import run_newprocess
 parser = _argparse.ArgumentParser(
     description="Run Power Supply Detailed Control Interface.")
 parser.add_argument("psname", type=str, help="PS name.")
+parser.add_argument("--psmodel", type=str, default='')
+parser.add_argument("--pstype", type=str, default='')
 args = parser.parse_args()
 
-if PSSearch.conv_psname_2_psmodel(args.psname) == 'REGATRON_DCLink':
+psmodel = args.psmodel
+if not psmodel:
+    try:
+        psmodel = PSSearch.conv_psname_2_psmodel(args.psname)
+    except KeyError:
+        pass
+
+if psmodel == 'REGATRON_DCLink':
     run_newprocess(
         ['sirius-hla-as-ps-regatron-individual', '-dev', args.psname],
         is_pydm=True)
 else:
     app = SiriusApplication()
-    app.open_window(PSDetailWindow, parent=None, psname=args.psname)
+    app.open_window(
+        PSDetailWindow, parent=None, psname=args.psname,
+        psmodel=psmodel, pstype=args.pstype)
     sys.exit(app.exec_())

--- a/pyqt-apps/siriushla/as_ps_control/PSDetailWindow.py
+++ b/pyqt-apps/siriushla/as_ps_control/PSDetailWindow.py
@@ -13,15 +13,17 @@ from .detail_widget.DetailWidgetFactory import DetailWidgetFactory
 class PSDetailWindow(SiriusMainWindow):
     """Window to control a detailed widget."""
 
-    def __init__(self, psname, parent=None):
+    def __init__(self, psname, parent=None, psmodel=None, pstype=None):
         """Init UI."""
         super(PSDetailWindow, self).__init__(parent)
         if isinstance(psname, str):
             self._psname = [_PVName(psname), ]
         else:
             self._psname = [_PVName(psn) for psn in psname]
+        self._psmodel = psmodel
+        self._pstype = pstype
         name = self._psname[0]
-        self._is_dclink = 'dclink' in PSSearch.conv_psname_2_pstype(name)
+        self._is_dclink = 'dclink' in name.lower()
         secs = {'AS', 'LI', 'TB', 'BO', 'TS', 'SI', 'IT'}
         if name.sub.endswith(('SA', 'SB', 'SP', 'ID')):
             sec = 'ID'
@@ -43,7 +45,9 @@ class PSDetailWindow(SiriusMainWindow):
         else:
             self.setWindowTitle(self._psname[0])
         # Set window layout
-        self.widget = DetailWidgetFactory.factory(self._psname, self)
+        self.widget = DetailWidgetFactory.factory(
+            self._psname, parent=self,
+            psmodel=self._psmodel, pstype=self._pstype)
         self._connect_buttons(self.widget)
         self.setCentralWidget(self.widget)
 
@@ -51,7 +55,10 @@ class PSDetailWindow(SiriusMainWindow):
         w = widget.findChild(QPushButton, 'dclink_button')
         if w:
             psname = self._psname[0]
-            dclinks = PSSearch.conv_psname_2_dclink(psname)
+            try:
+                dclinks = PSSearch.conv_psname_2_dclink(psname)
+            except KeyError:
+                dclinks = []
             if dclinks:
                 dclink_type = PSSearch.conv_psname_2_psmodel(dclinks[0])
                 if dclink_type != 'REGATRON_DCLink':

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -9,7 +9,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget, QGroupBox, QPushButton, QLabel, \
     QGridLayout, QVBoxLayout, QHBoxLayout, QFormLayout, QTabWidget, \
     QSizePolicy as QSzPlcy, QCheckBox, QHeaderView, QAbstractItemView, \
-    QScrollArea, QFrame
+    QScrollArea, QFrame, QComboBox
 from qtpy.QtGui import QColor
 
 import qtawesome as qta
@@ -23,14 +23,14 @@ from siriuspy.envars import VACA_PREFIX
 from siriuspy.search import PSSearch
 from siriuspy.pwrsupply.csdev import get_ps_propty_database, get_ps_modules, \
     DEF_WFMSIZE_FBP, DEF_WFMSIZE_OTHERS, PS_LI_INTLK_THRS as _PS_LI_INTLK, \
-    ETypes as _PSet
+    ETypes as _PSet, get_ps_scopesourcemap
 from siriuspy.devices import PowerSupply
 
 from ... import util
 from ...widgets import PyDMStateButton, PyDMSpinboxScrollbar, SiriusTimePlot, \
     SiriusConnectionSignal, SiriusLedState, SiriusLedAlert, SiriusLabel, \
     PyDMLedMultiChannel, SiriusDialog, SiriusWaveformTable, SiriusSpinbox, \
-    SiriusHexaSpinbox, SiriusWaveformPlot, PyDMLed
+    SiriusHexaSpinbox, SiriusWaveformPlot, PyDMLed, SiriusStringComboBox
 from .InterlockWindow import InterlockWindow, LIInterlockWindow
 from .custom_widgets import LISpectIntlkLed
 
@@ -945,14 +945,32 @@ class PSDetailWidget(QWidget):
         layout.setAlignment(Qt.AlignTop)
         layout.setContentsMargins(0, 6, 0, 0)
         layout.addWidget(self.scope_src_label, 0, 0, Qt.AlignRight)
-        layout.addWidget(self.scope_src_sp_sb, 0, 1)
-        layout.addWidget(self.scope_src_rb_lb, 0, 2)
-        layout.addWidget(self.scope_freq_label, 1, 0, Qt.AlignRight)
-        layout.addWidget(self.scope_freq_sp_sb, 1, 1)
-        layout.addWidget(self.scope_freq_rb_label, 1, 2)
-        layout.addWidget(self.scope_dur_label, 2, 0, Qt.AlignRight)
-        layout.addWidget(self.scope_dur_sp_sb, 2, 1)
-        layout.addWidget(self.scope_dur_rb_label, 2, 2)
+        layout.addWidget(self.scope_src_rb_lb, 0, 3)
+        layout.addWidget(self.scope_freq_label, 1, 0, 1, 2, Qt.AlignRight)
+        layout.addWidget(self.scope_freq_sp_sb, 1, 2)
+        layout.addWidget(self.scope_freq_rb_label, 1, 3)
+        layout.addWidget(self.scope_dur_label, 2, 0, 1, 2, Qt.AlignRight)
+        layout.addWidget(self.scope_dur_sp_sb, 2, 2)
+        layout.addWidget(self.scope_dur_rb_label, 2, 3)
+
+        try:
+            self.scope_src_sp_cb = SiriusStringComboBox(
+                self, src_sp, items=get_ps_scopesourcemap(self._psname))
+            self.scope_src_sp_opt = QComboBox(self)
+            self.scope_src_sp_opt.addItems(['[list]', '[0x]'])
+            self.scope_src_sp_opt.currentIndexChanged.connect(
+                self.scope_src_sp_cb.setHidden)
+            self.scope_src_sp_opt.currentIndexChanged.connect(
+                self.scope_src_sp_sb.setVisible)
+
+            self.scope_src_sp_sb.setVisible(False)
+            layout.addWidget(self.scope_src_label, 0, 0, Qt.AlignRight)
+            layout.addWidget(self.scope_src_sp_opt, 0, 1)
+            layout.addWidget(self.scope_src_sp_cb, 0, 2)
+            layout.addWidget(self.scope_src_sp_sb, 0, 2)
+        except KeyError:
+            layout.addWidget(self.scope_src_label, 0, 0, 1, 2, Qt.AlignRight)
+            layout.addWidget(self.scope_src_sp_sb, 0, 2)
         return layout
 
     def _wfmUpdAxisLabel(self, state):


### PR DESCRIPTION
This PR:
- changes Wfm graph to plot PSD transformations considering correct frequencies (scope freq. for Wfm-Mon and param. wfm freq. for other Wfm PVs);
- fixes SiriusStringComboBox to work with items of dict type; 
- adds combobox to select a predefined scope address in Scope tab (depends on https://github.com/lnls-sirius/dev-packages/pull/948);
- makes it possible to create an instance of the detail window for power supplies that are not in control system.
