### PR TITLE
Update Orbit Interlock window

### DIFF
--- a/pyqt-apps/siriushla/as_di_bpms/base.py
+++ b/pyqt-apps/siriushla/as_di_bpms/base.py
@@ -82,7 +82,7 @@ class BaseWidget(QWidget):
             hbl.addWidget(lab)
             lab = QLabel(txt)
             lab.setObjectName(pv1.split('-')[0])
-            lab.setStyleSheet("min-width:8em;")
+            lab.setStyleSheet("min-width:10em;")
             fbl.addRow(lab, hbl)
         return grpbx
 

--- a/pyqt-apps/siriushla/as_di_bpms/settings.py
+++ b/pyqt-apps/siriushla/as_di_bpms/settings.py
@@ -78,11 +78,17 @@ class ParamsSettings(BaseWidget):
         vbl.addSpacing(20)
         vbl.addStretch()
         grpbx = self._create_formlayout_groupbox('Informations', (
-            ('INFOHarmonicNumber-SP', 'Harmonic Number'),
-            ('INFOFOFBRate-SP', 'FOFB Rate'),
-            ('INFOMONITRate-SP', 'Monitor Rate'),
-            ('INFOTbTRate-SP', 'TbT Rate'),
-            ('RFFEAtt-SP', 'RFFE Attenuation')))
+            ('INFOHarmonicNumber-RB', 'Harmonic Number'),
+            ('INFOFOFBRate-RB', 'FOFB Rate'),
+            ('INFOMONITRate-RB', 'Monitor Rate'),
+            ('INFOTbTRate-RB', 'TbT Rate')))
+        vbl.addWidget(grpbx)
+        vbl.addSpacing(20)
+        vbl.addStretch()
+        grpbx = self._create_formlayout_groupbox(
+            'RFFE and Switching Settings', (
+                ('RFFEAtt-SP', 'RFFE Attenuation'),
+                ('SwMode-Sel', 'Switching Mode')))
         vbl.addWidget(grpbx)
         vbl.addSpacing(20)
         vbl.addStretch()

--- a/pyqt-apps/siriushla/as_di_bpms/settings.py
+++ b/pyqt-apps/siriushla/as_di_bpms/settings.py
@@ -44,7 +44,7 @@ class ParamsSettings(BaseWidget):
         grpbx = CustomGroupBox('Advanced Settings', self)
         vbl2 = QVBoxLayout(grpbx)
         vbl2.setSpacing(10)
-        pbt = QPushButton('Software')
+        pbt = QPushButton('Details')
         Window = create_window_from_widget(
             AdvancedSettings, title=self.bpm+': Advanced Settings')
         util.connect_window(

--- a/pyqt-apps/siriushla/as_di_bpms/trig_acq_config.py
+++ b/pyqt-apps/siriushla/as_di_bpms/trig_acq_config.py
@@ -19,7 +19,7 @@ class ACQTrigConfigs(BaseWidget):
             'General Configurations', (
                 ('BPMMode-Sel', 'Operation Mode'),
                 ('TriggerRep-Sel', 'Repeat Acquisitions'),
-                ('TriggerHwDly-SP', 'Delay [us]'),
+                ('TriggerHwDly-SP', 'Delay [adc counts]'),
                 ('SamplesPre-SP', 'Pre-Trigger NrSamples'),
                 ('SamplesPost-SP', 'Post-Trigger NrSamples'),
                 ('Trigger-Sel', 'Trigger Type')))
