### PR TITLE
RF Improvements

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -911,23 +911,18 @@ class RFMainControl(SiriusMainWindow):
         self.ramp_chn_wid = {}
 
         for unit_type, rmp_channels in self.chs['Ramp'].items():
-            idy = 1
             self.ramp_chn_wid[unit_type] = {}
-            for pos, rmp_ch_pvs in rmp_channels.items():
+            for idy, (pos, rmp_ch_pvs) in enumerate(rmp_channels.items(), 1):
                 self.ramp_chn_wid[unit_type][pos] = {}
                 wid_dict = self.ramp_chn_wid[unit_type][pos]
-                idx = 2
 
-                for pv_id, pv_val in rmp_ch_pvs.items():
+                for idx, (pv_id, pv_val) in enumerate(rmp_ch_pvs.items(), 2):
                     wid_dict[pv_id] = SiriusLabel(
                         self, self.prefix+pv_val)
                     wid_dict[pv_id].showUnits = True
                     lay.addWidget(wid_dict[pv_id], idx, idy)
                     if unit_type == 'mV':
                         wid_dict[pv_id].setVisible(False)
-
-                    idx += 1
-                idy += 1
 
         self.lb_c3phstop = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:TOP:CELL3:PHS')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1265,9 +1265,9 @@ class RFMainControl(SiriusMainWindow):
         lb_tempcirc = QLabel('<h3> • Circulator</h3>', self)
         lims_circ = self.chs['TL Sts']['Circ Limits']
         ch2vals = {
-            self.prefix+self.chs['TL Sts']['Circ TIn']: {
+            self.prefix+self.chs['TL Sts']['Circ TIn']['label']: {
                 'comp': 'wt', 'value': lims_circ},
-            self.prefix+self.chs['TL Sts']['Circ TOut']: {
+            self.prefix+self.chs['TL Sts']['label']['Circulator T Out']: {
                 'comp': 'wt', 'value': lims_circ}
         }
         self.led_tempcircok = PyDMLedMultiChannel(self, ch2vals)
@@ -1286,11 +1286,11 @@ class RFMainControl(SiriusMainWindow):
         self.tempcirc_graph.timeSpan = 1800
         self.tempcirc_graph.maxRedrawRate = 1
         self.tempcirc_graph.addYChannel(
-            y_channel=self.prefix+self.chs['TL Sts']['Circ TIn'],
+            y_channel=self.prefix+self.chs['TL Sts']['Circ TIn']['label'],
             name='CTIn', color='magenta',
             lineStyle=Qt.SolidLine, lineWidth=1)
         self.tempcirc_graph.addYChannel(
-            y_channel=self.prefix+self.chs['TL Sts']['Circ TOut'],
+            y_channel=self.prefix+self.chs['TL Sts']['label']['Circulator T Out'],
             name='CTOut', color='darkRed',
             lineStyle=Qt.SolidLine, lineWidth=1)
         self.tempcirc_graph.setLabel('left', '')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -342,9 +342,9 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+self.chs['SL']['ASet'][0]+'-SP')
         self.lb_amp1 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-RB')
-        self.sb_amp2 = SiriusSpinbox(
-            self, self.prefix+self.chs['SL']['ASet'][1]+'-SP')
-        self.sb_amp2.setVisible(False)
+        # self.sb_amp2 = SiriusSpinbox(
+        #     self, self.prefix+self.chs['SL']['ASet'][1]+'-SP')
+        # self.sb_amp2.setVisible(False)
         self.lb_amp2 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
         self.lb_amp2.setVisible(False)
@@ -373,9 +373,9 @@ class RFMainControl(SiriusMainWindow):
         lay_slctrl.addWidget(QLabel('<h4>Phase [DEG]</h4>', self,
                                     alignment=Qt.AlignCenter), 2, 0, 1, 2)
         lay_slctrl.addWidget(self.sb_amp1, 1, 2, alignment=Qt.AlignRight)
-        lay_slctrl.addWidget(self.sb_amp2, 1, 2, alignment=Qt.AlignRight)
+        # lay_slctrl.addWidget(self.sb_amp2, 1, 2, alignment=Qt.AlignRight)
         lay_slctrl.addWidget(self.lb_amp1, 1, 3, alignment=Qt.AlignLeft)
-        lay_slctrl.addWidget(self.lb_amp2, 1, 3, alignment=Qt.AlignLeft)
+        lay_slctrl.addWidget(self.lb_amp2, 1, 2, 1, 2, alignment=Qt.AlignCenter)
         lay_slctrl.addWidget(self.cb_ampincrate, 1, 4, alignment=Qt.AlignRight)
         lay_slctrl.addWidget(self.lb_ampincrate, 1, 5, alignment=Qt.AlignLeft)
         lay_slctrl.addWidget(self.sb_phs, 2, 2, alignment=Qt.AlignRight)
@@ -736,9 +736,9 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:TOP-RB')
         self.lb_rmpvolttop1.showUnits = True
-        self.le_rmpvolttop2 = PyDMLineEdit(
-            self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-SP')
-        self.le_rmpvolttop2.setVisible(False)
+        # self.le_rmpvolttop2 = PyDMLineEdit(
+        #     self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-SP')
+        # self.le_rmpvolttop2.setVisible(False)
         self.lb_rmpvolttop2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-RB')
         self.lb_rmpvolttop2.setVisible(False)
@@ -764,9 +764,9 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvoltbot1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:BOT-RB')
         self.lb_rmpvoltbot1.showUnits = True
-        self.le_rmpvoltbot2 = PyDMLineEdit(
-            self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-SP')
-        self.le_rmpvoltbot2.setVisible(False)
+        # self.le_rmpvoltbot2 = PyDMLineEdit(
+        #     self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-SP')
+        # self.le_rmpvoltbot2.setVisible(False)
         self.lb_rmpvoltbot2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-RB')
         self.lb_rmpvoltbot2.setVisible(False)
@@ -818,9 +818,9 @@ class RFMainControl(SiriusMainWindow):
         lay.addWidget(self.lb_rmpphsbot, 14, 2)
         lay.addLayout(lay_rmpphsbotdesc, 15, 0)
         lay.addWidget(self.le_rmpvoltbot1, 15, 1)
-        lay.addWidget(self.le_rmpvoltbot2, 15, 1)
+        # lay.addWidget(self.le_rmpvoltbot2, 15, 1)
         lay.addWidget(self.lb_rmpvoltbot1, 15, 2)
-        lay.addWidget(self.lb_rmpvoltbot2, 15, 2)
+        lay.addWidget(self.lb_rmpvoltbot2, 15, 1, 1, 2)
         lay.addWidget(QLabel('<h4>Top</h4>', self), 16, 0, 1, 3)
         lay.addWidget(QLabel('Phase', self,
                              alignment=Qt.AlignRight), 17, 0)
@@ -828,9 +828,9 @@ class RFMainControl(SiriusMainWindow):
         lay.addWidget(self.lb_rmpphstop, 17, 2)
         lay.addLayout(lay_rmpphstopdesc, 18, 0)
         lay.addWidget(self.le_rmpvolttop1, 18, 1)
-        lay.addWidget(self.le_rmpvolttop2, 18, 1)
+        # lay.addWidget(self.le_rmpvolttop2, 18, 1)
         lay.addWidget(self.lb_rmpvolttop1, 18, 2)
-        lay.addWidget(self.lb_rmpvolttop2, 18, 2)
+        lay.addWidget(self.lb_rmpvolttop2, 18, 1, 1, 2)
         lay.addItem(QSpacerItem(
             200, 10, QSzPlcy.Fixed, QSzPlcy.MinimumExpanding), 19, 3)
         return lay
@@ -1484,7 +1484,7 @@ class RFMainControl(SiriusMainWindow):
     def _handle_ampl_unit_visibility(self, text):
         self.sb_amp1.setVisible(text == '[mV]')
         self.lb_amp1.setVisible(text == '[mV]')
-        self.sb_amp2.setVisible(text == '[V]')
+        # self.sb_amp2.setVisible(text == '[V]')
         self.lb_amp2.setVisible(text == '[V]')
 
     def _handle_rmpampl_unit_visibility(self, text):
@@ -1495,8 +1495,8 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop1.setVisible(text == '[mV]')
         self.le_rmpvoltbot1.setVisible(text == '[mV]')
         self.lb_rmpvoltbot1.setVisible(text == '[mV]')
-        self.le_rmpvolttop2.setVisible(text == '[V]')
+        # self.le_rmpvolttop2.setVisible(text == '[V]')
         self.lb_rmpvolttop2.setVisible(text == '[V]')
-        self.le_rmpvoltbot2.setVisible(text == '[V]')
+        # self.le_rmpvoltbot2.setVisible(text == '[V]')
         self.lb_rmpvoltbot2.setVisible(text == '[V]')
         self.blockSignals(False)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -342,9 +342,6 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+self.chs['SL']['ASet'][0]+'-SP')
         self.lb_amp1 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-RB')
-        # self.sb_amp2 = SiriusSpinbox(
-        #     self, self.prefix+self.chs['SL']['ASet'][1]+'-SP')
-        # self.sb_amp2.setVisible(False)
         self.lb_amp2 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
         self.lb_amp2.setVisible(False)
@@ -373,7 +370,6 @@ class RFMainControl(SiriusMainWindow):
         lay_slctrl.addWidget(QLabel('<h4>Phase [DEG]</h4>', self,
                                     alignment=Qt.AlignCenter), 2, 0, 1, 2)
         lay_slctrl.addWidget(self.sb_amp1, 1, 2, alignment=Qt.AlignRight)
-        # lay_slctrl.addWidget(self.sb_amp2, 1, 2, alignment=Qt.AlignRight)
         lay_slctrl.addWidget(self.lb_amp1, 1, 3, alignment=Qt.AlignLeft)
         lay_slctrl.addWidget(self.lb_amp2, 1, 2, 1, 2, alignment=Qt.AlignCenter)
         lay_slctrl.addWidget(self.cb_ampincrate, 1, 4, alignment=Qt.AlignRight)
@@ -736,9 +732,6 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:TOP-RB')
         self.lb_rmpvolttop1.showUnits = True
-        # self.le_rmpvolttop2 = PyDMLineEdit(
-        #     self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-SP')
-        # self.le_rmpvolttop2.setVisible(False)
         self.lb_rmpvolttop2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-RB')
         self.lb_rmpvolttop2.setVisible(False)
@@ -764,9 +757,6 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvoltbot1 = SiriusLabel(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:BOT-RB')
         self.lb_rmpvoltbot1.showUnits = True
-        # self.le_rmpvoltbot2 = PyDMLineEdit(
-        #     self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-SP')
-        # self.le_rmpvoltbot2.setVisible(False)
         self.lb_rmpvoltbot2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-RB')
         self.lb_rmpvoltbot2.setVisible(False)
@@ -818,7 +808,6 @@ class RFMainControl(SiriusMainWindow):
         lay.addWidget(self.lb_rmpphsbot, 14, 2)
         lay.addLayout(lay_rmpphsbotdesc, 15, 0)
         lay.addWidget(self.le_rmpvoltbot1, 15, 1)
-        # lay.addWidget(self.le_rmpvoltbot2, 15, 1)
         lay.addWidget(self.lb_rmpvoltbot1, 15, 2)
         lay.addWidget(self.lb_rmpvoltbot2, 15, 1, 1, 2)
         lay.addWidget(QLabel('<h4>Top</h4>', self), 16, 0, 1, 3)
@@ -828,7 +817,6 @@ class RFMainControl(SiriusMainWindow):
         lay.addWidget(self.lb_rmpphstop, 17, 2)
         lay.addLayout(lay_rmpphstopdesc, 18, 0)
         lay.addWidget(self.le_rmpvolttop1, 18, 1)
-        # lay.addWidget(self.le_rmpvolttop2, 18, 1)
         lay.addWidget(self.lb_rmpvolttop1, 18, 2)
         lay.addWidget(self.lb_rmpvolttop2, 18, 1, 1, 2)
         lay.addItem(QSpacerItem(
@@ -1495,7 +1483,6 @@ class RFMainControl(SiriusMainWindow):
     def _handle_ampl_unit_visibility(self, text):
         self.sb_amp1.setVisible(text == '[mV]')
         self.lb_amp1.setVisible(text == '[mV]')
-        # self.sb_amp2.setVisible(text == '[V]')
         self.lb_amp2.setVisible(text == '[V]')
 
     def _handle_rmpampl_unit_visibility(self, text):
@@ -1506,8 +1493,6 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop1.setVisible(text == '[mV]')
         self.le_rmpvoltbot1.setVisible(text == '[mV]')
         self.lb_rmpvoltbot1.setVisible(text == '[mV]')
-        # self.le_rmpvolttop2.setVisible(text == '[V]')
         self.lb_rmpvolttop2.setVisible(text == '[V]')
-        # self.le_rmpvoltbot2.setVisible(text == '[V]')
         self.lb_rmpvoltbot2.setVisible(text == '[V]')
         self.blockSignals(False)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1260,9 +1260,9 @@ class RFMainControl(SiriusMainWindow):
         lb_tempcirc = QLabel('<h3> • Circulator</h3>', self)
         lims_circ = self.chs['TL Sts']['Circ Limits']
         ch2vals = {
-            self.prefix+self.chs['TL Sts']['Circ TIn']['label']: {
+            self.prefix+self.chs['TL Sts']['Circulator Temp. In']['label']: {
                 'comp': 'wt', 'value': lims_circ},
-            self.prefix+self.chs['TL Sts']['label']['Circulator T Out']: {
+            self.prefix+self.chs['TL Sts']['label']['Circulator Temp. Out']: {
                 'comp': 'wt', 'value': lims_circ}
         }
         self.led_tempcircok = PyDMLedMultiChannel(self, ch2vals)
@@ -1281,11 +1281,11 @@ class RFMainControl(SiriusMainWindow):
         self.tempcirc_graph.timeSpan = 1800
         self.tempcirc_graph.maxRedrawRate = 1
         self.tempcirc_graph.addYChannel(
-            y_channel=self.prefix+self.chs['TL Sts']['Circ TIn']['label'],
+            y_channel=self.prefix+self.chs['TL Sts']['Circulator Temp. In']['label'],
             name='CTIn', color='magenta',
             lineStyle=Qt.SolidLine, lineWidth=1)
         self.tempcirc_graph.addYChannel(
-            y_channel=self.prefix+self.chs['TL Sts']['label']['Circulator T Out'],
+            y_channel=self.prefix+self.chs['TL Sts']['label']['Circulator Temp. Out'],
             name='CTOut', color='darkRed',
             lineStyle=Qt.SolidLine, lineWidth=1)
         self.tempcirc_graph.setLabel('left', '')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -332,19 +332,10 @@ class RFMainControl(SiriusMainWindow):
         lay_over.addWidget(self.bt_slenbl, 1, 1)
         lay_over.addWidget(self.led_slenbl, 1, 2, alignment=Qt.AlignLeft)
 
-        self.cb_amp = QComboBox()
-        self.cb_amp.addItems(['[mV]', '[V]'])
-        self.cb_amp.setStyleSheet(
-            'QComboBox{max-width: 3.8em; font-weight: bold;}')
-        self.cb_amp.currentTextChanged.connect(
-            self._handle_ampl_unit_visibility)
         self.sb_amp1 = SiriusSpinbox(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-SP')
         self.lb_amp1 = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][0]+'-RB')
-        self.lb_amp2 = SiriusLabel(
-            self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
-        self.lb_amp2.setVisible(False)
         self.cb_ampincrate = PyDMEnumComboBox(
             self, self.prefix+self.chs['SL']['AInc']+':S')
         self.lb_ampincrate = SiriusLabel(
@@ -364,14 +355,12 @@ class RFMainControl(SiriusMainWindow):
                                     alignment=Qt.AlignCenter), 0, 2, 1, 2)
         lay_slctrl.addWidget(QLabel('<h4>Inc. Rate SP/RB</h4>', self,
                                     alignment=Qt.AlignCenter), 0, 4, 1, 2)
-        lay_slctrl.addWidget(QLabel('<h4>Amplitude</h4>', self,
-                                    alignment=Qt.AlignCenter), 1, 0)
-        lay_slctrl.addWidget(self.cb_amp, 1, 1)
+        lay_slctrl.addWidget(QLabel('<h4>Amplitude [mV]</h4>', self,
+                                    alignment=Qt.AlignCenter), 1, 0, 1, 2)
         lay_slctrl.addWidget(QLabel('<h4>Phase [DEG]</h4>', self,
                                     alignment=Qt.AlignCenter), 2, 0, 1, 2)
         lay_slctrl.addWidget(self.sb_amp1, 1, 2, alignment=Qt.AlignRight)
         lay_slctrl.addWidget(self.lb_amp1, 1, 3, alignment=Qt.AlignLeft)
-        lay_slctrl.addWidget(self.lb_amp2, 1, 2, 1, 2, alignment=Qt.AlignCenter)
         lay_slctrl.addWidget(self.cb_ampincrate, 1, 4, alignment=Qt.AlignRight)
         lay_slctrl.addWidget(self.lb_ampincrate, 1, 5, alignment=Qt.AlignLeft)
         lay_slctrl.addWidget(self.sb_phs, 2, 2, alignment=Qt.AlignRight)
@@ -1111,9 +1100,17 @@ class RFMainControl(SiriusMainWindow):
         self.lb_cavvgap = SiriusLabel(self, self.prefix+self.chs['CavVGap'])
         self.lb_cavvgap.setStyleSheet('QLabel{font-size: 20pt;}')
         self.lb_cavvgap.showUnits = True
-        lay_cavvgap = QHBoxLayout()
-        lay_cavvgap.addWidget(self.ld_cavvgap)
-        lay_cavvgap.addWidget(self.lb_cavvgap)
+
+        self.lbl_refvol = QLabel(
+            'Ref Voltage [V]:', self, alignment=Qt.AlignCenter)
+        self.rb_refvol = SiriusLabel(
+            self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
+
+        lay_cavvgap = QGridLayout()
+        lay_cavvgap.addWidget(self.ld_cavvgap, 0, 0)
+        lay_cavvgap.addWidget(self.lb_cavvgap, 0, 1)
+        lay_cavvgap.addWidget(self.lbl_refvol, 1, 0)
+        lay_cavvgap.addWidget(self.rb_refvol, 1, 1)
 
         lay = QGridLayout()
         lay.setHorizontalSpacing(25)
@@ -1479,11 +1476,6 @@ class RFMainControl(SiriusMainWindow):
             self.led_tempcoupok.set_channels2values(ch2vals)
             self.line_cell_minlim.setPos(lims[0])
             self.line_cell_maxlim.setPos(lims[1])
-
-    def _handle_ampl_unit_visibility(self, text):
-        self.sb_amp1.setVisible(text == '[mV]')
-        self.lb_amp1.setVisible(text == '[mV]')
-        self.lb_amp2.setVisible(text == '[V]')
 
     def _handle_rmpampl_unit_visibility(self, text):
         self.blockSignals(True)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1102,9 +1102,10 @@ class RFMainControl(SiriusMainWindow):
         self.lb_cavvgap.showUnits = True
 
         self.lbl_refvol = QLabel(
-            'Ref Voltage [V]:', self, alignment=Qt.AlignCenter)
+            'Ref Voltage:', self, alignment=Qt.AlignCenter)
         self.rb_refvol = SiriusLabel(
             self, self.prefix+self.chs['SL']['ASet'][1]+'-RB')
+        self.rb_refvol.showUnits = True
 
         lay_cavvgap = QGridLayout()
         lay_cavvgap.addWidget(self.ld_cavvgap, 0, 0)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -707,14 +707,8 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsTop-RB')
         self.lb_rmpphstop.showUnits = True
         self.ld_rmpphstop = QLabel('Amplitude', self, alignment=Qt.AlignRight)
-        self.cb_rmpphstop = QComboBox()
-        self.cb_rmpphstop.addItems(['[mV]', '[V]'])
-        self.cb_rmpphstop.setStyleSheet('QComboBox{max-width: 3.5em;}')
-        self.cb_rmpphstop.currentTextChanged.connect(
-            self._handle_rmpampl_unit_visibility)
         lay_rmpphstopdesc = QHBoxLayout()
         lay_rmpphstopdesc.addWidget(self.ld_rmpphstop)
-        lay_rmpphstopdesc.addWidget(self.cb_rmpphstop)
         lay_rmpphstopdesc.setAlignment(Qt.AlignRight)
         self.le_rmpvolttop1 = PyDMLineEdit(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:TOP-SP')
@@ -723,7 +717,6 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvolttop1.showUnits = True
         self.lb_rmpvolttop2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavTop-RB')
-        self.lb_rmpvolttop2.setVisible(False)
         self.lb_rmpvolttop2.showUnits = True
 
         self.sb_rmpphsbot = SiriusSpinbox(
@@ -732,14 +725,8 @@ class RFMainControl(SiriusMainWindow):
             self, self.prefix+'BR-RF-DLLRF-01:RmpPhsBot-RB')
         self.lb_rmpphsbot.showUnits = True
         self.ld_rmpphsbot = QLabel('Amplitude', self, alignment=Qt.AlignRight)
-        self.cb_rmpphsbot = QComboBox()
-        self.cb_rmpphsbot.addItems(['[mV]', '[V]'])
-        self.cb_rmpphsbot.setStyleSheet('QComboBox{max-width: 3.5em;}')
-        self.cb_rmpphsbot.currentTextChanged.connect(
-            self._handle_rmpampl_unit_visibility)
         lay_rmpphsbotdesc = QHBoxLayout()
         lay_rmpphsbotdesc.addWidget(self.ld_rmpphsbot)
-        lay_rmpphsbotdesc.addWidget(self.cb_rmpphsbot)
         lay_rmpphsbotdesc.setAlignment(Qt.AlignRight)
         self.le_rmpvoltbot1 = PyDMLineEdit(
             self, self.prefix+'BR-RF-DLLRF-01:mV:RAMP:AMP:BOT-SP')
@@ -748,7 +735,6 @@ class RFMainControl(SiriusMainWindow):
         self.lb_rmpvoltbot1.showUnits = True
         self.lb_rmpvoltbot2 = SiriusLabel(
             self, self.prefix+'RA-RaBO01:RF-LLRF:RmpAmpVCavBot-RB')
-        self.lb_rmpvoltbot2.setVisible(False)
         self.lb_rmpvoltbot2.showUnits = True
 
         lay = QGridLayout()
@@ -758,7 +744,7 @@ class RFMainControl(SiriusMainWindow):
             QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, 0)
         lay.addWidget(QLabel('Enable: ', self,
                              alignment=Qt.AlignRight), 2, 0)
-        lay.addWidget(self.bt_rmpenbl, 2, 1)
+        lay.addWidget(self.bt_rmpenbl, 2, 2)
         lay.addWidget(self.lb_rmpenbl, 2, 2, alignment=Qt.AlignLeft)
         lay.addWidget(QLabel('Ramp Ready: ', self,
                              alignment=Qt.AlignRight), 3, 0)
@@ -771,45 +757,57 @@ class RFMainControl(SiriusMainWindow):
         lay.addWidget(QLabel('<h4>Durations</h4>', self), 6, 0, 1, 3)
         lay.addWidget(QLabel('Bottom: ', self,
                              alignment=Qt.AlignRight), 7, 0)
-        lay.addWidget(self.sb_rmpts1, 7, 1)
-        lay.addWidget(self.lb_rmpts1, 7, 2)
+        lay.addWidget(self.sb_rmpts1, 7, 2)
+        lay.addWidget(self.lb_rmpts1, 7, 3)
         lay.addWidget(QLabel('Rampup: ', self,
                              alignment=Qt.AlignRight), 8, 0)
-        lay.addWidget(self.sb_rmpts2, 8, 1)
-        lay.addWidget(self.lb_rmpts2, 8, 2)
+        lay.addWidget(self.sb_rmpts2, 8, 2)
+        lay.addWidget(self.lb_rmpts2, 8, 3)
         lay.addWidget(QLabel('Top: ', self,
                              alignment=Qt.AlignRight), 9, 0)
-        lay.addWidget(self.sb_rmpts3, 9, 1)
-        lay.addWidget(self.lb_rmpts3, 9, 2)
+        lay.addWidget(self.sb_rmpts3, 9, 2)
+        lay.addWidget(self.lb_rmpts3, 9, 3)
         lay.addWidget(QLabel('Rampdown:', self,
                              alignment=Qt.AlignRight), 10, 0)
-        lay.addWidget(self.sb_rmpts4, 10, 1)
-        lay.addWidget(self.lb_rmpts4, 10, 2)
+        lay.addWidget(self.sb_rmpts4, 10, 2)
+        lay.addWidget(self.lb_rmpts4, 10, 3)
         lay.addWidget(QLabel('Ramp Inc. Rate: ', self,
                              alignment=Qt.AlignRight), 11, 0)
-        lay.addWidget(self.cb_rmpincts, 11, 1)
-        lay.addWidget(self.lb_rmpincts, 11, 2)
+        lay.addWidget(self.cb_rmpincts, 11, 2)
+        lay.addWidget(self.lb_rmpincts, 11, 3)
         lay.addItem(QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), 12, 0)
         lay.addWidget(QLabel('<h4>Bottom</h4>', self), 13, 0, 1, 3)
         lay.addWidget(QLabel('Phase', self,
                              alignment=Qt.AlignRight), 14, 0)
-        lay.addWidget(self.sb_rmpphsbot, 14, 1)
-        lay.addWidget(self.lb_rmpphsbot, 14, 2)
+        lay.addWidget(self.sb_rmpphsbot, 14, 2)
+        lay.addWidget(self.lb_rmpphsbot, 14, 3)
         lay.addLayout(lay_rmpphsbotdesc, 15, 0)
-        lay.addWidget(self.le_rmpvoltbot1, 15, 1)
-        lay.addWidget(self.lb_rmpvoltbot1, 15, 2)
-        lay.addWidget(self.lb_rmpvoltbot2, 15, 1, 1, 2)
-        lay.addWidget(QLabel('<h4>Top</h4>', self), 16, 0, 1, 3)
+        lbl = QLabel('[mV]', self, alignment=Qt.AlignCenter)
+        lbl.setMaximumWidth(25)
+        lay.addWidget(lbl, 15, 1)
+        lay.addWidget(self.le_rmpvoltbot1, 15, 2)
+        lay.addWidget(self.lb_rmpvoltbot1, 15, 3)
+        lbl = QLabel('[V]', self, alignment=Qt.AlignCenter)
+        lbl.setMaximumWidth(25)
+        lay.addWidget(lbl, 16, 1)
+        lay.addWidget(self.lb_rmpvoltbot2, 16, 1, 1, 3)
+        lay.addWidget(QLabel('<h4>Top</h4>', self), 17, 0, 1, 3)
         lay.addWidget(QLabel('Phase', self,
-                             alignment=Qt.AlignRight), 17, 0)
-        lay.addWidget(self.sb_rmpphstop, 17, 1)
-        lay.addWidget(self.lb_rmpphstop, 17, 2)
-        lay.addLayout(lay_rmpphstopdesc, 18, 0)
-        lay.addWidget(self.le_rmpvolttop1, 18, 1)
-        lay.addWidget(self.lb_rmpvolttop1, 18, 2)
-        lay.addWidget(self.lb_rmpvolttop2, 18, 1, 1, 2)
+                             alignment=Qt.AlignRight), 18, 0)
+        lay.addWidget(self.sb_rmpphstop, 18, 2)
+        lay.addWidget(self.lb_rmpphstop, 18, 3)
+        lay.addLayout(lay_rmpphstopdesc, 19, 0)
+        lbl = QLabel('[mV]', self, alignment=Qt.AlignCenter)
+        lbl.setMaximumWidth(25)
+        lay.addWidget(lbl, 19, 1)
+        lay.addWidget(self.le_rmpvolttop1, 19, 2)
+        lay.addWidget(self.lb_rmpvolttop1, 19, 3)
+        lbl = QLabel('[V]', self, alignment=Qt.AlignCenter)
+        lbl.setMaximumWidth(25)
+        lay.addWidget(lbl, 20, 1)
+        lay.addWidget(self.lb_rmpvolttop2, 20, 1, 1, 3)
         lay.addItem(QSpacerItem(
-            200, 10, QSzPlcy.Fixed, QSzPlcy.MinimumExpanding), 19, 3)
+            200, 10, QSzPlcy.Fixed, QSzPlcy.MinimumExpanding), 21, 3)
         return lay
 
     def _handle_rmptab_visibility(self, unit_type):
@@ -1477,15 +1475,3 @@ class RFMainControl(SiriusMainWindow):
             self.led_tempcoupok.set_channels2values(ch2vals)
             self.line_cell_minlim.setPos(lims[0])
             self.line_cell_maxlim.setPos(lims[1])
-
-    def _handle_rmpampl_unit_visibility(self, text):
-        self.blockSignals(True)
-        self.cb_rmpphsbot.setCurrentText(text)
-        self.cb_rmpphstop.setCurrentText(text)
-        self.le_rmpvolttop1.setVisible(text == '[mV]')
-        self.lb_rmpvolttop1.setVisible(text == '[mV]')
-        self.le_rmpvoltbot1.setVisible(text == '[mV]')
-        self.lb_rmpvoltbot1.setVisible(text == '[mV]')
-        self.lb_rmpvolttop2.setVisible(text == '[V]')
-        self.lb_rmpvoltbot2.setVisible(text == '[V]')
-        self.blockSignals(False)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -910,19 +910,17 @@ class RFMainControl(SiriusMainWindow):
         lay = QGridLayout()
         self.ramp_chn_wid = {}
 
-        for unit_type in ['W', 'mV']:
+        for unit_type, rmp_channels in self.chs['Ramp'].items():
             idy = 1
             self.ramp_chn_wid[unit_type] = {}
-            rmp_channels = self.chs['Ramp'][unit_type]
-            for pos in ['Bottom', 'Top']:
+            for pos, rmp_ch_pvs in rmp_channels.items():
                 self.ramp_chn_wid[unit_type][pos] = {}
                 wid_dict = self.ramp_chn_wid[unit_type][pos]
-                rmp_ch_pvs = rmp_channels[pos]
                 idx = 2
 
-                for pv_id in ['CavPwr', 'PowFwd', 'PowRev']:
+                for pv_id, pv_val in rmp_ch_pvs.items():
                     wid_dict[pv_id] = SiriusLabel(
-                        self, self.prefix+rmp_ch_pvs[pv_id])
+                        self, self.prefix+pv_val)
                     wid_dict[pv_id].showUnits = True
                     lay.addWidget(wid_dict[pv_id], idx, idy)
                     if unit_type == 'mV':

