### PR TITLE
Add windows related to PAPU50 

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-si-id-control.py
+++ b/pyqt-apps/scripts/sirius-hla-si-id-control.py
@@ -7,7 +7,7 @@ import argparse as _argparse
 from siriushla.sirius_application import SiriusApplication
 from siriuspy.envars import VACA_PREFIX
 from siriushla.si_id_control import IDControl, APUControlWindow, \
-    EPUControlWindow
+    EPUControlWindow, PAPUControlWindow
 
 
 parser = _argparse.ArgumentParser(
@@ -25,7 +25,10 @@ device = args.device
 isall = args.isall
 
 app = SiriusApplication()
-if 'APU' in args.device:
+if 'PAPU' in args.device:
+    app.open_window(
+        PAPUControlWindow, parent=None, prefix=prefix, device=device)
+elif 'APU' in args.device:
     app.open_window(
         APUControlWindow, parent=None, prefix=prefix, device=device)
 elif 'EPU' in args.device:

--- a/pyqt-apps/siriushla/as_ap_launcher/menu.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/menu.py
@@ -433,7 +433,8 @@ def get_object(ismenubar=True, parent=None):
 
             idlist = ['SI-06SB:ID-APU22', 'SI-07SP:ID-APU22',
                       'SI-08SB:ID-APU22', 'SI-09SA:ID-APU22',
-                      'SI-11SP:ID-APU58', 'SI-10SB:ID-EPU50']
+                      'SI-11SP:ID-APU58', 'SI-10SB:ID-EPU50',
+                      'SI-17SA:ID-PAPU50']
             for idname in idlist:
                 idname = SiriusPVName(idname)
                 beamline = IDSearch.conv_idname_2_beamline(idname)

--- a/pyqt-apps/siriushla/as_ap_monitor/util.py
+++ b/pyqt-apps/siriushla/as_ap_monitor/util.py
@@ -28,5 +28,5 @@ def get_sec2dev_laypos(sec, label):
     SEC2LABEL2SECPOS['BO'].update({
         'RF': (2, 1, 1, 1)})
     SEC2LABEL2SECPOS['SI'].update({
-        'RF': (0, 3, 1, 1)})
+        'RF': (0, 6, 1, 1)})
     return SEC2LABEL2SECPOS[sec][label]

--- a/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/control_widget/BasePSControlWidget.py
@@ -275,8 +275,20 @@ class BasePSControlWidget(QWidget):
         self.containers_dict = dict()
         self.filtered_widgets = set()  # Set with key of visible widgets
 
+        # Get groups and respective power supplies
+        self.groups, self.groups2devs = list(), dict()
+        for group in self._getGroups():
+            pwrsupplies = list()
+            pattern = re.compile(group[1])
+            for el in self._dev_list:
+                if pattern.search(el):
+                    pwrsupplies.append(el)
+            if not pwrsupplies:
+                continue
+            self.groups.append(group)
+            self.groups2devs[group[0]] = pwrsupplies
+
         # Setup the UI
-        self.groups = self._getGroups()
         self._setup_ui()
         self._create_actions()
         self._enable_actions()
@@ -318,13 +330,7 @@ class BasePSControlWidget(QWidget):
         # Build power supply Layout
         # Create group boxes and pop. layout
         for idx, group in enumerate(self.groups):
