### PR TITLE
MNT: Update requirements to avoid problems with new versions of QtPy

### DIFF
--- a/pyqt-apps/requirements.txt
+++ b/pyqt-apps/requirements.txt
@@ -1,3 +1,4 @@
 pydm>=1.8.0
 QtAwesome>=0.7.2
 pyqtgraph>=0.11.0
+QtPy<=2.3.1


### PR DESCRIPTION
QtPy>=2.4 brings a breaking change: renames QT_ENUM(S) to QEnum for standandization with Qt6. This breaks our and pydm widgets. While pydm does not handle this, we need to keep older versions.