--- a/pyqt-apps/siriushla/as_rf_control/details.py
+++ b/pyqt-apps/siriushla/as_rf_control/details.py
@@ -192,6 +192,10 @@ class TransmLineStatusDetails(SiriusDialog):
             self, self.prefix+self.chs['TL Sts']['Load FlwRt'])
         self.led_circintlkop = SiriusLedAlert(
             self, self.prefix+self.chs['TL Sts']['Circ Intlk'])
+        self.led_circsplyfail = SiriusLedAlert(
+            self, self.prefix+self.chs['TL Sts']['Circ Sply Fail'])
+        self.led_loadsplyfail = SiriusLedAlert(
+            self, self.prefix+self.chs['TL Sts']['Circ Sply Fail'])
 
         lay = QFormLayout(self)
         lay.setLabelAlignment(Qt.AlignRight)
@@ -202,7 +206,9 @@ class TransmLineStatusDetails(SiriusDialog):
         lay.addItem(QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed))
         lay.addRow('Circulator Arc Detector: ', self.led_circarc)
         if self.section == 'SI':
+            lay.addRow('Circulator Supply Fail Arc Detector: ', self.led_circsplyfail)
             lay.addRow('Load Arc Detector: ', self.led_loadarc)
+            lay.addRow('Load Supply Fail Arc Detector: ', self.led_loadsplyfail)
         lay.addRow('Circulator Flow: ', self.led_circflwrt)
         lay.addRow('Load Flow: ', self.led_loadflwrt)
         lay.addRow('TCU Status: ', self.led_circintlkop)