-
-            # Get power supplies that belong to group
-            pwrsupplies = list()
-            pattern = re.compile(group[1])
-            for el in self._dev_list:
-                if pattern.search(el):
-                    pwrsupplies.append(el)
+            pwrsupplies = self.groups2devs[group[0]]
 
             # Create header
             header = SummaryHeader(pwrsupplies[0],

--- a/pyqt-apps/siriushla/as_ps_diag/util.py
+++ b/pyqt-apps/siriushla/as_ps_diag/util.py
@@ -89,16 +89,16 @@ SEC2LABEL2SECPOS = {
     'SI': {
         'B': (0, 1, 1, 1),
         'PM': (0, 2, 1, 1),
+        'FFCH/FFCV': (0, 3, 1, 1),
         'Q': (0, 4, 1, 1),
         'S': (0, 5, 1, 1),
-        'ID-CH/CV/QS': (0, 6, 1, 2),
-        'FFCH/FFCV': (0, 7, 1, 2),
-        'QS': (1, 1, 1, 1),
-        'CH': (1, 2, 1, 2),
+        'ID-CH/CV/QS': (0, 7, 1, 2),
+        'QS': (1, 1, 1, 2),
+        'CH': (1, 3, 1, 1),
         'CV': (1, 4, 1, 1),
-        'Trims': (1, 5, 1, 1),
-        'FCH': (1, 6, 1, 1),
-        'FCV': (1, 7, 1, 1),
+        'Trims': (1, 5, 1, 2),
+        'FCH': (1, 7, 1, 1),
+        'FCV': (1, 8, 1, 1),
     },
 }
 
@@ -110,26 +110,25 @@ def get_sec2dev_laypos(sec, label):
 def get_col2dev_count(sec, label):
     if label == 'QS':
         return 5
-    elif label == 'CH':
+    if label == 'CH':
         return 6 if sec == 'SI' else 5 if sec == 'BO' else 7
-    elif label == 'CV':
+    if label == 'CV':
         return 8 if sec == 'SI' else 5 if sec == 'BO' else 10
-    elif 'Trims' in label:
+    if 'Trims' in label:
         return 14
-    elif 'FFC' in label:
+    if 'FFC' in label:
         return 4
-    elif 'ID' in label:
+    if 'ID' in label:
+        return 8
+    if 'FC' in label:
         return 4
-    elif 'FC' in label:
-        return 4
-    elif label == 'S':
+    if label == 'S':
         return 11
-    elif label == 'Q':
+    if label == 'Q':
         return 10 if sec != 'SI' else 6
-    elif label == 'Slnd':
+    if label == 'Slnd':
         return 21
-    else:
-        return 10
+    return 10
 
 
 def get_dev2sub_labels(label):

--- a/pyqt-apps/siriushla/si_ap_idff/main.py
+++ b/pyqt-apps/siriushla/si_ap_idff/main.py
@@ -80,13 +80,6 @@ class IDFFWindow(SiriusMainWindow):
         self.lb_loopfreq = SiriusLabel(
             self, self.dev_pref.substitute(propty='LoopFreq-RB'))
 
-        ld_controlqs = QLabel(
-            'Control QS: ', self, alignment=Qt.AlignRight)
-        self.sb_controlqs = PyDMStateButton(
-            self, self.dev_pref.substitute(propty='ControlQS-Sel'))
-        self.lb_controlqs = SiriusLedState(
-            self, self.dev_pref.substitute(propty='ControlQS-Sts'))
-
         ld_usepssofb = QLabel(
             'Use PSSOFB: ', self, alignment=Qt.AlignRight)
         self.sb_usepssofb = PyDMStateButton(
@@ -106,13 +99,23 @@ class IDFFWindow(SiriusMainWindow):
         lay.addWidget(ld_configname, 3, 0)
         lay.addWidget(self.le_configname, 3, 1, 1, 3)
         lay.addWidget(self.lb_configname, 4, 1, 1, 3)
-        lay.addWidget(ld_controlqs, 5, 0)
-        lay.addWidget(self.sb_controlqs, 5, 1)
-        lay.addWidget(self.lb_controlqs, 5, 2)
         lay.addItem(QSpacerItem(0, 15, QSzPlcy.Ignored, QSzPlcy.Fixed), 6, 0)
         lay.addWidget(ld_usepssofb, 7, 0)
         lay.addWidget(self.sb_usepssofb, 7, 1)
         lay.addWidget(self.lb_usepssofb, 7, 2)
+
+        if IDSearch.conv_idname_2_idff_qsnames(self.idname):
+            ld_controlqs = QLabel(
+                'Control QS: ', self, alignment=Qt.AlignRight)
+            self.sb_controlqs = PyDMStateButton(
+                self, self.dev_pref.substitute(propty='ControlQS-Sel'))
+            self.lb_controlqs = SiriusLedState(
+                self, self.dev_pref.substitute(propty='ControlQS-Sts'))
+
+            lay.addWidget(ld_controlqs, 5, 0)
+            lay.addWidget(self.sb_controlqs, 5, 1)
+            lay.addWidget(self.lb_controlqs, 5, 2)
+
         return gbox
 
     def _corrStatusWidget(self):
@@ -149,29 +152,31 @@ class IDFFWindow(SiriusMainWindow):
         return gbox
 
     def _idStatusWidget(self):
-        pparam = _PVName(self._idffdata['pparameter'])
-        ld_pparam = QLabel(
-            pparam.propty_name + ': ', self, alignment=Qt.AlignRight)
-        self._lb_pparam = SiriusLabel(self, pparam, keep_unit=True)
-        self._lb_pparam.showUnits = True
+        gbox = QGroupBox('ID Status', self)
+        lay = QGridLayout(gbox)
 
-        kparam = _PVName(self._idffdata['kparameter'])
-        ld_kparam = QLabel(
-            kparam.propty_name + ': ', self, alignment=Qt.AlignRight)
-        self._lb_kparam = SiriusLabel(self, kparam, keep_unit=True)
-        self._lb_kparam.showUnits = True
+        if self._idffdata['pparameter']:
+            pparam = _PVName(self._idffdata['pparameter'])
+            ld_pparam = QLabel(
+                pparam.propty_name + ': ', self, alignment=Qt.AlignRight)
+            self._lb_pparam = SiriusLabel(self, pparam, keep_unit=True)
+            self._lb_pparam.showUnits = True
+            lay.addWidget(ld_pparam, 0, 0)
+            lay.addWidget(self._lb_pparam, 0, 1)
+
+        if self._idffdata['kparameter']:
+            kparam = _PVName(self._idffdata['kparameter'])
+            ld_kparam = QLabel(
+                kparam.propty_name + ': ', self, alignment=Qt.AlignRight)
+            self._lb_kparam = SiriusLabel(self, kparam, keep_unit=True)
+            self._lb_kparam.showUnits = True
+            lay.addWidget(ld_kparam, 1, 0)
+            lay.addWidget(self._lb_kparam, 1, 1)
 
         ld_polar = QLabel(
             'Polarization: ', self, alignment=Qt.AlignRight)
         self.lb_polar = SiriusLabel(
             self, self.dev_pref.substitute(propty='Polarization-Mon'))
-
-        gbox = QGroupBox('ID Status', self)
-        lay = QGridLayout(gbox)
-        lay.addWidget(ld_pparam, 0, 0)
-        lay.addWidget(self._lb_pparam, 0, 1)
-        lay.addWidget(ld_kparam, 1, 0)
-        lay.addWidget(self._lb_kparam, 1, 1)
         lay.addItem(QSpacerItem(0, 15, QSzPlcy.Ignored, QSzPlcy.Fixed), 2, 0)
         lay.addWidget(ld_polar, 3, 0)
         lay.addWidget(self.lb_polar, 3, 1, 1, 3)

--- a/pyqt-apps/siriushla/si_id_control/__init__.py
+++ b/pyqt-apps/siriushla/si_id_control/__init__.py
@@ -2,4 +2,5 @@
 
 from .apu import APUControlWindow
 from .epu import EPUControlWindow
+from .papu import PAPUControlWindow
 from .id_control import IDControl

--- a/pyqt-apps/siriushla/si_id_control/id_control.py
+++ b/pyqt-apps/siriushla/si_id_control/id_control.py
@@ -14,6 +14,7 @@ from ..widgets import SiriusMainWindow, SiriusConnectionSignal
 
 from .apu import APUSummaryHeader, APUSummaryWidget
 from .epu import EPUSummaryHeader, EPUSummaryWidget
+from .papu import PAPUSummaryHeader, PAPUSummaryWidget
 from .util import get_id_icon
 
 
@@ -59,12 +60,16 @@ class IDControl(SiriusMainWindow):
         self._gbox_epu = QGroupBox('EPU', self)
         self._gbox_epu.setLayout(self._setupEPULayout())
 
+        self._gbox_papu = QGroupBox('PAPU', self)
+        self._gbox_papu.setLayout(self._setupPAPULayout())
+
         lay = QGridLayout(cwid)
         lay.addWidget(self.label_mov1, 0, 0)
         lay.addWidget(label, 0, 1)
         lay.addWidget(self.label_mov2, 0, 2)
         lay.addWidget(self._gbox_apu, 1, 0, 1, 3)
         lay.addWidget(self._gbox_epu, 2, 0, 1, 3)
+        lay.addWidget(self._gbox_papu, 3, 0, 1, 3)
         lay.setColumnStretch(0, 1)
         lay.setColumnStretch(1, 15)
         lay.setColumnStretch(2, 1)
@@ -100,6 +105,25 @@ class IDControl(SiriusMainWindow):
         idlist = ['SI-10SB:ID-EPU50', ]
         for idname in idlist:
             epu_wid = EPUSummaryWidget(self, self._prefix, idname)
+            lay.addWidget(epu_wid)
+            self._id_widgets.append(epu_wid)
+            ch_mov = SiriusConnectionSignal(_PVName(idname).substitute(
+                prefix=self._prefix, propty='Moving-Mon'))
+            ch_mov.new_value_signal[int].connect(self._handle_moving_vis)
+            self._channels_mov.append(ch_mov)
+
+        return lay
+
+    def _setupPAPULayout(self):
+        lay = QVBoxLayout()
+        lay.setAlignment(Qt.AlignTop)
+
+        self._epu_header = PAPUSummaryHeader(self)
+        lay.addWidget(self._epu_header)
+
+        idlist = ['SI-17SA:ID-PAPU50', ]
+        for idname in idlist:
+            epu_wid = PAPUSummaryWidget(self, self._prefix, idname)
             lay.addWidget(epu_wid)
             self._id_widgets.append(epu_wid)
             ch_mov = SiriusConnectionSignal(_PVName(idname).substitute(

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -291,7 +291,7 @@ class PAPUDetails(IDCommonDialog):
         flay = QFormLayout(drivebox)
         flay.setLabelAlignment(Qt.AlignRight)
         for pvn in ['ResolverPos-Mon', 'Code-Mon', 'Torque-Mon',
-                    'Speed-Mon', 'MotorTemp-Mon']:
+                    'MotorTemp-Mon']:
             lbl = pvn.split('-')[0] + ':'
             wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
             flay.addRow(lbl, wid)

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -28,6 +28,7 @@ class PAPUControlWindow(IDCommonControlWindow):
             self, self.dev_pref.substitute(propty='Phase-RB'))
         self._lb_phsmon = SiriusLabel(
             self, self.dev_pref.substitute(propty='Phase-Mon'))
+        self._lb_phsmon.setStyleSheet('QLabel{min-width:6em;}')
 
         self._ld_phsspd = QLabel('Phase Speed [mm/s]', self)
         self._sb_phsspd = SiriusSpinbox(
@@ -36,6 +37,7 @@ class PAPUControlWindow(IDCommonControlWindow):
             self, self.dev_pref.substitute(propty='PhaseSpeed-RB'))
         self._lb_phsspdmon = SiriusLabel(
             self, self.dev_pref.substitute(propty='PhaseSpeed-Mon'))
+        self._lb_phsspdmon.setStyleSheet('QLabel{min-width:6em;}')
 
         self._ld_enbl = QLabel('Allow Phase Motion', self)
         self._ld_enbl.setToolTip('Enable Axis and Release Brakes')
@@ -284,7 +286,7 @@ class PAPUDetails(IDCommonDialog):
         for pvn in ['Connected-Mon', 'MsgServerConnected-Mon',
                     'IoServerConnected-Mon', 'SerialConnected-Mon']:
             lbl = pvn.split('-')[0] + ':'
-            wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
+            wid = SiriusLedState(self, self.dev_pref.substitute(propty=pvn))
             flay.addRow(lbl, wid)
 
         drivebox = QGroupBox('Drive Status', self)
@@ -296,10 +298,17 @@ class PAPUDetails(IDCommonDialog):
             glay.addWidget(lbl, row, 0, alignment=Qt.AlignRight)
             wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
             glay.addWidget(wid, row, 1)
-            if pvn == 'MotorTemp-Mon':
+
+            c2v = None
+            if pvn == 'Code-Mon':
+                c2v = {self.dev_pref.substitute(
+                    propty=pvn): {'comp': 'eq', 'value': 'A211'}}
+            elif pvn == 'MotorTemp-Mon':
                 c2v = {self.dev_pref.substitute(
                     propty=pvn): {'comp': 'lt', 'value': 90}}
+            if c2v:
                 led = PyDMLedMultiChannel(self, c2v)
+                led.offColor = led.Yellow
                 glay.addWidget(led, row, 2, alignment=Qt.AlignLeft)
 
         self.setStyleSheet(

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -110,6 +110,17 @@ class PAPUControlWindow(IDCommonControlWindow):
         return gbox
 
     def _statusWidget(self):
+        self._ld_drivests = QLabel(
+            'Drive Status:', self, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        self._lb_drivests = SiriusLabel(
+            self, self.dev_pref.substitute(propty='DiagMessage-Mon'))
+        self._lb_drivests.setStyleSheet('QLabel{min-width: 10em;}')
+        self._lb_drivests.displayFormat = SiriusLabel.DisplayFormat.String
+        self._led_drivests = PyDMLedMultiChannel(
+            self, {
+                self.dev_pref.substitute(propty='Code-Mon'): {
+                    'comp': 'in', 'value': ['A211', 'A012']}})
+
         self._pb_dtlsts = QPushButton('', self)
         self._pb_dtlsts.setIcon(qta.icon('fa5s.list-ul'))
         self._pb_dtlsts.setToolTip('Open Detailed Status View')
@@ -133,12 +144,18 @@ class PAPUControlWindow(IDCommonControlWindow):
         gbox = QGroupBox('Status')
         gbox.setSizePolicy(QSzPlcy.MinimumExpanding, QSzPlcy.Preferred)
         lay = QGridLayout(gbox)
-        lay.addWidget(self._log, 0, 0, 1, 2)
-        lay.addWidget(self._bt_logclear, 1, 0, alignment=Qt.AlignCenter)
-        lay.addWidget(self._pb_dtlsts, 1, 1, alignment=Qt.AlignRight)
+        lay.addWidget(self._ld_drivests, 0, 0)
+        lay.addWidget(self._lb_drivests, 0, 1)
+        lay.addWidget(self._led_drivests, 0, 2)
+        lay.addWidget(self._pb_dtlsts, 0, 3, alignment=Qt.AlignRight)
+        lay.addWidget(self._log, 1, 0, 1, 4)
+        lay.addWidget(self._bt_logclear, 2, 0, 1, 4, alignment=Qt.AlignCenter)
         return gbox
 
     def _auxCommandsWidget(self):
+        btnname = 'btn'
+        btnsty = '#btn{min-width:30px; max-width:30px; icon-size:25px;}'
+
         gbox = QGroupBox('Auxiliary Commands', self)
 
         self._ld_phsspdlim = QLabel('Max Phase Speed [mm/s]', self)
@@ -153,9 +170,8 @@ class PAPUControlWindow(IDCommonControlWindow):
         self._pb_pwrenbl = PyDMPushButton(
             parent=self, label='', icon=qta.icon('fa5s.plug'),
             init_channel=pvname, pressValue=1)
-        self._pb_pwrenbl.setObjectName('btn')
-        self._pb_pwrenbl.setStyleSheet(
-            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+        self._pb_pwrenbl.setObjectName(btnname)
+        self._pb_pwrenbl.setStyleSheet(btnsty)
         self._led_pwrsts = SiriusLedState(
             self, self.dev_pref.substitute(propty='PwrPhase-Mon'))
         self._led_pwrsts.offColor = PyDMLed.Red
@@ -166,34 +182,71 @@ class PAPUControlWindow(IDCommonControlWindow):
         self._pb_home.setToolTip('Execute homing for selected axis.')
         self._pb_home.channel = self.dev_pref.substitute(propty='Home-Cmd')
         self._pb_home.pressValue = 1
-        self._pb_home.setObjectName('btn')
-        self._pb_home.setStyleSheet(
-            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
-        self._led_home = SiriusLedState(
+        self._pb_home.setObjectName(btnname)
+        self._pb_home.setStyleSheet(btnsty)
+        self._led_home = SiriusLabel(
             self, self.dev_pref.substitute(propty='Home-Mon'))
+
+        self._ld_parkspd = QLabel('Park Speed [mm/s]', self)
+        self._sb_parkspd = SiriusSpinbox(
+            self, self.dev_pref.substitute(propty='ParkSpeed-SP'))
+        self._sb_parkspd.setStyleSheet('max-width:4.5em;')
+        self._lb_parkspd = SiriusLabel(
+            self, self.dev_pref.substitute(propty='ParkSpeed-RB'))
+
+        self._ld_park = QLabel('Do parking', self)
+        pvname = self.dev_pref.substitute(propty='Park-Cmd')
+        self._pb_park = PyDMPushButton(
+            parent=self, label='', icon=qta.icon('fa5s.parking'),
+            init_channel=pvname, pressValue=1)
+        self._pb_park.setObjectName(btnname)
+        self._pb_park.setStyleSheet(btnsty)
+
+        self._ld_gotomin = QLabel('Go to minimum Phase', self)
+        pvname = self.dev_pref.substitute(propty='GoToMinPhase-Cmd')
+        self._pb_gotomin = PyDMPushButton(
+            parent=self, label='Go to minimum',
+            init_channel=pvname, pressValue=1)
+        self._ld_gotoop = QLabel('Go to operation Phase', self)
+        pvname = self.dev_pref.substitute(propty='GoToOpPhase-Cmd')
+        self._pb_gotoop = PyDMPushButton(
+            parent=self, label='Go to operation',
+            init_channel=pvname, pressValue=1)
 
         self._ld_clrerr = QLabel('Clear Drive Errors', self)
         pvname = self.dev_pref.substitute(propty='ClearErr-Cmd')
         self._pb_clrerr = PyDMPushButton(
             parent=self, label='', icon=qta.icon('fa5s.sync'),
             init_channel=pvname, pressValue=1)
-        self._pb_clrerr.setObjectName('btn')
-        self._pb_clrerr.setStyleSheet(
-            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+        self._pb_clrerr.setObjectName(btnname)
+        self._pb_clrerr.setStyleSheet(btnsty)
 
         lay = QGridLayout(gbox)
         lay.addWidget(self._ld_phsspdlim, 0, 0)
         lay.addWidget(self._sb_phsspdlim, 0, 1)
         lay.addWidget(self._lb_phsspdlim, 0, 2)
-        lay.addWidget(self._ld_pwrenbl, 1, 0)
-        lay.addWidget(self._pb_pwrenbl, 1, 1)
-        lay.addWidget(self._led_pwrsts, 1, 2, alignment=Qt.AlignLeft)
-        lay.addWidget(self._ld_homeaxis, 2, 0)
-        lay.addWidget(self._pb_home, 2, 1)
-        lay.addWidget(self._led_home, 2, 2, alignment=Qt.AlignLeft)
-        lay.addItem(QSpacerItem(1, 15, QSzPlcy.Ignored, QSzPlcy.Fixed), 3, 0)
-        lay.addWidget(self._ld_clrerr, 4, 0)
-        lay.addWidget(self._pb_clrerr, 4, 1)
+        lay.addItem(QSpacerItem(1, 8, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, 0)
+        lay.addWidget(self._ld_pwrenbl, 2, 0)
+        lay.addWidget(self._pb_pwrenbl, 2, 1)
+        lay.addWidget(self._led_pwrsts, 2, 2, alignment=Qt.AlignLeft)
+        lay.addItem(QSpacerItem(1, 8, QSzPlcy.Ignored, QSzPlcy.Fixed), 3, 0)
+        lay.addWidget(self._ld_homeaxis, 4, 0)
+        lay.addWidget(self._pb_home, 4, 1)
+        lay.addWidget(self._led_home, 4, 2, alignment=Qt.AlignLeft)
+        lay.addItem(QSpacerItem(1, 8, QSzPlcy.Ignored, QSzPlcy.Fixed), 5, 0)
+        lay.addWidget(self._ld_parkspd, 6, 0)
+        lay.addWidget(self._sb_parkspd, 6, 1)
+        lay.addWidget(self._lb_parkspd, 6, 2)
+        lay.addWidget(self._ld_park, 7, 0)
+        lay.addWidget(self._pb_park, 7, 1)
+        lay.addItem(QSpacerItem(1, 8, QSzPlcy.Ignored, QSzPlcy.Fixed), 8, 0)
+        lay.addWidget(self._ld_gotomin, 9, 0)
+        lay.addWidget(self._pb_gotomin, 9, 1, 1, 2)
+        lay.addWidget(self._ld_gotoop, 10, 0)
+        lay.addWidget(self._pb_gotoop, 10, 1, 1, 2)
+        lay.addItem(QSpacerItem(1, 8, QSzPlcy.Ignored, QSzPlcy.Fixed), 11, 0)
+        lay.addWidget(self._ld_clrerr, 12, 0)
+        lay.addWidget(self._pb_clrerr, 12, 1)
 
         gbox.setStyleSheet(
             '.QLabel{qproperty-alignment: "AlignRight | AlignVCenter";}')
@@ -297,6 +350,7 @@ class PAPUDetails(IDCommonDialog):
             lbl = QLabel(pvn.split('-')[0] + ':', self)
             glay.addWidget(lbl, row, 0, alignment=Qt.AlignRight)
             wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
+            wid.showUnits = True
             if pvn == 'DiagMessage-Mon':
                 wid.displayFormat = wid.DisplayFormat.String
             glay.addWidget(wid, row, 1)
@@ -304,7 +358,7 @@ class PAPUDetails(IDCommonDialog):
             c2v = None
             if pvn == 'Code-Mon':
                 c2v = {self.dev_pref.substitute(
-                    propty=pvn): {'comp': 'eq', 'value': 'A211'}}
+                    propty=pvn): {'comp': 'in', 'value': ['A211', 'A012']}}
             elif pvn == 'MotorTemp-Mon':
                 c2v = {self.dev_pref.substitute(
                     propty=pvn): {'comp': 'lt', 'value': 90}}

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -291,12 +291,14 @@ class PAPUDetails(IDCommonDialog):
 
         drivebox = QGroupBox('Drive Status', self)
         glay = QGridLayout(drivebox)
-        propties = ['ResolverPos-Mon', 'Code-Mon', 'Torque-Mon',
-                    'MotorTemp-Mon']
+        propties = ['ResolverPos-Mon', 'Torque-Mon', 'MotorTemp-Mon',
+                    'Code-Mon', 'DiagMessage-Mon']
         for row, pvn in enumerate(propties):
             lbl = QLabel(pvn.split('-')[0] + ':', self)
             glay.addWidget(lbl, row, 0, alignment=Qt.AlignRight)
             wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
+            if pvn == 'DiagMessage-Mon':
+                wid.displayFormat = wid.DisplayFormat.String
             glay.addWidget(wid, row, 1)
 
             c2v = None

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -1,0 +1,303 @@
+"""EPU Control Module."""
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QGroupBox, QGridLayout, QLabel, QFormLayout, \
+    QHBoxLayout, QSizePolicy as QSzPlcy, QSpacerItem, QPushButton, QVBoxLayout
+import qtawesome as qta
+from pydm.widgets import PyDMPushButton
+
+from ..util import connect_newprocess, connect_window
+from ..widgets import PyDMLogLabel, PyDMLed, \
+    SiriusLedState, SiriusLabel, SiriusSpinbox
+
+from .base import IDCommonControlWindow, IDCommonDialog, \
+    IDCommonSummaryBase, IDCommonSummaryHeader, IDCommonSummaryWidget
+
+
+class PAPUControlWindow(IDCommonControlWindow):
+    """PAPU Control Window."""
+
+    def _mainControlsWidget(self):
+        gbox = QGroupBox('Main Controls', self)
+        lay = QGridLayout(gbox)
+
+        self._ld_phs = QLabel('Phase [mm]', self)
+        self._sb_phs = SiriusSpinbox(
+            self, self.dev_pref.substitute(propty='Phase-SP'))
+        self._lb_phs = SiriusLabel(
+            self, self.dev_pref.substitute(propty='Phase-RB'))
+        self._lb_phsmon = SiriusLabel(
+            self, self.dev_pref.substitute(propty='Phase-Mon'))
+
+        self._ld_phsspd = QLabel('Phase Speed [mm/s]', self)
+        self._sb_phsspd = SiriusSpinbox(
+            self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
+        self._lb_phsspd = SiriusLabel(
+            self, self.dev_pref.substitute(propty='PhaseSpeed-RB'))
+        self._lb_phsspdmon = SiriusLabel(
+            self, self.dev_pref.substitute(propty='PhaseSpeed-Mon'))
+
+        self._ld_enbl = QLabel('Allow Phase Motion', self)
+        self._ld_enbl.setToolTip('Enable Axis and Release Brakes')
+        pvname = self.dev_pref.substitute(propty='EnblAndReleasePhase-Sel')
+        self._pb_movdsbl = PyDMPushButton(
+            parent=self, label='Dsbl', init_channel=pvname, pressValue=0)
+        self._pb_movdsbl.setObjectName('btn')
+        self._pb_movdsbl.setStyleSheet('#btn{min-width:3em; max-width:3em;}')
+        self._pb_movenbl = PyDMPushButton(
+            parent=self, label='Enbl', init_channel=pvname, pressValue=1)
+        self._pb_movenbl.setObjectName('btn')
+        self._pb_movenbl.setStyleSheet('#btn{min-width:3em; max-width:3em;}')
+        self._led_movsts = SiriusLedState(
+            self, self.dev_pref.substitute(propty='AllowedToChangePhase-Mon'))
+        hbox_enbl = QHBoxLayout()
+        hbox_enbl.setContentsMargins(0, 0, 0, 0)
+        hbox_enbl.setSpacing(3)
+        hbox_enbl.addWidget(self._pb_movdsbl)
+        hbox_enbl.addWidget(self._pb_movenbl)
+        hbox_enbl.addWidget(self._led_movsts)
+        hbox_enbl.addStretch()
+
+        self._ld_phsismov = QLabel('Phase Motion', self)
+        self._pb_phsstop = PyDMPushButton(
+            self, label='', icon=qta.icon('fa5s.stop'))
+        self._pb_phsstop.setToolTip('Stop all phase motion, lock all brakes.')
+        pvname = self.dev_pref.substitute(propty='StopPhase-Cmd')
+        self._pb_phsstop.channel = pvname
+        self._pb_phsstop.pressValue = 1  # Stop
+        self._pb_phsstop.setObjectName('Stop')
+        self._pb_phsstop.setStyleSheet(
+            '#Stop{min-width:30px; max-width:30px; icon-size:25px;}')
+        self._pb_phsstart = PyDMPushButton(
+            self, label='', icon=qta.icon('fa5s.play'))
+        self._pb_phsstart.setToolTip(
+            'Start automatic Phase motion towards previously '
+            'entered setpoint.')
+        pvname = self.dev_pref.substitute(propty='ChangePhase-Cmd')
+        self._pb_phsstart.channel = pvname
+        self._pb_phsstart.pressValue = 1
+        self._pb_phsstart.setObjectName('Start')
+        self._pb_phsstart.setStyleSheet(
+            '#Start{min-width:30px; max-width:30px; icon-size:25px;}')
+
+        self._led_ismov = SiriusLedState(
+            self, self.dev_pref.substitute(propty='Moving-Mon'))
+        hbox_mov = QHBoxLayout()
+        hbox_mov.setSpacing(24)
+        hbox_mov.addWidget(self._pb_phsstop)
+        hbox_mov.addWidget(self._pb_phsstart)
+        hbox_mov.addWidget(self._led_ismov)
+        hbox_mov.addStretch()
+
+        lay.addWidget(self._ld_phs, 0, 0)
+        lay.addWidget(self._sb_phs, 0, 1)
+        lay.addWidget(self._lb_phs, 0, 2)
+        lay.addWidget(self._lb_phsmon, 0, 3)
+        lay.addWidget(self._ld_phsspd, 1, 0)
+        lay.addWidget(self._sb_phsspd, 1, 1)
+        lay.addWidget(self._lb_phsspd, 1, 2)
+        lay.addWidget(self._lb_phsspdmon, 1, 3)
+        lay.addWidget(self._ld_enbl, 2, 0)
+        lay.addLayout(hbox_enbl, 2, 1, 1, 3)
+        lay.addWidget(self._ld_phsismov, 3, 0)
+        lay.addLayout(hbox_mov, 3, 1, 1, 3)
+        lay.addItem(QSpacerItem(1, 15, QSzPlcy.Ignored, QSzPlcy.Fixed), 4, 0)
+
+        gbox.setStyleSheet(
+            '.QLabel{qproperty-alignment: "AlignRight | AlignVCenter";}')
+        return gbox
+
+    def _statusWidget(self):
+        self._pb_dtlsts = QPushButton('', self)
+        self._pb_dtlsts.setIcon(qta.icon('fa5s.list-ul'))
+        self._pb_dtlsts.setToolTip('Open Detailed Status View')
+        self._pb_dtlsts.setObjectName('sts')
+        self._pb_dtlsts.setStyleSheet(
+            '#sts{min-width:25px; max-width:25px; icon-size:20px;}')
+        connect_window(
+            self._pb_dtlsts, PAPUDetails, self,
+            prefix=self._prefix, device=self._device)
+
+        self._log = PyDMLogLabel(
+            self, init_channel=self.dev_pref.substitute(propty='Log-Mon'))
+        self._log.setSizePolicy(
+            QSzPlcy.MinimumExpanding, QSzPlcy.MinimumExpanding)
+        self._log.setAlternatingRowColors(True)
+        self._log.maxCount = 2000
+
+        self._bt_logclear = QPushButton('Clear Log', self)
+        self._bt_logclear.clicked.connect(self._log.clear)
+
+        gbox = QGroupBox('Status')
+        gbox.setSizePolicy(QSzPlcy.MinimumExpanding, QSzPlcy.Preferred)
+        lay = QGridLayout(gbox)
+        lay.addWidget(self._log, 0, 0, 1, 2)
+        lay.addWidget(self._bt_logclear, 1, 0, alignment=Qt.AlignCenter)
+        lay.addWidget(self._pb_dtlsts, 1, 1, alignment=Qt.AlignRight)
+        return gbox
+
+    def _auxCommandsWidget(self):
+        gbox = QGroupBox('Auxiliary Commands', self)
+
+        self._ld_phsspdlim = QLabel('Max Phase Speed [mm/s]', self)
+        self._sb_phsspdlim = SiriusSpinbox(
+            self, self.dev_pref.substitute(propty='MaxPhaseSpeed-SP'))
+        self._sb_phsspdlim.setStyleSheet('max-width:4.5em;')
+        self._lb_phsspdlim = SiriusLabel(
+            self, self.dev_pref.substitute(propty='MaxPhaseSpeed-RB'))
+
+        self._ld_pwrenbl = QLabel('Enable Phase Drives Power', self)
+        pvname = self.dev_pref.substitute(propty='EnblPwrPhase-Cmd')
+        self._pb_pwrenbl = PyDMPushButton(
+            parent=self, label='', icon=qta.icon('fa5s.plug'),
+            init_channel=pvname, pressValue=1)
+        self._pb_pwrenbl.setObjectName('btn')
+        self._pb_pwrenbl.setStyleSheet(
+            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+        self._led_pwrsts = SiriusLedState(
+            self, self.dev_pref.substitute(propty='PwrPhase-Mon'))
+        self._led_pwrsts.offColor = PyDMLed.Red
+
+        self._ld_homeaxis = QLabel('Do homing', self)
+        self._pb_home = PyDMPushButton(
+            self, label='', icon=qta.icon('mdi.keyboard-return'))
+        self._pb_home.setToolTip('Execute homing for selected axis.')
+        self._pb_home.channel = self.dev_pref.substitute(propty='Home-Cmd')
+        self._pb_home.pressValue = 1
+        self._pb_home.setObjectName('btn')
+        self._pb_home.setStyleSheet(
+            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+        self._led_home = SiriusLedState(
+            self, self.dev_pref.substitute(propty='Home-Mon'))
+
+        self._ld_clrerr = QLabel('Clear Drive Errors', self)
+        pvname = self.dev_pref.substitute(propty='ClearErr-Cmd')
+        self._pb_clrerr = PyDMPushButton(
+            parent=self, label='', icon=qta.icon('fa5s.sync'),
+            init_channel=pvname, pressValue=1)
+        self._pb_clrerr.setObjectName('btn')
+        self._pb_clrerr.setStyleSheet(
+            '#btn{min-width:30px; max-width:30px; icon-size:25px;}')
+
+        lay = QGridLayout(gbox)
+        lay.addWidget(self._ld_phsspdlim, 0, 0)
+        lay.addWidget(self._sb_phsspdlim, 0, 1)
+        lay.addWidget(self._lb_phsspdlim, 0, 2)
+        lay.addWidget(self._ld_pwrenbl, 1, 0)
+        lay.addWidget(self._pb_pwrenbl, 1, 1)
+        lay.addWidget(self._led_pwrsts, 1, 2, alignment=Qt.AlignLeft)
+        lay.addWidget(self._ld_homeaxis, 2, 0)
+        lay.addWidget(self._pb_home, 2, 1)
+        lay.addWidget(self._led_home, 2, 2, alignment=Qt.AlignLeft)
+        lay.addItem(QSpacerItem(1, 15, QSzPlcy.Ignored, QSzPlcy.Fixed), 3, 0)
+        lay.addWidget(self._ld_clrerr, 4, 0)
+        lay.addWidget(self._pb_clrerr, 4, 1)
+
+        gbox.setStyleSheet(
+            '.QLabel{qproperty-alignment: "AlignRight | AlignVCenter";}')
+        return gbox
+
+    def _ffSettingsWidget(self):
+        but = QPushButton('Feedforward Settings', self)
+        connect_newprocess(
+            but, ['sirius-hla-si-ap-idff.py', self._device])
+        return but
+
+
+class PAPUSummaryBase(IDCommonSummaryBase):
+    """PAPU Summary Base Widget."""
+
+    MODEL_WIDTHS = (
+        ('Status', 4),
+        ('Phase', 6),
+        ('Phase Speed', 6),
+        ('Start Phase', 4),
+        ('Stop Phase', 4),
+    )
+
+
+class PAPUSummaryHeader(IDCommonSummaryHeader, PAPUSummaryBase):
+    """EPU Summary Header."""
+
+
+class PAPUSummaryWidget(IDCommonSummaryWidget, PAPUSummaryBase):
+    """EPU Summary Widget."""
+
+    def _get_widgets(self, prop):
+        wids, orientation = super()._get_widgets(prop)
+        if not wids:
+            orientation = 'v'
+        if prop == 'Status':
+            led = SiriusLedState(
+                self, self.dev_pref.substitute(
+                    propty='AllowedToChangePhase-Mon'))
+            led.offColor = led.Red
+            wids.append(led)
+        elif prop == 'Phase':
+            spb = SiriusSpinbox(
+                self, self.dev_pref.substitute(propty='Phase-SP'))
+            wids.append(spb)
+            lbl = SiriusLabel(
+                self, self.dev_pref.substitute(propty='Phase-Mon'))
+            wids.append(lbl)
+        elif prop == 'Phase Speed':
+            spb = SiriusSpinbox(
+                self, self.dev_pref.substitute(propty='PhaseSpeed-SP'))
+            wids.append(spb)
+            lbl = SiriusLabel(
+                self, self.dev_pref.substitute(propty='PhaseSpeed-Mon'))
+            wids.append(lbl)
+        elif prop == 'Start Phase':
+            btn = PyDMPushButton(self, label='', icon=qta.icon('fa5s.play'))
+            btn.setToolTip(
+                'Start automatic motion towards previously entered setpoint.')
+            btn.channel = self.dev_pref.substitute(propty='ChangePhase-Cmd')
+            btn.pressValue = 1
+            btn.setObjectName('Start')
+            btn.setStyleSheet(
+                '#Start{min-width:30px; max-width:30px; icon-size:25px;}')
+            wids.append(btn)
+        elif prop == 'Stop Phase':
+            btn = PyDMPushButton(self, label='', icon=qta.icon('fa5s.stop'))
+            btn.setToolTip('Stop all motion, lock all brakes.')
+            btn.channel = self.dev_pref.substitute(propty='StopPhase-Cmd')
+            btn.pressValue = 1
+            btn.setObjectName('Stop')
+            btn.setStyleSheet(
+                '#Stop{min-width:30px; max-width:30px; icon-size:25px;}')
+            wids.append(btn)
+        return wids, orientation
+
+
+class PAPUDetails(IDCommonDialog):
+    """PAPU Details."""
+
+    def __init__(self, parent=None, prefix='', device=''):
+        """Init."""
+        super().__init__(
+            parent, prefix, device, title=device+' Drive Details')
+
+    def _setupUi(self):
+        connbox = QGroupBox('Connection', self)
+        flay = QFormLayout(connbox)
+        flay.setLabelAlignment(Qt.AlignRight)
+        for pvn in ['Connected-Mon', 'MsgServerConnected-Mon',
+                    'IoServerConnected-Mon', 'SerialConnected-Mon']:
+            lbl = pvn.split('-')[0] + ':'
+            wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
+            flay.addRow(lbl, wid)
+
+        drivebox = QGroupBox('Drive Status', self)
+        flay = QFormLayout(drivebox)
+        flay.setLabelAlignment(Qt.AlignRight)
+        for pvn in ['ResolverPos-Mon', 'Code-Mon', 'Torque-Mon',
+                    'Speed-Mon', 'MotorTemp-Mon']:
+            lbl = pvn.split('-')[0] + ':'
+            wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
+            flay.addRow(lbl, wid)
+
+        self.setStyleSheet(
+            'QLabel{qproperty-alignment: AlignCenter; max-width: 12em;}')
+        lay = QVBoxLayout(self)
+        lay.addWidget(connbox)
+        lay.addWidget(drivebox)

--- a/pyqt-apps/siriushla/si_id_control/papu.py
+++ b/pyqt-apps/siriushla/si_id_control/papu.py
@@ -7,7 +7,7 @@ import qtawesome as qta
 from pydm.widgets import PyDMPushButton
 
 from ..util import connect_newprocess, connect_window
-from ..widgets import PyDMLogLabel, PyDMLed, \
+from ..widgets import PyDMLogLabel, PyDMLed, PyDMLedMultiChannel, \
     SiriusLedState, SiriusLabel, SiriusSpinbox
 
 from .base import IDCommonControlWindow, IDCommonDialog, \
@@ -288,13 +288,19 @@ class PAPUDetails(IDCommonDialog):
             flay.addRow(lbl, wid)
 
         drivebox = QGroupBox('Drive Status', self)
-        flay = QFormLayout(drivebox)
-        flay.setLabelAlignment(Qt.AlignRight)
-        for pvn in ['ResolverPos-Mon', 'Code-Mon', 'Torque-Mon',
-                    'MotorTemp-Mon']:
-            lbl = pvn.split('-')[0] + ':'
+        glay = QGridLayout(drivebox)
+        propties = ['ResolverPos-Mon', 'Code-Mon', 'Torque-Mon',
+                    'MotorTemp-Mon']
+        for row, pvn in enumerate(propties):
+            lbl = QLabel(pvn.split('-')[0] + ':', self)
+            glay.addWidget(lbl, row, 0, alignment=Qt.AlignRight)
             wid = SiriusLabel(self, self.dev_pref.substitute(propty=pvn))
-            flay.addRow(lbl, wid)
+            glay.addWidget(wid, row, 1)
+            if pvn == 'MotorTemp-Mon':
+                c2v = {self.dev_pref.substitute(
+                    propty=pvn): {'comp': 'lt', 'value': 90}}
+                led = PyDMLedMultiChannel(self, c2v)
+                glay.addWidget(led, row, 2, alignment=Qt.AlignLeft)
 
         self.setStyleSheet(
             'QLabel{qproperty-alignment: AlignCenter; max-width: 12em;}')

--- a/pyqt-apps/siriushla/widgets/QLed.py
+++ b/pyqt-apps/siriushla/widgets/QLed.py
@@ -49,11 +49,15 @@ class QLed(QFrame, ShapeMap):
     f.close()
 
     Green = QColor(15, 105, 0)
+    DarkGreen = QColor(20, 80, 10)
+    LightGreen = QColor(0, 140, 0)
     Red = QColor(207, 0, 0)
+    DarkRed = QColor(120, 0, 0)
     Gray = QColor(90, 90, 90)
     SelColor = QColor(0, 0, 0)
     NotSelColor1 = QColor(251, 244, 252)
     NotSelColor2 = QColor(173, 173, 173)
+    Yellow = QColor(210, 205, 0)
 
     clicked = Signal()
     selected = Signal(bool)

--- a/pyqt-apps/siriushla/widgets/led.py
+++ b/pyqt-apps/siriushla/widgets/led.py
@@ -31,12 +31,8 @@ class PyDMLed(QLed, PyDMWidget):
         List of QColor objects for each state the channel can assume.
     """
 
-    DarkGreen = QColor(20, 80, 10)
-    LightGreen = QColor(0, 140, 0)
-    Yellow = QColor(210, 205, 0)
-    Red = QColor(207, 0, 0)
-    DarkRed = QColor(120, 0, 0)
-    default_colorlist = [DarkGreen, LightGreen, Yellow, Red]
+    default_colorlist = [
+        QLed.DarkGreen, QLed.LightGreen, QLed.Yellow, QLed.Red]
 
     def __init__(self, parent=None, init_channel=None, bit=-1,
                  color_list=None):


### PR DESCRIPTION
This PR:
- adds first version of PAPU50 window
![Screenshot from 2023-06-14 10-26-41](https://github.com/lnls-sirius/hla/assets/21130191/e02e6ea3-b04a-42ef-9a3b-8a99fce276ee)
![Screenshot from 2023-06-16 09-33-44](https://github.com/lnls-sirius/hla/assets/21130191/9f999e14-f446-4d01-bac9-92016d6da8d8)
![Screenshot from 2023-06-16 09-33-35](https://github.com/lnls-sirius/hla/assets/21130191/f521564a-470f-4c52-97e4-3f293cfe9d9b)

- adapts PSMonitor and PSDetail windows to include new FF power supplies
![Screenshot from 2023-06-13 15-04-18](https://github.com/lnls-sirius/hla/assets/21130191/dabea2fc-5957-4d17-b850-6c48298136a6)

- generalize IDFF to consider only ID existing parameters and add PVs to control QS only when necessary
![Screenshot from 2023-06-13 15-02-26](https://github.com/lnls-sirius/hla/assets/21130191/4e0d3aa4-7b3c-4074-a71f-67b2777e6b35)