@@ -57,9 +57,9 @@ class ACQTrigConfigs(BaseWidget):
             'MultiBunch Configurations', (
                 ('Channel-Sel', 'Acquisition Rate'),
                 ('Shots-SP', 'Number of Shots'),
-                ('UpdateTime-SP', 'Update Interval'),
+                ('UpdateTime-SP', 'Update Interval [s]'),
                 ('TbTTagEn-Sel', 'Sync Timing', False),
-                ('TbTTagDly-SP', 'TbT Delay', False),
+                ('TbTTagDly-SP', 'TbT Delay [adc counts]', False),
                 ('TbTDataMaskEn-Sel', 'Mask Data', False),
                 ('TbTDataMaskSamplesBeg-SP', 'Mask Begin', False),
                 ('TbTDataMaskSamplesEnd-SP', 'Mask End', False),

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -1537,6 +1537,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         self._psmodel = 'FOFB_PS'
         self._pstype = 'si-corrector-fc1-ch'
         self._db = get_ps_propty_database(self._psmodel, self._pstype)
+        self._db['AlarmsAmpLtcLabels-Cte'] = self._db['AlarmsAmpLabels-Cte']
         self._setup_ui()
 
     def _setup_ui(self):
@@ -1720,22 +1721,37 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         return layout
 
     def _interlockLayout(self):
-        self.alarm_label = QLabel('AlarmsAmp', self, alignment=Qt.AlignCenter)
-        self.alarm_bt = QPushButton(qta.icon('fa5s.list-ul'), '', self)
-        self.alarm_bt.setObjectName('alarm_bt')
-        self.alarm_bt.setStyleSheet(
-            '#alarm_bt{min-width:25px; max-width:25px; icon-size:20px;}')
-        util.connect_window(
-            self.alarm_bt, InterlockWindow, self,
-            devname=self._psname, database=self._db, interlock='AlarmsAmp')
-        self.alarm_led = SiriusLedAlert(
-            parent=self, init_channel=self._prefixed_psname + ":AlarmsAmp-Mon")
-
         layout = QGridLayout()
         layout.setAlignment(Qt.AlignCenter)
-        layout.addWidget(self.alarm_bt, 0, 0)
-        layout.addWidget(self.alarm_label, 0, 1)
-        layout.addWidget(self.alarm_led, 0, 2)
+
+        row = 0
+        for pvn in ['AlarmsAmp', 'AlarmsAmpLtc']:
+            alarm_label = QLabel(pvn, self, alignment=Qt.AlignCenter)
+            alarm_bt = QPushButton(qta.icon('fa5s.list-ul'), '', self)
+            alarm_bt.setObjectName('alarm_bt')
+            alarm_bt.setStyleSheet(
+                '#alarm_bt{min-width:25px; max-width:25px; icon-size:20px;}')
+
+            util.connect_window(
+                alarm_bt, InterlockWindow, self,
+                devname=self._psname, database=self._db, interlock=pvn)
+            alarm_led = SiriusLedAlert(
+                parent=self, init_channel=self._prefixed_psname+':'+pvn+'-Mon')
+            alarm_led.onColor = alarm_led.Yellow
+
+            layout.addWidget(alarm_bt, row, 0)
+            layout.addWidget(alarm_label, row, 1)
+            layout.addWidget(alarm_led, row, 2)
+            row += 1
+
+        self.reset_bt = PyDMPushButton(
+            parent=self, icon=qta.icon('fa5s.sync'), pressValue=1,
+            init_channel=self._prefixed_psname + ":AlarmsAmpLtcRst-Cmd")
+        self.reset_bt.setObjectName('reset_bt')
+        self.reset_bt.setStyleSheet(
+            '#reset_bt{min-width:25px; max-width:25px; icon-size:20px;}')
+        layout.addWidget(self.reset_bt, row, 2)
+
         return layout
 
     def _currLoopLayout(self):

--- a/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
+++ b/pyqt-apps/siriushla/as_ps_control/detail_widget/PSDetailWidget.py
@@ -1905,7 +1905,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         self.graph_curr = SiriusWaveformPlot()
         self.graph_curr.addChannel(
             y_channel=self._prefixed_psname + ':LAMPCurrentData',
-            name='Current', color='blue', lineWidth=2)
+            name='Current', color='blue', lineWidth=1)
         # self.graph_curr.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
         self.graph_curr.autoRangeX = True
         self.graph_curr.autoRangeY = True
@@ -1915,13 +1915,13 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         self.graph_curr.setLabel('left', text='Current [A]', color='gray')
         self.graph_curr.setLabel('bottom', text='Index')
         self.graph_curr.setBackgroundColor(QColor(255, 255, 255))
