### PR TITLE
COMMON.ENH: add more exceptions to EpicsSetter.

### DIFF
--- a/pyqt-apps/siriushla/common/epics/task/setter.py
+++ b/pyqt-apps/siriushla/common/epics/task/setter.py
@@ -1,6 +1,8 @@
 """Epics Setter."""
 import time
 import logging as _log
+from epics.ca import ChannelAccessGetFailure as _ChannelAccessGetFailure, \
+    CASeverityException as _CASeverityException
 from .task import EpicsTask
 
 
@@ -16,7 +18,7 @@ class EpicsSetter(EpicsTask):
                 try:
                     pv.put(self._values[i])
                     time.sleep(self._delays[i])
-                except TypeError:
+                except (TypeError, _ChannelAccessGetFailure, _CASeverityException):
                     _log.warning('PV {} not set with value: {}'.format(
                         pvn, self._values[i]))
                 self.itemDone.emit()


### PR DESCRIPTION
These exceptions were copied from the siriuspy Device class. CASeverityException, for example, can be thrown when writing to a PV for which we don't have write access.