--- a/pyqt-apps/siriushla/as_rf_control/details.py
+++ b/pyqt-apps/siriushla/as_rf_control/details.py
@@ -203,13 +203,13 @@ class TransmLineStatusDetails(SiriusDialog):
         hlay.setContentsMargins(0, 0, 0, 0)
 
         lb_circtin = SiriusLabel(
-            self, self.prefix+self.chs['TL Sts']['Circ TIn']['label'])
+            self, self.prefix+self.chs['TL Sts']['Circulator Temp. In']['label'])
         lb_circtin.showUnits = True
         lb_circtin.setStyleSheet('qproperty-alignment: AlignLeft;')
         hlay.addWidget(lb_circtin)
 
         si_led_wid = PyDMLedMultiChannel(
-            self, self.chs['TL Sts']['Circ TIn']['led'])
+            self, self.chs['TL Sts']['Circulator Temp. In']['led'])
         hlay.addWidget(si_led_wid)
 
         lay.addRow('Circulator T In: ', wid)

--- a/pyqt-apps/siriushla/as_rf_control/details.py
+++ b/pyqt-apps/siriushla/as_rf_control/details.py
@@ -205,7 +205,7 @@ class TransmLineStatusDetails(SiriusDialog):
             lay.addRow('Load Arc Detector: ', self.led_loadarc)
         lay.addRow('Circulator Flow: ', self.led_circflwrt)
         lay.addRow('Load Flow: ', self.led_loadflwrt)