-        tabmon.addTab(self.graph_curr, 'Curr.')
+        tabmon.addTab(self.graph_curr, 'Current Acq.')
 
         # # voltage waveform
         self.graph_volt = SiriusWaveformPlot()
         self.graph_volt.addChannel(
             y_channel=self._prefixed_psname + ':LAMPVoltageData',
-            name='Voltage', color='blue', lineWidth=2)
+            name='Voltage', color='blue', lineWidth=1)
         # self.graph_volt.setSizePolicy(QSzPlcy.Maximum, QSzPlcy.Maximum)
         self.graph_volt.autoRangeX = True
         self.graph_volt.autoRangeY = True
@@ -1931,7 +1931,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         self.graph_volt.setLabel('left', text='Voltage [V]', color='gray')
         self.graph_volt.setLabel('bottom', text='Index')
         self.graph_volt.setBackgroundColor(QColor(255, 255, 255))
-        tabmon.addTab(self.graph_volt, 'Volt.')
+        tabmon.addTab(self.graph_volt, 'Voltage Acq.')
 
         # # current history
         self.graph_chist = SiriusTimePlot()
@@ -1950,7 +1950,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
             pvname = self._prefixed_psname.substitute(propty='Current'+pvs)
             legtxt = pvs.replace('-', '')
             self.graph_chist.addYChannel(
-                y_channel=pvname, name=legtxt, color=color, lineWidth=2)
+                y_channel=pvname, name=legtxt, color=color, lineWidth=1)
             curve = self.graph_chist.curveAtIndex(-1)
             cb_show = QCheckBox(legtxt)
             cb_show.setChecked(True)
@@ -1962,6 +1962,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         self.graph_chist.autoRangeY = True
         self.graph_chist.showXGrid = True
         self.graph_chist.showYGrid = True
+        self.graph_chist.timeSpan = 30  # [s]
         self.graph_chist.title = 'Current Mean History'
         self.graph_chist.setLabel('left', text='Current [A]', color='gray')
         self.graph_chist.showLegend = True
@@ -1971,7 +1972,7 @@ class FastCorrPSDetailWidget(_BaseDetailWidget):
         lay_currhist.setContentsMargins(0, 0, 0, 0)
         lay_currhist.addWidget(self.graph_chist)
         lay_currhist.addLayout(hbox_show)
