### PR TITLE
Add new "Flow Switch 4" sensor in BO RF cavity status detail window

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/details.py
+++ b/pyqt-apps/siriushla/as_rf_control/details.py
@@ -102,12 +102,6 @@ class CavityStatusDetails(SiriusDialog):
             led.channel = self.prefix+disc
             lay_dtemp.addRow('Disc '+str(idx)+': ', led)
 
-        self.led_hdflwrt1 = SiriusLedAlert(
-            self, self.prefix+self.chs['Cav Sts']['FlwRt'][0])
-        self.led_hdflwrt2 = SiriusLedAlert(
-            self, self.prefix+self.chs['Cav Sts']['FlwRt'][1])
-        self.led_hdflwrt3 = SiriusLedAlert(
-            self, self.prefix+self.chs['Cav Sts']['FlwRt'][2])
         lay_flwrt = QFormLayout()
         lay_flwrt.setHorizontalSpacing(9)
         lay_flwrt.setVerticalSpacing(9)
@@ -117,9 +111,9 @@ class CavityStatusDetails(SiriusDialog):
         lb_flwrf.setStyleSheet(
             'font-weight:bold; qproperty-alignment:AlignCenter;')
         lay_flwrt.addRow(lb_flwrf)
-        lay_flwrt.addRow('Flow Switch 1: ', self.led_hdflwrt1)
-        lay_flwrt.addRow('Flow Switch 2: ', self.led_hdflwrt2)
-        lay_flwrt.addRow('Flow Switch 3: ', self.led_hdflwrt3)
+        for flwsw, pvn in self.chs['Cav Sts']['FlwRt'].items():
+            led = SiriusLedAlert(self, self.prefix+pvn)
+            lay_flwrt.addRow(flwsw+': ', led)
 
         self.led_couppressure = SiriusLedAlert(
             self, self.prefix+self.chs['Cav Sts']['Vac']['Coupler ok'])

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -106,11 +106,12 @@ SEC_2_CHANNELS = {
                     'BO-05D:RF-P5Cav:Disc6Tms-Mon',
                 ),
             },
-            'FlwRt': (
-                'BO-05D:RF-P5Cav:Hd1FlwRt-Mon',
-                'BO-05D:RF-P5Cav:Hd2FlwRt-Mon',
-                'BO-05D:RF-P5Cav:Hd3FlwRt-Mon',
-            ),
+            'FlwRt': {
+                'Flow Switch 1': 'BO-05D:RF-P5Cav:Hd1FlwRt-Mon',
+                'Flow Switch 2': 'BO-05D:RF-P5Cav:Hd2FlwRt-Mon',
+                'Flow Switch 3': 'BO-05D:RF-P5Cav:Hd3FlwRt-Mon',
+                'Flow Switch 4': 'BO-05D:RF-P5Cav:Hd4FlwRt-Mon',
+            },
             'Vac': {
                 'Cells': 'BO-05D:VA-CCG-RFC:Pressure-Mon',
                 'Cond': 'BR-RF-DLLRF-01:VACUUM',
@@ -328,11 +329,11 @@ SEC_2_CHANNELS = {
                     'SI-02SB:RF-P7Cav:Disc8Tms-Mon',
                 ),
             },
-            'FlwRt': (
-                'SI-02SB:RF-P7Cav:HDFlwRt1-Mon',
-                'SI-02SB:RF-P7Cav:HDFlwRt2-Mon',
-                'SI-02SB:RF-P7Cav:HDFlwRt3-Mon',
-            ),
+            'FlwRt': {
+                'Flow Switch 1': 'SI-02SB:RF-P7Cav:HDFlwRt1-Mon',
+                'Flow Switch 2': 'SI-02SB:RF-P7Cav:HDFlwRt2-Mon',
+                'Flow Switch 3': 'SI-02SB:RF-P7Cav:HDFlwRt3-Mon',
+            },
             'Vac': {
                 'Cells': 'SI-02SB:VA-CCG-CAV:Pressure-Mon',
                 'Cond': 'SR-RF-DLLRF-01:VACUUM',


### PR DESCRIPTION
New "Flow Switch 4" sensor in BO RF cavity status detail window: 
![Screenshot from 2023-05-24 15-47-59](https://github.com/lnls-sirius/hla/assets/21130191/9353ffb1-2a02-449f-aba7-fac3afaef720)