-        lay.addRow('Circulator Intlk: ', self.led_circintlkop)
+        lay.addRow('TCU Status: ', self.led_circintlkop)
 
         self.setStyleSheet("""
             SiriusLabel{

--- a/pyqt-apps/siriushla/as_rf_control/details.py
+++ b/pyqt-apps/siriushla/as_rf_control/details.py
@@ -2,7 +2,7 @@
 
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtWidgets import QFormLayout, QLabel, QSpacerItem, QTabWidget, \
-    QSizePolicy as QSzPlcy, QGridLayout, QHBoxLayout, QGroupBox
+    QSizePolicy as QSzPlcy, QGridLayout, QHBoxLayout, QGroupBox, QWidget
 
 from pyqtgraph import PlotWidget, BarGraphItem
 
@@ -173,45 +173,62 @@ class TransmLineStatusDetails(SiriusDialog):
         self._setupUi()
 
     def _setupUi(self):
-        self.lb_circtin = SiriusLabel(
-            self, self.prefix+self.chs['TL Sts']['Circ TIn'])
-        self.lb_circtin.showUnits = True
-        self.lb_circtin.setStyleSheet('qproperty-alignment: AlignLeft;')
-        self.lb_circtout = SiriusLabel(
-            self, self.prefix+self.chs['TL Sts']['Circ TOut'])
-        self.lb_circtout.showUnits = True
-        self.lb_circtout.setStyleSheet('qproperty-alignment: AlignLeft;')
-        self.led_circarc = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Circ Arc'])
-        if self.section == 'SI':
-            self.led_loadarc = SiriusLedAlert(
-                self, self.prefix+self.chs['TL Sts']['Load Arc'])
-        self.led_circflwrt = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Circ FlwRt'])
-        self.led_loadflwrt = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Load FlwRt'])
-        self.led_circintlkop = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Circ Intlk'])
-        self.led_circsplyfail = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Circ Sply Fail'])
-        self.led_loadsplyfail = SiriusLedAlert(
-            self, self.prefix+self.chs['TL Sts']['Circ Sply Fail'])
-
         lay = QFormLayout(self)
         lay.setLabelAlignment(Qt.AlignRight)
         lay.addRow(QLabel('<h4>Transm. Line - Detailed Status</h4>'))
         lay.addItem(QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed))
-        lay.addRow('Circulator T In: ', self.lb_circtin)
-        lay.addRow('Circulator T Out: ', self.lb_circtout)
+
+        for widget_id, pvname in self.chs['TL Sts']['label_led'].items():
+            wid = QWidget()
+            hlay = QHBoxLayout()
+            wid.setLayout(hlay)
+            hlay.setContentsMargins(0, 0, 0, 0)
+
+            si_lbl_wid = SiriusLabel(
+                self, self.prefix+pvname['label'])
+            si_lbl_wid.showUnits = True
+            si_lbl_wid.setMaximumWidth(100)
+            si_lbl_wid.setStyleSheet('qproperty-alignment: AlignLeft;')
+            hlay.addWidget(si_lbl_wid)
+
+            si_led_wid = SiriusLedAlert(
+                self, self.prefix+pvname['led'])
+            hlay.addWidget(si_led_wid)
+
+            lay.addRow(widget_id, wid)
+
+        wid = QWidget()
+        hlay = QHBoxLayout()
+        wid.setLayout(hlay)
+        hlay.setContentsMargins(0, 0, 0, 0)
+
+        lb_circtin = SiriusLabel(
+            self, self.prefix+self.chs['TL Sts']['Circ TIn']['label'])
+        lb_circtin.showUnits = True
+        lb_circtin.setStyleSheet('qproperty-alignment: AlignLeft;')
+        hlay.addWidget(lb_circtin)
+
+        si_led_wid = PyDMLedMultiChannel(
+            self, self.chs['TL Sts']['Circ TIn']['led'])
+        hlay.addWidget(si_led_wid)
+
+        lay.addRow('Circulator T In: ', wid)
+
+        for widget_id, pvname in self.chs['TL Sts']['label'].items():
+            if not ((self.section == 'BO') and ('Combiner' == widget_id)):
+                si_lbl_wid = SiriusLabel(
+                    self, self.prefix+pvname)
+                si_lbl_wid.showUnits = True
+                si_lbl_wid.setStyleSheet('qproperty-alignment: AlignLeft;')
+                lay.addRow(widget_id, si_lbl_wid)
+
         lay.addItem(QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed))
-        lay.addRow('Circulator Arc Detector: ', self.led_circarc)
-        if self.section == 'SI':
-            lay.addRow('Circulator Supply Fail Arc Detector: ', self.led_circsplyfail)
-            lay.addRow('Load Arc Detector: ', self.led_loadarc)
-            lay.addRow('Load Supply Fail Arc Detector: ', self.led_loadsplyfail)
-        lay.addRow('Circulator Flow: ', self.led_circflwrt)
-        lay.addRow('Load Flow: ', self.led_loadflwrt)
-        lay.addRow('TCU Status: ', self.led_circintlkop)
+
+        for widget_id, pvname in self.chs['TL Sts']['led'].items():
+            if not ((self.section == 'BO') and ('Detector Load' in widget_id)):
+                si_led_wid = SiriusLedAlert(
+                    self, self.prefix+pvname)
+                lay.addRow(widget_id + ": ", si_led_wid)
 
         self.setStyleSheet("""
             SiriusLabel{

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -122,20 +122,20 @@ SEC_2_CHANNELS = {
         'TL Sts': {
             'Geral': 'RA-TLBO:RF-TrLine:Sts-Mon',
             'label_led': {
-                'Circ TDrift': {
+                'Circulator Temp. Drift': {
                     'label': 'RA-TLBO:RF-Circulator:dT-Mon',
                     'led': 'RA-TLBO:RF-Circulator:TDrift-Mon'
                 },
-                'Circ Coil': {
+                'Circulator Coil': {
                     'label': 'RA-TLBO:RF-Circulator:Current-Mon',
                     'led': 'RA-TLBO:RF-Circulator:Sts-Mon'
                 },
-                'Room Temp': {
+                'Room Temp.': {
                     'label': 'RA-TLBO:RF-Circulator:Tamb-Mon',
                     'led': 'RA-TLBO:RF-Circulator:TEnv-Mon'
                 }
             },
-            'Circ TIn': {
+            'Circulator Temp. In': {
                 'label': 'RA-TLBO:RF-Circulator:Tin-Mon',
                 'led': {
                     'RA-TLBO:RF-Circulator:TinDown-Mon': 0,
@@ -143,7 +143,7 @@ SEC_2_CHANNELS = {
                 }
             },
             'label': {
-                'Circulator T Out': 'RA-TLBO:RF-Circulator:Tout-Mon',
+                'Circulator Temp. Out': 'RA-TLBO:RF-Circulator:Tout-Mon',
                 'Circulator In Reflected Power': 'RA-TLBO:RF-Circulator:PwrRevIndBm-Mon'
             },
             'led': {
@@ -397,7 +397,7 @@ SEC_2_CHANNELS = {
         },
         'TL Sts': {
             'Geral': 'RA-TLSIA:RF-TrLine:Sts-Mon',
-            'Circ TIn': {
+            'Circulator Temp. In': {
                 'label': 'RA-TLSIA:RF-Circulator:Tin-Mon',
                 'led': {
                     'RA-TLSIA:RF-Circulator:TinDown-Mon': 0,
@@ -405,21 +405,21 @@ SEC_2_CHANNELS = {
                 }
             },
             'label_led': {
-                'Circ TDrift': {
+                'Circulator Temp. Drift': {
                     'label': 'RA-TLSIA:RF-Circulator:dT-Mon',
                     'led': 'RA-TLSIA:RF-Circulator:TDrift-Mon'
                 },
-                'Circ Coil': {
+                'Circulator Coil': {
                     'label': 'RA-TLSIA:RF-Circulator:Current-Mon',
                     'led': 'RA-TLSIA:RF-Circulator:Sts-Mon'
                 },
-                'Room Temp': {
+                'Room Temp.': {
                     'label': 'RA-TLSIA:RF-Circulator:Tamb-Mon',
                     'led': 'RA-TLSIA:RF-Circulator:TEnv-Mon'
                 }
             },
             'label': {
-                'Circulator T Out': 'RA-TLSIA:RF-Circulator:Tout-Mon',
+                'Circulator Temp. Out': 'RA-TLSIA:RF-Circulator:Tout-Mon',
                 'Circulator In Reflected Power': 'RA-TLSIA:RF-Circulator:PwrRevIndBm-Mon',
                 'Combiner': 'RA-TLSIA:RF-Combiner:T-Mon'
             },

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -220,8 +220,34 @@ SEC_2_CHANNELS = {
                     'Cell 4': 'BO-05D:RF-P5Cav:Cylin4T-Mon',
                     'Cell 5': 'BO-05D:RF-P5Cav:Cylin5T-Mon',
                 },
-            },
+            }
         },
+        'Ramp': {
+            'W': {
+                'Top': {
+                    'CavPwr': 'BO-05D:RF-P5Cav:Cell3PwrTop-Mon',
+                    'PowFwd': 'BO-05D:RF-P5Cav:PwrFwdTop-Mon',
+                    'PowRev': 'BO-05D:RF-P5Cav:PwrRevTop-Mon'
+                },
+                'Bottom': {
+                    'CavPwr': 'BO-05D:RF-P5Cav:Cell3PwrBot-Mon',
+                    'PowFwd': 'BO-05D:RF-P5Cav:PwrFwdBot-Mon',
+                    'PowRev': 'BO-05D:RF-P5Cav:PwrRevBot-Mon'
+                }
+            },
+            'mV': {
+                'Top': {
+                    'CavPwr': 'BR-RF-DLLRF-01:TOP:CELL3:AMP',
+                    'PowFwd': 'BR-RF-DLLRF-01:TOP:FWDCAV:AMP',
+                    'PowRev': 'BR-RF-DLLRF-01:TOP:REVCAV:AMP'
+                },
+                'Bottom': {
+                    'CavPwr': 'BR-RF-DLLRF-01:BOT:CELL3:AMP',
+                    'PowFwd': 'BR-RF-DLLRF-01:BOT:FWDCAV:AMP',
+                    'PowRev': 'BR-RF-DLLRF-01:BOT:REVCAV:AMP'
+                }
+            }
+        }
     },
     'SI': {
         'Emergency': 'RA-RaSIA02:RF-IntlkCtrl:EStop-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -374,6 +374,8 @@ SEC_2_CHANNELS = {
             'Circ TIn': 'RA-TLSIA:RF-Circulator:Tin-Mon',
             'Circ TOut': 'RA-TLSIA:RF-Circulator:Tout-Mon',
             'Circ Arc': 'RA-TLSIA:RF-Circulator:Arc-Mon',
+            'Load Sply Fail': 'RA-RaSIA02:RF-ArcDetec-Load:PwrFail-Mon',
+            'Circ Sply Fail': 'RA-RaSIA02:RF-ArcDetec-Circ:PwrFail-Mon',
             'Load Arc': 'RA-TLSIA:RF-Load:Arc-Mon',
             'Circ FlwRt': 'RA-TLSIA:RF-Circulator:FlwRt-Mon',
             'Load FlwRt': 'RA-TLSIA:RF-Load:FlwRt-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -121,12 +121,38 @@ SEC_2_CHANNELS = {
         },
         'TL Sts': {
             'Geral': 'RA-TLBO:RF-TrLine:Sts-Mon',
-            'Circ TIn': 'RA-TLBO:RF-Circulator:Tin-Mon',
-            'Circ TOut': 'RA-TLBO:RF-Circulator:Tout-Mon',
-            'Circ Arc': 'RA-TLBO:RF-Circulator:Arc-Mon',
-            'Circ FlwRt': 'RA-TLBO:RF-Circulator:FlwRt-Mon',
-            'Load FlwRt': 'RA-TLBO:RF-Load:FlwRt-Mon',
-            'Circ Intlk': 'RA-TLBO:RF-Circulator:IntlkOp-Mon',
+            'label_led': {
+                'Circ TDrift': {
+                    'label': 'RA-TLBO:RF-Circulator:dT-Mon',
+                    'led': 'RA-TLBO:RF-Circulator:TDrift-Mon'
+                },
+                'Circ Coil': {
+                    'label': 'RA-TLBO:RF-Circulator:Current-Mon',
+                    'led': 'RA-TLBO:RF-Circulator:Sts-Mon'
+                },
+                'Room Temp': {
+                    'label': 'RA-TLBO:RF-Circulator:Tamb-Mon',
+                    'led': 'RA-TLBO:RF-Circulator:TEnv-Mon'
+                }
+            },
+            'Circ TIn': {
+                'label': 'RA-TLBO:RF-Circulator:Tin-Mon',
+                'led': {
+                    'RA-TLBO:RF-Circulator:TinDown-Mon': 0,
+                    'RA-TLBO:RF-Circulator:TinUp-Mon': 0
+                }
+            },
+            'label': {
+                'Circulator T Out': 'RA-TLBO:RF-Circulator:Tout-Mon',
+                'Circulator In Reflected Power': 'RA-TLBO:RF-Circulator:PwrRevIndBm-Mon'
+            },
+            'led': {
+                'Circulator Arc Detector': 'RA-TLBO:RF-Circulator:Arc-Mon',
+                'Circulator Arc Detector Supply Fail': 'RA-TLBO02:RF-ArcDetec-Circ:PwrFail-Mon',
+                'Circulator Flow': 'RA-TLBO:RF-Circulator:FlwRt-Mon',
+                'Load Flow': 'RA-TLBO:RF-Load:FlwRt-Mon',
+                'TCU Status': 'RA-TLBO:RF-Circulator:IntlkOp-Mon',
+            },
             'Circ Limits': (19.0, 23.0),
         },
         'SSA': {
@@ -224,27 +250,27 @@ SEC_2_CHANNELS = {
         },
         'Ramp': {
             'W': {
-                'Top': {
-                    'CavPwr': 'BO-05D:RF-P5Cav:Cell3PwrTop-Mon',
-                    'PowFwd': 'BO-05D:RF-P5Cav:PwrFwdTop-Mon',
-                    'PowRev': 'BO-05D:RF-P5Cav:PwrRevTop-Mon'
-                },
                 'Bottom': {
                     'CavPwr': 'BO-05D:RF-P5Cav:Cell3PwrBot-Mon',
                     'PowFwd': 'BO-05D:RF-P5Cav:PwrFwdBot-Mon',
                     'PowRev': 'BO-05D:RF-P5Cav:PwrRevBot-Mon'
+                },
+                'Top': {
+                    'CavPwr': 'BO-05D:RF-P5Cav:Cell3PwrTop-Mon',
+                    'PowFwd': 'BO-05D:RF-P5Cav:PwrFwdTop-Mon',
+                    'PowRev': 'BO-05D:RF-P5Cav:PwrRevTop-Mon'
                 }
             },
             'mV': {
-                'Top': {
-                    'CavPwr': 'BR-RF-DLLRF-01:TOP:CELL3:AMP',
-                    'PowFwd': 'BR-RF-DLLRF-01:TOP:FWDCAV:AMP',
-                    'PowRev': 'BR-RF-DLLRF-01:TOP:REVCAV:AMP'
-                },
                 'Bottom': {
                     'CavPwr': 'BR-RF-DLLRF-01:BOT:CELL3:AMP',
                     'PowFwd': 'BR-RF-DLLRF-01:BOT:FWDCAV:AMP',
                     'PowRev': 'BR-RF-DLLRF-01:BOT:REVCAV:AMP'
+                },
+                'Top': {
+                    'CavPwr': 'BR-RF-DLLRF-01:TOP:CELL3:AMP',
+                    'PowFwd': 'BR-RF-DLLRF-01:TOP:FWDCAV:AMP',
+                    'PowRev': 'BR-RF-DLLRF-01:TOP:REVCAV:AMP'
                 }
             }
         }
@@ -371,15 +397,41 @@ SEC_2_CHANNELS = {
         },
         'TL Sts': {
             'Geral': 'RA-TLSIA:RF-TrLine:Sts-Mon',
-            'Circ TIn': 'RA-TLSIA:RF-Circulator:Tin-Mon',
-            'Circ TOut': 'RA-TLSIA:RF-Circulator:Tout-Mon',
-            'Circ Arc': 'RA-TLSIA:RF-Circulator:Arc-Mon',
-            'Load Sply Fail': 'RA-RaSIA02:RF-ArcDetec-Load:PwrFail-Mon',
-            'Circ Sply Fail': 'RA-RaSIA02:RF-ArcDetec-Circ:PwrFail-Mon',
-            'Load Arc': 'RA-TLSIA:RF-Load:Arc-Mon',
-            'Circ FlwRt': 'RA-TLSIA:RF-Circulator:FlwRt-Mon',
-            'Load FlwRt': 'RA-TLSIA:RF-Load:FlwRt-Mon',
-            'Circ Intlk': 'RA-TLSIA:RF-Circulator:IntlkOp-Mon',
+            'Circ TIn': {
+                'label': 'RA-TLSIA:RF-Circulator:Tin-Mon',
+                'led': {
+                    'RA-TLSIA:RF-Circulator:TinDown-Mon': 0,
+                    'RA-TLSIA:RF-Circulator:TinUp-Mon': 0
+                }
+            },
+            'label_led': {
+                'Circ TDrift': {
+                    'label': 'RA-TLSIA:RF-Circulator:dT-Mon',
+                    'led': 'RA-TLSIA:RF-Circulator:TDrift-Mon'
+                },
+                'Circ Coil': {
+                    'label': 'RA-TLSIA:RF-Circulator:Current-Mon',
+                    'led': 'RA-TLSIA:RF-Circulator:Sts-Mon'
+                },
+                'Room Temp': {
+                    'label': 'RA-TLSIA:RF-Circulator:Tamb-Mon',
+                    'led': 'RA-TLSIA:RF-Circulator:TEnv-Mon'
+                }
+            },
+            'label': {
+                'Circulator T Out': 'RA-TLSIA:RF-Circulator:Tout-Mon',
+                'Circulator In Reflected Power': 'RA-TLSIA:RF-Circulator:PwrRevIndBm-Mon',
+                'Combiner': 'RA-TLSIA:RF-Combiner:T-Mon'
+            },
+            'led': {
+                'Circulator Arc Detector': 'RA-TLSIA:RF-Circulator:Arc-Mon',
+                'Circulator Arc Detector Supply Fail': 'RA-RaSIA02:RF-ArcDetec-Circ:PwrFail-Mon',
+                'Arc Detector Load': 'RA-TLSIA:RF-Load:Arc-Mon',
+                'Arc Detector Load Supply Fail': 'RA-RaSIA02:RF-ArcDetec-Load:PwrFail-Mon',
+                'Circulator Flow': 'RA-TLSIA:RF-Circulator:FlwRt-Mon',
+                'Load Flow': 'RA-TLSIA:RF-Load:FlwRt-Mon',
+                'TCU Status': 'RA-TLSIA:RF-Circulator:IntlkOp-Mon',
+            },
             'Circ Limits': (19.0, 23.0),
         },
         'SSA': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -148,7 +148,7 @@ SEC_2_CHANNELS = {
             },
             'led': {
                 'Circulator Arc Detector': 'RA-TLBO:RF-Circulator:Arc-Mon',
-                'Circulator Arc Detector Supply Fail': 'RA-TLBO02:RF-ArcDetec-Circ:PwrFail-Mon',
+                'Circulator Arc Detector Supply Fail': 'RA-RaBO02:RF-ArcDetec-Circ:PwrFail-Mon',
                 'Circulator Flow': 'RA-TLBO:RF-Circulator:FlwRt-Mon',
                 'Load Flow': 'RA-TLBO:RF-Load:FlwRt-Mon',
                 'TCU Status': 'RA-TLBO:RF-Circulator:IntlkOp-Mon',


### PR DESCRIPTION
Remove the Amplitude setpoint input when the Volt unit is selected and move the Amplitude Readback [V](Ref Voltage):![image](https://github.com/lnls-sirius/hla/assets/63302930/ce5ef421-1f40-4325-9cc9-959fb79cc754)
![image](https://github.com/lnls-sirius/hla/assets/63302930/a986669f-1e2a-4ad3-bb57-1c4f2755bde1)

Switch ramp unit between Watts and millivolts:
![image](https://github.com/lnls-sirius/hla/assets/63302930/a95fc235-916c-4ed7-a896-5b3caa3db295) 
![image](https://github.com/lnls-sirius/hla/assets/63302930/00db9f13-1f8a-41ab-9dd6-076487ae2573)

Addtion of Transmission Line Status PVs
![image](https://github.com/lnls-sirius/hla/assets/63302930/9290f7a6-2e4d-4cf6-ab25-7a1faa10e02c)
![image](https://github.com/lnls-sirius/hla/assets/63302930/c3a2179d-0d7b-4632-896d-ae6bedaf513d)