-        tabmon.addTab(wid_currhist, 'Curr.Hist.')
+        tabmon.addTab(wid_currhist, 'Current Hist.')
         tabmon.setCurrentIndex(2)
 
         layout = QHBoxLayout()

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -406,13 +406,13 @@ class EVG(BaseWidget):
         lb = QLabel("<b>FRMVERSION</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.Hex
+        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.Hex
+        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.Hex
+        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)
@@ -1230,13 +1230,13 @@ class FOUT(BaseWidget):
         lb = QLabel("<b>FRMVERSION</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.Hex
+        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.Hex
+        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.Hex
+        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)
@@ -1837,13 +1837,13 @@ class _EVR_EVE(BaseWidget):
         lb = QLabel("<b>FRMVERSION</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.Hex
+        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.Hex
+        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.Hex
+        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -93,7 +93,7 @@ class EVG(BaseWidget):
         self.configs_wid = self._setup_configs_wid()
         maintab.addTab(self.configs_wid, 'Main')
         self.info_wid = self._setup_info_wid()
-        maintab.addTab(self.info_wid, 'FRM && IOC')
+        maintab.addTab(self.info_wid, 'Fw && IOC')
         conflay.addWidget(maintab)
         self.bucketlist_wid = BucketList(self, self.device, self.prefix)
         conflay.addWidget(self.bucketlist_wid)
@@ -403,16 +403,16 @@ class EVG(BaseWidget):
         gb = self._create_small_group('', info_wid, (lb, mon, inp))
         lay.addWidget(gb, 1, 2, alignment=Qt.AlignHCenter)
 
-        lb = QLabel("<b>FRMVERSION</b>")
+        lb = QLabel("<b>Fw.Version</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
+        frma.displayFormat = frma.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
+        frmb.displayFormat = frmb.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
+        frmc.displayFormat = frmc.DisplayFormat.TIFwVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)
@@ -1083,7 +1083,7 @@ class FOUT(BaseWidget):
         self.status_wid = self._setup_status_wid()
         stattab.addTab(self.status_wid, 'Status')
         self.info_wid = self._setup_info_wid()
-        stattab.addTab(self.info_wid, 'FRM && IOC')
+        stattab.addTab(self.info_wid, 'Fw && IOC')
         self.my_layout.addWidget(stattab, 2, 0)
         stattab.setSizePolicy(QSzPol.Preferred, QSzPol.Maximum)
 
@@ -1227,16 +1227,16 @@ class FOUT(BaseWidget):
         gb = self._create_small_group('', info_wid, (lb, sp))
         info_lay.addWidget(gb, 1, 1, alignment=Qt.AlignTop)
 
-        lb = QLabel("<b>FRMVERSION</b>")
+        lb = QLabel("<b>Fw.Version</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
+        frma.displayFormat = frma.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
+        frmb.displayFormat = frmb.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
+        frmc.displayFormat = frmc.DisplayFormat.TIFwVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)
@@ -1303,7 +1303,7 @@ class AFC(BaseWidget):
         self.status_wid = self._setup_status_wid()
         stattab.addTab(self.status_wid, 'Status')
         self.info_wid = self._setup_info_wid()
-        stattab.addTab(self.info_wid, 'FRM && IOC')
+        stattab.addTab(self.info_wid, 'Fw && IOC')
         self.my_layout.addWidget(stattab, 2, 0)
         stattab.setSizePolicy(QSzPol.Preferred, QSzPol.Maximum)
 
@@ -1640,7 +1640,7 @@ class _EVR_EVE(BaseWidget):
         self.status_wid = self._setup_status_wid()
         stattab.addTab(self.status_wid, 'Status')
         self.info_wid = self._setup_info_wid()
-        stattab.addTab(self.info_wid, 'FRM && IOC')
+        stattab.addTab(self.info_wid, 'Fw && IOC')
         self.my_layout.addWidget(stattab, 2, 0)
         stattab.setSizePolicy(QSzPol.Preferred, QSzPol.Maximum)
 
@@ -1834,16 +1834,16 @@ class _EVR_EVE(BaseWidget):
         gb = self._create_small_group('', info_wid, (lb, mon, inp))
         info_lay.addWidget(gb, 0, 6, alignment=Qt.AlignTop)
 
-        lb = QLabel("<b>FRMVERSION</b>")
+        lb = QLabel("<b>Fw.Version</b>")
         pvname = self.get_pvname(propty='FrmVersionA-Cte')
         frma = SiriusLabel(self, init_channel=pvname)
-        frma.displayFormat = frma.DisplayFormat.TIFRMVersion
+        frma.displayFormat = frma.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionB-Cte')
         frmb = SiriusLabel(self, init_channel=pvname)
-        frmb.displayFormat = frmb.DisplayFormat.TIFRMVersion
+        frmb.displayFormat = frmb.DisplayFormat.TIFwVersion
         pvname = self.get_pvname(propty='FrmVersionC-Cte')
         frmc = SiriusLabel(self, init_channel=pvname)
-        frmc.displayFormat = frmc.DisplayFormat.TIFRMVersion
+        frmc.displayFormat = frmc.DisplayFormat.TIFwVersion
         gb = self._create_small_group(
             '', info_wid, (lb, frma, frmb, frmc))
         gb.layout().setSpacing(3)

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -73,8 +73,10 @@ class BaseObject(BaseOrbitIntlk):
                 prefix=self._prefix, propty=propty)
             if pvname in self._pvs:
                 continue
+            auto_monitor = not pvname.endswith('-Mon') or 'Ltc' in pvname
             new_pvs[pvname] = _PV(
-                pvname, auto_monitor=False, connection_timeout=0.01)
+                pvname, auto_monitor=auto_monitor,
+                connection_timeout=0.01)
         self._pvs.update(new_pvs)
 
     def _get_values(self, propty):

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -94,7 +94,8 @@ class BaseObject(BaseOrbitIntlk):
                 val = None
             if val is None:
                 val = 0
-            elif propty.startswith('Intlk') and propty.endswith('-Mon'):
+            elif propty in ['Intlk-Mon', 'IntlkLtc-Mon'] or \
+                    'Lower' in propty or 'Upper' in propty:
                 val = 1 if val == 0 else 0
             values.append(val)
         return values

--- a/pyqt-apps/siriushla/si_ap_orbintlk/base.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/base.py
@@ -26,14 +26,23 @@ class BaseObject(BaseOrbitIntlk):
         self._client = ConfigDBClient(config_type='si_orbit')
         self._prefix = prefix
 
+        self._pv_facqrate_value = None
+        self._pv_monitrate_value = None
+        self._monitsum2intlksum_factor = 1
+
         pvname = SiriusPVName(
             self.BPM_NAMES[0]).substitute(
                 propty='INFOMONITRate-RB', prefix=prefix)
-        self._pv_monitrate = _PV(pvname)
+        self._pv_monitrate = _PV(pvname, callback=self._callback_get_rate)
         pvname = SiriusPVName(
             self.BPM_NAMES[0]).substitute(
                 propty='INFOFAcqRate-RB', prefix=prefix)
-        self._pv_facqrate = _PV(pvname)
+        self._pv_facqrate = _PV(pvname, callback=self._callback_get_rate)
+
+    @property
+    def monitsum2intlksum_factor(self):
+        """Return factor between BPM Monit Sum and interlock Sum."""
+        return self._monitsum2intlksum_factor
 
     def get_ref_orb(self, configname):
         """Get reference orbit from config [um].
@@ -54,16 +63,6 @@ class BaseObject(BaseOrbitIntlk):
             value['x'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
             value['y'] = _np.zeros(len(self.BPM_NAMES), dtype=float)
         return value
-
-    def get_monitsum2intlksum_factor(self):
-        """Return factor between BPM Monit Sum and interlock Sum."""
-        monit = self._pv_monitrate.value
-        facq = self._pv_facqrate.value
-        if None in [monit, facq]:  # connecting
-            return 1
-        frac = monit/facq
-        factor = 2**_math.ceil(_math.log2(frac)) / frac
-        return factor
 
     # --- pv handler methods ---
 
@@ -99,3 +98,18 @@ class BaseObject(BaseOrbitIntlk):
                 val = 1 if val == 0 else 0
             values.append(val)
         return values
+
+    def _callback_get_rate(self, pvname, value, **kws):
+        if value is None:
+            return
+        if 'MONIT' in pvname:
+            self._pv_monitrate_value = value
+        elif 'FAcq' in pvname:
+            self._pv_facqrate_value = value
+        monit = self._pv_monitrate_value
+        facq = self._pv_facqrate_value
+        if None in [monit, facq]:
+            return
+        frac = monit/facq
+        factor = 2**_math.ceil(_math.log2(frac)) / frac
+        self._monitsum2intlksum_factor = factor

--- a/pyqt-apps/siriushla/si_ap_orbintlk/bpmdetail.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/bpmdetail.py
@@ -12,7 +12,7 @@ from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName
 
 from ..widgets import SiriusMainWindow, SiriusLedState, SiriusLabel, \
-    PyDMStateButton, SiriusLedAlert, SiriusSpinbox
+    PyDMStateButton, SiriusLedAlert, SiriusSpinbox, SiriusLineEdit
 from .base import BaseObject
 
 
@@ -110,11 +110,9 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
         self._ld_minsumlim = QLabel(
             'Min.Sum.Thres.[sum count]: ', self,
             alignment=Qt.AlignRight | Qt.AlignVCenter)
-        self._sb_minsumlim = SiriusSpinbox(
+        self._le_minsumlim = SiriusLineEdit(
             self, self.devpref.substitute(propty='IntlkLmtMinSum-SP'))
-        self._sb_minsumlim.limitsFromChannel = False
-        self._sb_minsumlim.setMinimum(-1e12)
-        self._sb_minsumlim.setMaximum(+1e12)
+        self._le_minsumlim.setStyleSheet('QLineEdit{max-width: 12em;}')
         self._lb_minsumlim = SiriusLabel(
             self, self.devpref.substitute(propty='IntlkLmtMinSum-RB'))
 
@@ -122,7 +120,7 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
         lay.setAlignment(Qt.AlignCenter)
         lay.addWidget(self._ld_genenbl, 0, 0)
         lay.addWidget(self._sb_genenbl, 0, 1)
-        lay.addWidget(self._led_genenbl, 0, 2)
+        lay.addWidget(self._led_genenbl, 0, 2, alignment=Qt.AlignLeft)
         lay.addWidget(self._ld_genclr, 1, 0)
         lay.addWidget(self._bt_genclr, 1, 1, alignment=Qt.AlignCenter)
         lay.addWidget(self._ld_intlkinst, 2, 0)
@@ -132,9 +130,9 @@ class BPMOrbIntlkDetailWindow(BaseObject, SiriusMainWindow):
         lay.addItem(QSpacerItem(1, 15, QSzPlc.Ignored, QSzPlc.Fixed), 4, 0)
         lay.addWidget(self._ld_minsumenbl, 5, 0)
         lay.addWidget(self._sb_minsumenbl, 5, 1)
-        lay.addWidget(self._led_minsumenbl, 5, 2)
+        lay.addWidget(self._led_minsumenbl, 5, 2, alignment=Qt.AlignLeft)
         lay.addWidget(self._ld_minsumlim, 6, 0)
-        lay.addWidget(self._sb_minsumlim, 6, 1)
+        lay.addWidget(self._le_minsumlim, 6, 1)
         lay.addWidget(self._lb_minsumlim, 6, 2)
         return lay
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/custom_widgets.py
@@ -419,7 +419,7 @@ class BPMIntlkLimSPWidget(BaseObject, QWidget):
 
         if 'sum' in self.metric:
             summonit = self._summon
-            sumintlk = summonit * self.get_monitsum2intlksum_factor()
+            sumintlk = summonit * self.monitsum2intlksum_factor
             allvals = self._spin_scl.value() * sumintlk
             reso = self.MINSUM_RESO
             allvals = _np.ceil(allvals / reso) * reso

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -588,6 +588,7 @@ class _BaseGraphWidget(BaseObject, QWidget):
 class _UpdateGraphThread(BaseObject, QThread):
     """Update Graph Thread."""
 
+    UPDATE_FREQ = 0.5  # [Hz]
     dataChanged = Signal(list)
 
     def __init__(self, intlktype, meas_data, meas_symb,
@@ -635,7 +636,7 @@ class _UpdateGraphThread(BaseObject, QThread):
             self._update_data()
             _dt = _time.time() - _t0
 
-            sleep = 2 - _dt
+            sleep = 1/self.UPDATE_FREQ - _dt
             if sleep > 0:
                 _time.sleep(sleep)
 

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -663,13 +663,9 @@ class _UpdateGraphThread(BaseObject, QThread):
             self._create_pvs(self.meas_data)
             vals = _np.array(self._get_values(self.meas_data), dtype=float)
             if self.metric in ['pos', 'ang']:
-                vals -= self._reforb
-                vals = _np.array(self.calc_intlk_metric(
-                    vals, metric=self.metric), dtype=float)
-                # use BPM IOC pos & ang
-                # ref = self.calc_intlk_metric(
-                #     self._reforb, metric=self.metric)
-                # vals -= ref
+                ref = self.calc_intlk_metric(
+                    self._reforb, metric=self.metric)
+                vals -= ref
                 vals *= self.CONV_NM2M
             else:
                 # sum case
@@ -741,8 +737,7 @@ class PosXGraphWidget(_BaseGraphWidget):
     """Position Graph Widget."""
 
     INTLKTYPE = 'PosX'
-    PROPTY_MEAS_DATA = 'PosX-Mon'
-    # PROPTY_MEAS_DATA = 'IntlkPosX-Mon'
+    PROPTY_MEAS_DATA = 'IntlkPosX-Mon'
     PROPTY_MEAS_SYMB = {
         'Instantaneous': {
             'General': 'Intlk-Mon',
@@ -775,8 +770,7 @@ class PosYGraphWidget(_BaseGraphWidget):
     """Position Graph Widget."""
 
     INTLKTYPE = 'PosY'
-    PROPTY_MEAS_DATA = 'PosY-Mon'
-    # PROPTY_MEAS_DATA = 'IntlkPosY-Mon'
+    PROPTY_MEAS_DATA = 'IntlkPosY-Mon'
     PROPTY_MEAS_SYMB = {
         'Instantaneous': {
             'General': 'Intlk-Mon',
@@ -811,8 +805,7 @@ class AngXGraphWidget(_BaseGraphWidget):
     """Angulation Graph Widget."""
 
     INTLKTYPE = 'AngX'
-    PROPTY_MEAS_DATA = 'PosX-Mon'
-    # PROPTY_MEAS_DATA = 'IntlkPosX-Mon'
+    PROPTY_MEAS_DATA = 'IntlkAngX-Mon'
     PROPTY_MEAS_SYMB = {
         'Instantaneous': {
             'General': 'Intlk-Mon',
@@ -847,8 +840,7 @@ class AngYGraphWidget(_BaseGraphWidget):
     """Angulation Graph Widget."""
 
     INTLKTYPE = 'AngY'
-    PROPTY_MEAS_DATA = 'PosY-Mon'
-    # PROPTY_MEAS_DATA = 'IntlkPosY-Mon'
+    PROPTY_MEAS_DATA = 'IntlkAngY-Mon'
     PROPTY_MEAS_SYMB = {
         'Instantaneous': {
             'General': 'Intlk-Mon',

--- a/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
+++ b/pyqt-apps/siriushla/si_ap_orbintlk/graphics.py
@@ -609,6 +609,8 @@ class _UpdateGraphThread(BaseObject, QThread):
         self._propintlktype = propintlktype
         self._propcomptype = propcomptype
         self._reforb = reforb
+        self._refmetric = _np.array(self.calc_intlk_metric(
+            self._reforb, metric=self.metric))
         self._prefix = prefix
 
         self._quit_task = False
@@ -624,6 +626,8 @@ class _UpdateGraphThread(BaseObject, QThread):
     def set_reforb(self, new):
         """Update reference orbit."""
         self._reforb = new
+        self._refmetric = _np.array(self.calc_intlk_metric(
+            self._reforb, metric=self.metric))
 
     def exit_task(self):
         """Set flag to quit thread."""
@@ -663,13 +667,11 @@ class _UpdateGraphThread(BaseObject, QThread):
             self._create_pvs(self.meas_data)
             vals = _np.array(self._get_values(self.meas_data), dtype=float)
             if self.metric in ['pos', 'ang']:
-                ref = self.calc_intlk_metric(
-                    self._reforb, metric=self.metric)
-                vals -= ref
+                vals -= self._refmetric
                 vals *= self.CONV_NM2M
             else:
                 # sum case
-                vals *= self.get_monitsum2intlksum_factor()
+                vals *= self.monitsum2intlksum_factor
             y_data_meas = list(vals)
 
             self.dataChanged.emit(['meas', symbols_meas, y_data_meas])
@@ -690,8 +692,7 @@ class _UpdateGraphThread(BaseObject, QThread):
             # data min
             vals = _np.array(self._get_values(self.min_data), dtype=float)
             if self.metric in ['pos', 'ang']:
-                ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
-                vals -= ref
+                vals -= self._refmetric
                 vals *= self.CONV_NM2M
             y_data_min = list(vals)
 
@@ -713,8 +714,7 @@ class _UpdateGraphThread(BaseObject, QThread):
             # data max
             vals = _np.array(self._get_values(self.max_data), dtype=float)
             if self.metric in ['pos', 'ang']:
-                ref = self.calc_intlk_metric(self._reforb, metric=self.metric)
-                vals -= ref
+                vals -= self._refmetric
                 vals *= self.CONV_NM2M
             y_data_max = list(vals)
 

--- a/pyqt-apps/siriushla/widgets/label.py
+++ b/pyqt-apps/siriushla/widgets/label.py
@@ -30,6 +30,7 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     DisplayFormat = DisplayFormat
     DisplayFormat.Time = 6
     DisplayFormat.BSMPUDCVersion = 7
+    DisplayFormat.TIFRMVersion = 8
 
     def __init__(self, parent=None, init_channel=None, keep_unit=False, **kws):
         """Init."""
@@ -106,11 +107,24 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
             self.setText(time)
             return
 
-        # If it is a version string, replace multiple whitespaces with a single one
+        # If it is a version string, replace multiple whitespaces with a
+        # single one
         if self._display_format_type == self.DisplayFormat.BSMPUDCVersion:
             version = new_value[:16] + " " + new_value[16:] \
                 if new_value is not None else ''
             version = " ".join(version.split())
+            self.setText(version)
+            return
+
+        # If it is a TI Frm. version string, convert to unsigned int and
+        # represent in hex
+        if self._display_format_type == self.DisplayFormat.TIFRMVersion:
+            new_value = (new_value & ((1 << 32) - 1)) \
+                if new_value is not None else ''
+            version = parse_value_for_display(
+                value=new_value, precision=self.precision,
+                display_format_type=self.DisplayFormat.Hex,
+                string_encoding=self._string_encoding, widget=self)
             self.setText(version)
             return
 

--- a/pyqt-apps/siriushla/widgets/label.py
+++ b/pyqt-apps/siriushla/widgets/label.py
@@ -1,5 +1,6 @@
 """Sirius Label."""
 
+import ctypes
 from pyqtgraph import functions as func
 from qtpy.QtWidgets import QLabel, QApplication
 from qtpy.QtCore import Qt, Property, Q_ENUMS
@@ -30,7 +31,7 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
     DisplayFormat = DisplayFormat
     DisplayFormat.Time = 6
     DisplayFormat.BSMPUDCVersion = 7
-    DisplayFormat.TIFRMVersion = 8
+    DisplayFormat.TIFwVersion = 8
 
     def __init__(self, parent=None, init_channel=None, keep_unit=False, **kws):
         """Init."""
@@ -116,10 +117,10 @@ class SiriusLabel(QLabel, TextFormatter, PyDMWidget, DisplayFormat):
             self.setText(version)
             return
 
-        # If it is a TI Frm. version string, convert to unsigned int and
-        # represent in hex
-        if self._display_format_type == self.DisplayFormat.TIFRMVersion:
-            new_value = (new_value & ((1 << 32) - 1)) \
+        # If it is a timing firmware version string, convert to unsigned int
+        # and represent in hex
+        if self._display_format_type == self.DisplayFormat.TIFwVersion:
+            new_value = ctypes.c_uint32(new_value).value \
                 if new_value is not None else ''
             version = parse_value_for_display(
                 value=new_value, precision=self.precision,


### PR DESCRIPTION
This PR updates Orbit Interlock window:
- Use new Pos ang Ang PVs from BPM orbit interlock core
- Remove several repeated unnecessary calculations
- Avoid unnecessary PV.get calls turning on auto_monitor of some PVs, what reduced CPU load by a factor of ~2
- Clean up code

And BPM detail window:
- Change minimum sum setpoint widget to line edit
- Add minor layout and label improvements, take a look:
![Screenshot from 2023-06-30 15-21-24](https://github.com/lnls-sirius/hla/assets/21130191/71577b5e-6e4a-4fd0-afab-818ac8a50443)

Also, this PR brings minor improvements to fast corrector detail windows.
![Screenshot from 2023-06-30 16-34-37](https://github.com/lnls-sirius/hla/assets/21130191/643d1e22-3317-4bcf-9f48-b4bcb973b2b5)
