### PR TITLE
Updates RF SSA

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/__init__.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/__init__.py
@@ -6,4 +6,5 @@ from .conditioning import ConditioningDetails
 from .hardware import HardwareDetails
 from .loops import LoopsDetails
 from .ramps import RampsDetails
+from .ssa_currents import SSACurrentsDetails
 from .tuning import TuningDetails

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
@@ -148,7 +148,7 @@ class RampsDetails(SiriusDialog):
         for i in range(len(addrs)):
             rule += ('{"channel": ' +
                 self.prefix+chs_dict[addrs[i]][1]+'-RB"' +
-                ', "trigger": true}')
+                ', "trigger": true}, ')
 
         rule += ']}]'
         lb_total.rules = rule

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
@@ -146,9 +146,9 @@ class RampsDetails(SiriusDialog):
                 '"expression": "ch[0] + ch[1] + ch[2] + ch[4]", ' +
                 '"channels": [')
         for i in range(len(addrs)):
-            rule += ('{"channel": ' +
+            rule += ('{"channel": "' +
                 self.prefix+chs_dict[addrs[i]][1]+'-RB"' +
-                ', "trigger": true}, ')
+                '", "trigger": true}, ')
 
         rule += ']}]'
         lb_total.rules = rule

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -206,12 +206,6 @@ class SSACurrentsDetails(SiriusDialog):
 
         row = 0
         column = 0
-        hs_nums = {
-            1: [1, 2],
-            2: [3, 4],
-            3: [5, 6],
-            4: [7, 8]
-        }
 
         # Racks 1 to 4
         total_pvs = []

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -1,0 +1,158 @@
+"""SSA Currents Details."""
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
+    QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox
+
+from ...widgets import SiriusDialog, SiriusLabel
+from ..util import SEC_2_CHANNELS
+
+
+class SSACurrentsDetails(SiriusDialog):
+    """SSA Currents Details."""
+
+    def __init__(self, parent, prefix='', section='', num='', system=''):
+        """Init."""
+        super().__init__(parent)
+        self.prefix = prefix
+        self.prefix += ('-' if prefix and not prefix.endswith('-') else '')
+        self.section = section
+        self.chs = SEC_2_CHANNELS[self.section]
+        self.num = num
+        self.system = system
+        self.setObjectName(self.section+'App')
+        if self.section == 'SI':
+            self.syst_dict = self.chs['SSACurr'][self.system]
+            self.title = f'SSA 0{self.num} Currents Details'
+        else:
+            self.syst_dict = self.chs['SSACurr']
+            self.title = 'SSA Currents Details'
+        self.setWindowTitle(f'{self.section} {self.title}')
+        self._setupUi()
+
+    def _setupUi(self):
+        lay = QVBoxLayout(self)
+        lay.setAlignment(Qt.AlignTop)
+
+        dtls = QTabWidget(self)
+        dtls.setObjectName(self.section+'Tab')
+        dtls.setStyleSheet(
+            "#"+self.section+'Tab'+"::pane {"
+            "    border-left: 2px solid gray;"
+            "    border-bottom: 2px solid gray;"
+            "    border-right: 2px solid gray;}")
+
+        wid_diag = QWidget(self)
+        wid_diag.setLayout(self._setupDiagLay())
+        dtls.addTab(wid_diag, 'Diagnostics')
+
+        # wid_graphs = QWidget(self)
+        # wid_graphs.setLayout(self._setupGraphsLay())
+        # dtls.addTab(wid_graphs, 'Graphs')
+
+        lay.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(dtls)
+
+    def _setupDiagLay(self):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(18)
+
+        row = 0
+        column = 0
+        for i in range(1, 9):
+            row_label = ''
+            if column == 0:
+                row_label = 'left'
+            elif column == 4:
+                row_label = 'right'
+
+            lay.addLayout(self._setupHeatSinkLay(
+                i, self.syst_dict['HeatSink'], row_label), row, column)
+
+            column += 1
+            if column == 2:
+                if row == 0:
+                    gbox_preamp = QGroupBox('Pre Amplifiers')
+                    gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
+                    lay.addWidget(gbox_preamp, row, column)
+                else:
+                    gbox_total = QGroupBox('Total Current')
+                    gbox_total.setLayout(self._setupTotalLay(self.syst_dict['Total']))
+                    lay.addWidget(gbox_total, row, column)
+                column += 1
+            elif column == 5:
+                lay.addItem(QSpacerItem(
+                    0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row+1, 0)
+                column = 0
+                row += 2
+
+        return lay
+
+    def _setupHeatSinkLay(self, hs_num, chs_dict, row_label=''):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        lay.addWidget(QLabel(
+            f'<h4>Heat Sink {hs_num}</h4>', alignment=Qt.AlignCenter),
+            0, 1, 1, 4)
+        lay.addWidget(QLabel(
+            '<h4>A</h4>', alignment=Qt.AlignCenter), 1, 1, 1, 2)
+        lay.addWidget(QLabel(
+            '<h4>B</h4>', alignment=Qt.AlignCenter), 1, 3, 1, 2)
+
+        for i in range(1, 9):
+            base_pv = self.prefix+chs_dict['Curr']
+            lb_a_1 = SiriusLabel(self, self._substitute_macros(
+                base_pv, hs_num, 'A', i, 1))
+            lb_a_1.showUnits = True
+            lb_a_2 = SiriusLabel(self, self._substitute_macros(
+                base_pv, hs_num, 'A', i, 2))
+            lb_a_2.showUnits = True
+            lb_b_1 = SiriusLabel(self, self._substitute_macros(
+                base_pv, hs_num, 'B', i, 1))
+            lb_b_1.showUnits = True
+            lb_b_2 = SiriusLabel(self, self._substitute_macros(
+                base_pv, hs_num, 'B', i, 2))
+            lb_b_2.showUnits = True
+
+            if row_label == 'left':
+                lay.addWidget(QLabel(
+                    f'M0{i}', alignment=Qt.AlignCenter), i+1, 0)
+            elif row_label == 'right':
+                lay.addWidget(QLabel(
+                    f'M0{i}', alignment=Qt.AlignCenter), i+1, 5)
+            lay.addWidget(lb_a_1, i+1, 1)
+            lay.addWidget(lb_a_2, i+1, 2)
+            lay.addWidget(lb_b_1, i+1, 3)
+            lay.addWidget(lb_b_2, i+1, 4)
+
+        return lay
+
+    def _setupPreAmpLay(self, chs_dict):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        return lay
+
+    def _setupTotalLay(self, chs_dict):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        return lay
+
+    def _substitute_macros(self, pv_name, hs_num='', letter='', m_num='', curr_num=''):
+        pv_name = pv_name.replace('$(NB)', str(self.num))
+        if hs_num:
+            pv_name = pv_name.replace('$(hs_num)', str(hs_num))
+        if letter:
+            pv_name = pv_name.replace('$(letter)', str(letter))
+        if m_num:
+            pv_name = pv_name.replace('$(m_num)', str(m_num))
+        if curr_num:
+            pv_name = pv_name.replace('$(curr_num)', str(curr_num))
+        return pv_name

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -47,9 +47,9 @@ class SSACurrentsDetails(SiriusDialog):
         wid_diag.setLayout(self._setupDiagLay())
         dtls.addTab(wid_diag, 'Diagnostics')
 
-        # wid_graphs = QWidget(self)
-        # wid_graphs.setLayout(self._setupAlarmLay())
-        # dtls.addTab(wid_graphs, 'Alarm Limits')
+        wid_graphs = QWidget(self)
+        wid_graphs.setLayout(self._setupAlarmLay())
+        dtls.addTab(wid_graphs, 'Alarm Limits')
 
         lay.addWidget(QLabel(
             f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
@@ -98,18 +98,31 @@ class SSACurrentsDetails(SiriusDialog):
                     row_label = 'right'
 
                 lay.addLayout(self._setupHeatSinkLay(
-                    i, self.syst_dict['HeatSink'], row_label), row, column)
+                    i, self.syst_dict['HeatSink'], row_label),
+                    row, column, 2, 1)
 
                 column += 1
                 if column == 3:
-                    # gbox_preamp = QGroupBox('Pre Amplifiers')
-                    # gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
-                    # lay.addWidget(gbox_preamp, row, column)
-                    column += 1
+                    # PreAmp
+                    gbox_preamp = QGroupBox('Pre Amplifiers')
+                    gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
+                    lay.addWidget(gbox_preamp, row, column)
 
-            # gbox_total = QGroupBox('Total Current')
-            # gbox_total.setLayout(self._setupTotalLay())
-            # lay.addWidget(gbox_total, 2, 2)
+                    # Power
+                    lay.addLayout(self._setupPowerLay(
+                        self.syst_dict['Pwr']), row+1, column)
+
+                    # Total Current
+                    lb_total = SiriusLabel(
+                        self, self.prefix+self.syst_dict['Total'])
+                    lb_total.showUnits = True
+                    lay_total = QHBoxLayout()
+                    lay_total.addWidget(QLabel(
+                        '<h4>Total Current</h4>', alignment=Qt.AlignCenter))
+                    lay_total.addWidget(lb_total, alignment=Qt.AlignCenter)
+                    lay.addLayout(lay_total, row+2, column)
+
+                    column += 1
 
         return lay
 
@@ -239,54 +252,151 @@ class SSACurrentsDetails(SiriusDialog):
 
         row = 0
         column = 0
-        for i in range(2, 9, 2):
+        if self.section == 'SI':
+            for i in range(2, 9, 2):
+                # Heat Sinks
+                label = QLabel(
+                    f'<h4>Heat Sink {i}</h4>', alignment=Qt.AlignCenter)
+                label.setStyleSheet("min-width:6em;")
+                lb_1 = SiriusLabel(self, self._substitute_macros(
+                    self.prefix+chs_dict['HS'], i, curr_num='1'))
+                lb_1.showUnits = True
+                lb_2 = SiriusLabel(self, self._substitute_macros(
+                    self.prefix+chs_dict['HS'], i, curr_num='2'))
+                lb_2.showUnits = True
+
+                lay.addWidget(label, row, column)
+                lay.addWidget(lb_1, row+1, column)
+                lay.addWidget(lb_2, row+2, column)
+
+                column += 1
+                if column == 1:
+                    if row == 0:
+                        # Pre Amp
+                        label = QLabel(
+                            '<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
+                        label.setStyleSheet("min-width:6em;")
+                        lb_1 = SiriusLabel(self, self._substitute_macros(
+                            self.prefix+chs_dict['PreAmp'], curr_num='1'))
+                        lb_1.showUnits = True
+                        lb_2 = SiriusLabel(self, self._substitute_macros(
+                            self.prefix+chs_dict['PreAmp'], curr_num='2'))
+                        lb_2.showUnits = True
+
+                        lay.addWidget(label, row, column)
+                        lay.addWidget(lb_1, row+1, column)
+                        lay.addWidget(lb_2, row+2, column)
+                        column += 1
+                    else:
+                        # TDK Source
+                        label = QLabel(
+                            '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
+                        label.setStyleSheet("min-width:6em;")
+
+                        lay.addWidget(label, row, column)
+                        lay.addWidget(SiriusLedState(
+                            self, self._substitute_macros(
+                                self.prefix+chs_dict['TDK'])), row+1, column,
+                                alignment=Qt.AlignCenter)
+                        column += 1
+
+                if column > 2:
+                    row += 3
+                    column = 0
+        else:
             # Heat Sinks
-            label = QLabel(f'<h4>Heat Sink {i}</h4>', alignment=Qt.AlignCenter)
-            label.setStyleSheet("min-width:6em;")
-            lb_1 = SiriusLabel(self, self._substitute_macros(
-                self.prefix+chs_dict['HS'], i, curr_num='1'))
-            lb_1.showUnits = True
-            lb_2 = SiriusLabel(self, self._substitute_macros(
-                self.prefix+chs_dict['HS'], i, curr_num='2'))
-            lb_2.showUnits = True
+            hs_nums = [1, 4, 3, 6]
+            m_nums = [1, 1, 17, 17]
+            row = 0
+            column = 0
+            for i, hs_num in enumerate(hs_nums):
+                lb_1 = SiriusLabel(self, self._substitute_macros(
+                    self.prefix+chs_dict['HS'], i, m_num=m_nums[i],
+                    curr_num='1'))
+                lb_1.showUnits = True
+                lb_2 = SiriusLabel(self, self._substitute_macros(
+                    self.prefix+chs_dict['HS'], i, m_num=m_nums[i],
+                    curr_num='2'))
+                lb_2.showUnits = True
 
-            lay.addWidget(label, row, column)
-            lay.addWidget(lb_1, row+1, column)
-            lay.addWidget(lb_2, row+2, column)
+                lay.addWidget(QLabel(
+                    f'<h4>Heat Sink {hs_num}</h4>',
+                    alignment=Qt.AlignCenter), row, column, 1, 2)
+                lay.addWidget(lb_1, row+1, column)
+                lay.addWidget(lb_2, row+1, column+1)
 
-            column += 1
-            if column == 1:
-                if row == 0:
-                    # Pre Amp
-                    label = QLabel('<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
-                    label.setStyleSheet("min-width:6em;")
-                    lb_1 = SiriusLabel(self, self._substitute_macros(
-                        self.prefix+chs_dict['PreAmp'], curr_num='1'))
-                    lb_1.showUnits = True
-                    lb_2 = SiriusLabel(self, self._substitute_macros(
-                        self.prefix+chs_dict['PreAmp'], curr_num='2'))
-                    lb_2.showUnits = True
+                column += 2
+                if column == 4:
+                    row += 2
+                    column = 0
 
-                    lay.addWidget(label, row, column)
-                    lay.addWidget(lb_1, row+1, column)
-                    lay.addWidget(lb_2, row+2, column)
-                    column += 1
-                else:
-                    # TDK Source
-                    label = QLabel(
-                        '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
-                    label.setStyleSheet("min-width:6em;")
+            lay_dc = QHBoxLayout()
+            lay_dc.addWidget(QLabel(
+                '<h4>DC-DC Conv.</h4>', alignment=Qt.AlignCenter))
+            lay_dc.addWidget(SiriusLedState(
+                self, self.prefix+chs_dict['DC']), alignment=Qt.AlignCenter)
+            lay.addItem(QSpacerItem(
+                0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
+            lay.addLayout(lay_dc, row+1, 1, 1, 2)
 
-                    lay.addWidget(label, row, column)
-                    lay.addWidget(SiriusLedState(
-                        self, self._substitute_macros(
-                            self.prefix+chs_dict['TDK'])), row+1, column,
-                            alignment=Qt.AlignCenter)
-                    column += 1
+            #     column += 1
+            #     if column == 1:
+            #         if row == 0:
+            #             # Pre Amp
+            #             label = QLabel(
+            #                 '<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
+            #             label.setStyleSheet("min-width:6em;")
+            #             lb_1 = SiriusLabel(self, self._substitute_macros(
+            #                 self.prefix+chs_dict['PreAmp'], curr_num='1'))
+            #             lb_1.showUnits = True
+            #             lb_2 = SiriusLabel(self, self._substitute_macros(
+            #                 self.prefix+chs_dict['PreAmp'], curr_num='2'))
+            #             lb_2.showUnits = True
 
-            if column > 2:
-                row += 3
-                column = 0
+            #             lay.addWidget(label, row, column)
+            #             lay.addWidget(lb_1, row+1, column)
+            #             lay.addWidget(lb_2, row+2, column)
+            #             column += 1
+            #         else:
+            #             # TDK Source
+            #             label = QLabel(
+            #                 '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
+            #             label.setStyleSheet("min-width:6em;")
+
+            #             lay.addWidget(label, row, column)
+            #             lay.addWidget(SiriusLedState(
+            #                 self, self._substitute_macros(
+            #                     self.prefix+chs_dict['TDK'])), row+1, column,
+            #                     alignment=Qt.AlignCenter)
+            #             column += 1
+
+            #     if column > 2:
+            #         row += 3
+
+        return lay
+
+    def _setupPowerLay(self, chs_dict):
+        lay = QHBoxLayout()
+        lay.setSpacing(9)
+
+        for k, dic in chs_dict.items():
+            gbox = QGroupBox(f'{k} Power')
+            lay_pwr = QVBoxLayout()
+            lay_pwr.setAlignment(Qt.AlignVCenter)
+            lay_pwr.setSpacing(9)
+            gbox.setLayout(lay_pwr)
+
+            lb_fwd = SiriusLabel(self, self.prefix+dic['Fwd'])
+            lb_fwd.showUnits = True
+            lb_rev = SiriusLabel(self, self.prefix+dic['Rev'])
+            lb_rev.showUnits = True
+
+            lay_pwr.addWidget(QLabel('<h4>Forward</h4>'))
+            lay_pwr.addWidget(lb_fwd)
+            lay_pwr.addWidget(QLabel('<h4>Reverse</h4>'))
+            lay_pwr.addWidget(lb_rev)
+
+            lay.addWidget(gbox)
 
         return lay
 
@@ -361,7 +471,7 @@ class SSACurrentsDetails(SiriusDialog):
 
         # Alarms
         lay_alarms = QGridLayout()
-        lay_alarms.setAlignment(Qt.AlignTop)
+        lay_alarms.setAlignment(Qt.AlignVCenter)
         lay_alarms.setSpacing(9)
         gbox_alarms = QGroupBox('Alarms')
         gbox_alarms.setLayout(lay_alarms)

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -24,11 +24,13 @@ class SSACurrentsDetails(SiriusDialog):
         self.curr_pvs = {}
         if self.section == 'SI':
             self.syst_dict = self.chs['SSACurr'][self.system]
-            self.title = f'SSA 0{self.num} Currents Details'
+            self.title = f"""
+                {self.section}{self.system} SSA 0{self.num} Currents Details
+                """
         else:
             self.syst_dict = self.chs['SSACurr']
-            self.title = 'SSA Currents Details'
-        self.setWindowTitle(f'{self.section} {self.title}')
+            self.title = f'{self.section} SSA Currents Details'
+        self.setWindowTitle(self.title)
         self._setupUi()
 
     def _setupUi(self):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -47,9 +47,9 @@ class SSACurrentsDetails(SiriusDialog):
         wid_diag.setLayout(self._setupDiagLay())
         dtls.addTab(wid_diag, 'Diagnostics')
 
-        wid_graphs = QWidget(self)
-        wid_graphs.setLayout(self._setupAlarmLay())
-        dtls.addTab(wid_graphs, 'Alarm Limits')
+        # wid_graphs = QWidget(self)
+        # wid_graphs.setLayout(self._setupAlarmLay())
+        # dtls.addTab(wid_graphs, 'Alarm Limits')
 
         lay.addWidget(QLabel(
             f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
@@ -62,32 +62,54 @@ class SSACurrentsDetails(SiriusDialog):
 
         row = 0
         column = 0
-        for i in range(1, 9):
-            row_label = ''
-            if column == 0:
-                row_label = 'left'
-            elif column == 4:
-                row_label = 'right'
+        if self.section == 'SI':
+            for i in range(1, 9):
+                row_label = ''
+                if column == 0:
+                    row_label = 'left'
+                elif column == 4:
+                    row_label = 'right'
 
-            lay.addLayout(self._setupHeatSinkLay(
-                i, self.syst_dict['HeatSink'], row_label), row, column)
+                lay.addLayout(self._setupHeatSinkLay(
+                    i, self.syst_dict['HeatSink'], row_label), row, column)
 
-            column += 1
-            if column == 2:
-                if row == 0:
-                    gbox_preamp = QGroupBox('Pre Amplifiers')
-                    gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
-                    lay.addWidget(gbox_preamp, row, column)
                 column += 1
-            elif column == 5:
-                lay.addItem(QSpacerItem(
-                    0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row+1, 0)
-                column = 0
-                row += 2
+                if column == 2:
+                    if row == 0:
+                        gbox_preamp = QGroupBox('Pre Amplifiers')
+                        gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
+                        lay.addWidget(gbox_preamp, row, column)
+                    column += 1
+                elif column == 5:
+                    lay.addItem(QSpacerItem(
+                        0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row+1, 0)
+                    column = 0
+                    row += 2
 
-        gbox_total = QGroupBox('Total Current')
-        gbox_total.setLayout(self._setupTotalLay())
-        lay.addWidget(gbox_total, 2, 2)
+            gbox_total = QGroupBox('Total Current')
+            gbox_total.setLayout(self._setupTotalLay())
+            lay.addWidget(gbox_total, 2, 2)
+        else:
+            for i in range(1, 7):
+                row_label = ''
+                if column == 0:
+                    row_label = 'left'
+                elif column == 6:
+                    row_label = 'right'
+
+                lay.addLayout(self._setupHeatSinkLay(
+                    i, self.syst_dict['HeatSink'], row_label), row, column)
+
+                column += 1
+                if column == 3:
+                    # gbox_preamp = QGroupBox('Pre Amplifiers')
+                    # gbox_preamp.setLayout(self._setupPreAmpLay(self.syst_dict['PreAmp']))
+                    # lay.addWidget(gbox_preamp, row, column)
+                    column += 1
+
+            # gbox_total = QGroupBox('Total Current')
+            # gbox_total.setLayout(self._setupTotalLay())
+            # lay.addWidget(gbox_total, 2, 2)
 
         return lay
 
@@ -96,67 +118,117 @@ class SSACurrentsDetails(SiriusDialog):
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
 
-        lay.addWidget(QLabel(
-            f'<h4>Heat Sink {hs_num}</h4>', alignment=Qt.AlignCenter),
-            0, 1, 1, 4)
-        lay.addWidget(QLabel(
-            '<h4>A</h4>', alignment=Qt.AlignCenter), 1, 1, 1, 2)
-        lay.addWidget(QLabel(
-            '<h4>B</h4>', alignment=Qt.AlignCenter), 1, 3, 1, 2)
+        if self.section == 'SI':
+            lay.addWidget(QLabel(
+                f'<h4>Heat Sink {hs_num}</h4>', alignment=Qt.AlignCenter),
+                0, 1, 1, 4)
+            lay.addWidget(QLabel(
+                '<h4>A</h4>', alignment=Qt.AlignCenter), 1, 1, 1, 2)
+            lay.addWidget(QLabel(
+                '<h4>B</h4>', alignment=Qt.AlignCenter), 1, 3, 1, 2)
 
-        # Currents
-        for i in range(1, 9):
-            pv_a_1 = self._substitute_macros(
-                self.prefix+chs_dict['Curr'], hs_num, 'A', i, 1)
-            pv_a_2 = self._substitute_macros(
-                self.prefix+chs_dict['Curr'], hs_num, 'A', i, 2)
-            pv_b_1 = self._substitute_macros(
-                self.prefix+chs_dict['Curr'], hs_num, 'B', i, 1)
-            pv_b_2 = self._substitute_macros(
-                self.prefix+chs_dict['Curr'], hs_num, 'A', i, 2)
-            if i == 1:
-                self.curr_pvs[hs_num] = [pv_a_1, pv_a_2, pv_b_1, pv_b_2]
-            else:
-                self.curr_pvs[hs_num].append(pv_a_1)
-                self.curr_pvs[hs_num].append(pv_a_2)
-                self.curr_pvs[hs_num].append(pv_b_1)
-                self.curr_pvs[hs_num].append(pv_b_2)
+            # Currents
+            for i in range(1, 9):
+                pv_a_1 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, 'A', i, 1)
+                pv_a_2 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, 'A', i, 2)
+                pv_b_1 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, 'B', i, 1)
+                pv_b_2 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, 'A', i, 2)
+                if i == 1:
+                    self.curr_pvs[hs_num] = [pv_a_1, pv_a_2, pv_b_1, pv_b_2]
+                else:
+                    self.curr_pvs[hs_num].append(pv_a_1)
+                    self.curr_pvs[hs_num].append(pv_a_2)
+                    self.curr_pvs[hs_num].append(pv_b_1)
+                    self.curr_pvs[hs_num].append(pv_b_2)
 
-            lb_a_1 = SiriusLabel(self, pv_a_1)
-            lb_a_1.showUnits = True
-            lb_a_2 = SiriusLabel(self, pv_a_2)
-            lb_a_2.showUnits = True
-            lb_b_1 = SiriusLabel(self, pv_b_1)
-            lb_b_1.showUnits = True
-            lb_b_2 = SiriusLabel(self, pv_b_2)
-            lb_b_2.showUnits = True
+                lb_a_1 = SiriusLabel(self, pv_a_1)
+                lb_a_1.showUnits = True
+                lb_a_2 = SiriusLabel(self, pv_a_2)
+                lb_a_2.showUnits = True
+                lb_b_1 = SiriusLabel(self, pv_b_1)
+                lb_b_1.showUnits = True
+                lb_b_2 = SiriusLabel(self, pv_b_2)
+                lb_b_2.showUnits = True
 
-            if row_label == 'left':
-                lay.addWidget(QLabel(
-                    f'M0{i}', alignment=Qt.AlignCenter), i+1, 0)
-            elif row_label == 'right':
-                lay.addWidget(QLabel(
-                    f'M0{i}', alignment=Qt.AlignCenter), i+1, 5)
-            lay.addWidget(lb_a_1, i+1, 1)
-            lay.addWidget(lb_a_2, i+1, 2)
-            lay.addWidget(lb_b_1, i+1, 3)
-            lay.addWidget(lb_b_2, i+1, 4)
-            row = i+2
+                if row_label == 'left':
+                    lay.addWidget(QLabel(
+                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 0)
+                elif row_label == 'right':
+                    lay.addWidget(QLabel(
+                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 5)
+                lay.addWidget(lb_a_1, i+1, 1)
+                lay.addWidget(lb_a_2, i+1, 2)
+                lay.addWidget(lb_b_1, i+1, 3)
+                lay.addWidget(lb_b_2, i+1, 4)
+                row = i+2
 
-        # Power
-        lay.addWidget(QLabel(
-            '<h4>Power</h4>', alignment=Qt.AlignCenter), row, 1, 1, 4)
-        column = 1
-        for key, val in chs_dict.items():
-            if key != 'Curr':
-                lb_pwr = SiriusLabel(
-                    self, self._substitute_macros(self.prefix+val, hs_num))
-                lb_pwr.showUnits = True
-                lay.addWidget(QLabel(
-                    f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
-                    row+1, column)
-                lay.addWidget(lb_pwr, row+2, column)
-                column += 1
+            # Power
+            lay.addWidget(QLabel(
+                '<h4>Power</h4>', alignment=Qt.AlignCenter), row, 1, 1, 4)
+            column = 1
+            for key, val in chs_dict.items():
+                if key != 'Curr':
+                    lb_pwr = SiriusLabel(
+                        self, self._substitute_macros(self.prefix+val, hs_num))
+                    lb_pwr.showUnits = True
+                    lay.addWidget(QLabel(
+                        f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
+                        row+1, column)
+                    lay.addWidget(lb_pwr, row+2, column)
+                    column += 1
+        else:
+            lay.addWidget(QLabel(
+                f'<h4>Heat Sink {hs_num}</h4>', alignment=Qt.AlignCenter),
+                0, 1, 1, 2)
+
+            # Currents
+            for i in range(1, 9):
+                pv_curr_1 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, m_num=i, curr_num=1)
+                pv_curr_2 = self._substitute_macros(
+                    self.prefix+chs_dict['Curr'], hs_num, m_num=i, curr_num=2)
+                if i == 1:
+                    self.curr_pvs[hs_num] = [pv_curr_1, pv_curr_2]
+                else:
+                    self.curr_pvs[hs_num].append(pv_curr_1)
+                    self.curr_pvs[hs_num].append(pv_curr_2)
+
+                lb_curr_1 = SiriusLabel(self, pv_curr_1)
+                lb_curr_1.showUnits = True
+                lb_curr_2 = SiriusLabel(self, pv_curr_2)
+                lb_curr_2.showUnits = True
+
+                if row_label == 'left':
+                    lay.addWidget(QLabel(
+                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 0)
+                elif row_label == 'right':
+                    lay.addWidget(QLabel(
+                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 5)
+                lay.addWidget(lb_curr_1, i+1, 1)
+                lay.addWidget(lb_curr_2, i+1, 2)
+                row = i+2
+
+            # Power
+            lay.addWidget(QLabel(
+                '<h4>Power</h4>', alignment=Qt.AlignCenter), row, 1, 1, 2)
+            column = 1
+            for key, val in chs_dict.items():
+                if key != 'Curr':
+                    lb_pwr = SiriusLabel(
+                        self, self._substitute_macros(self.prefix+val, hs_num))
+                    lb_pwr.showUnits = True
+                    lay.addWidget(QLabel(
+                        f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
+                        row+1, column)
+                    lay.addWidget(lb_pwr, row+2, column)
+                    column += 1
+                if column > 2:
+                    row += 3
+                    column = 1
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -292,19 +292,7 @@ class SSACurrentsDetails(SiriusDialog):
                         lay.addWidget(label, row, column)
                         lay.addWidget(lb_1, row+1, column)
                         lay.addWidget(lb_2, row+2, column)
-                        column += 1
-                    else:
-                        # TDK Source
-                        label = QLabel(
-                            '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
-                        label.setStyleSheet("min-width:6em;")
-
-                        lay.addWidget(label, row, column)
-                        lay.addWidget(SiriusLedState(
-                            self, self._substitute_macros(
-                                self.prefix+chs_dict['TDK'])), row+1, column,
-                                alignment=Qt.AlignCenter)
-                        column += 1
+                    column += 1
 
                 if column > 2:
                     row += 3

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -152,6 +152,8 @@ class SSACurrentsDetails(SiriusDialog):
         column = 0
         for i in range(2, 9, 2):
             # Heat Sinks
+            label = QLabel(f'<h4>Heat Sink {i}</h4>', alignment=Qt.AlignCenter)
+            label.setStyleSheet("min-width:6em;")
             lb_1 = SiriusLabel(self, self._substitute_macros(
                 self.prefix+chs_dict['HS'], i, curr_num='1'))
             lb_1.showUnits = True
@@ -159,9 +161,7 @@ class SSACurrentsDetails(SiriusDialog):
                 self.prefix+chs_dict['HS'], i, curr_num='2'))
             lb_2.showUnits = True
 
-            lay.addWidget(QLabel(
-                f'<h4>Heat Sink {i}</h4>', alignment=Qt.AlignCenter),
-                row, column)
+            lay.addWidget(label, row, column)
             lay.addWidget(lb_1, row+1, column)
             lay.addWidget(lb_2, row+2, column)
 
@@ -169,6 +169,8 @@ class SSACurrentsDetails(SiriusDialog):
             if column == 1:
                 if row == 0:
                     # Pre Amp
+                    label = QLabel('<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
+                    label.setStyleSheet("min-width:6em;")
                     lb_1 = SiriusLabel(self, self._substitute_macros(
                         self.prefix+chs_dict['PreAmp'], curr_num='1'))
                     lb_1.showUnits = True
@@ -176,17 +178,17 @@ class SSACurrentsDetails(SiriusDialog):
                         self.prefix+chs_dict['HS'], curr_num='2'))
                     lb_2.showUnits = True
 
-                    lay.addWidget(QLabel(
-                        '<h4>PreAmp</h4>', alignment=Qt.AlignCenter),
-                        row, column)
+                    lay.addWidget(label, row, column)
                     lay.addWidget(lb_1, row+1, column)
                     lay.addWidget(lb_2, row+2, column)
                     column += 1
                 else:
                     # TDK Source
-                    lay.addWidget(QLabel(
-                        '<h4>TDK Source</h4>', alignment=Qt.AlignCenter),
-                        row, column)
+                    label = QLabel(
+                        '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
+                    label.setStyleSheet("min-width:6em;")
+
+                    lay.addWidget(label, row, column)
                     lay.addWidget(SiriusLedState(
                         self, self._substitute_macros(
                             self.prefix+chs_dict['TDK'])), row+1, column,

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -1,8 +1,8 @@
 """SSA Currents Details."""
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
-    QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox, QHBoxLayout
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, \
+    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget
 
 from ...widgets import SiriusDialog, SiriusLabel, SiriusLedState, SiriusSpinbox
 from ..util import SEC_2_CHANNELS
@@ -237,7 +237,7 @@ class SSACurrentsDetails(SiriusDialog):
                 '"expression": ' + '"ch[0] + ch[1] + ch[2] + ch[3]", ' +
                 '"channels": [')
         for pv in total_pvs:
-            rule += ('{"channel": ' + pv + ', "trigger": true}, ')
+            rule += ('{"channel": "' + pv + '", "trigger": true}, ')
         rule += ']}]'
         lb_total.rules = rule
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -333,40 +333,6 @@ class SSACurrentsDetails(SiriusDialog):
                 0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
             lay.addLayout(lay_dc, row+1, 1, 1, 2)
 
-            #     column += 1
-            #     if column == 1:
-            #         if row == 0:
-            #             # Pre Amp
-            #             label = QLabel(
-            #                 '<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
-            #             label.setStyleSheet("min-width:6em;")
-            #             lb_1 = SiriusLabel(self, self._substitute_macros(
-            #                 self.prefix+chs_dict['PreAmp'], curr_num='1'))
-            #             lb_1.showUnits = True
-            #             lb_2 = SiriusLabel(self, self._substitute_macros(
-            #                 self.prefix+chs_dict['PreAmp'], curr_num='2'))
-            #             lb_2.showUnits = True
-
-            #             lay.addWidget(label, row, column)
-            #             lay.addWidget(lb_1, row+1, column)
-            #             lay.addWidget(lb_2, row+2, column)
-            #             column += 1
-            #         else:
-            #             # TDK Source
-            #             label = QLabel(
-            #                 '<h4>TDK Source</h4>', alignment=Qt.AlignCenter)
-            #             label.setStyleSheet("min-width:6em;")
-
-            #             lay.addWidget(label, row, column)
-            #             lay.addWidget(SiriusLedState(
-            #                 self, self._substitute_macros(
-            #                     self.prefix+chs_dict['TDK'])), row+1, column,
-            #                     alignment=Qt.AlignCenter)
-            #             column += 1
-
-            #     if column > 2:
-            #         row += 3
-
         return lay
 
     def _setupPowerLay(self, chs_dict):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -214,24 +214,12 @@ class SSACurrentsDetails(SiriusDialog):
         }
 
         # Racks 1 to 4
+        total_pvs = []
         for i in range(1, 5):
-            sum_expr = '"ch[0] + '
-            for j in range(1, 63):
-                sum_expr += f'ch[{j}] + '
-            sum_expr += 'ch[63]"'
-
-            lb_total = SiriusLabel(self)
+            total_pvs.append(self._substitute_macros(
+                self.prefix+self.syst_dict['RacksTotal'], rack_num=i))
+            lb_total = SiriusLabel(self, total_pvs[-1])
             lb_total.showUnits = True
-            rule = ('[{"name": "TextRule", "property": "Text", ' +
-                    '"expression": ' + sum_expr + ', ' +
-                    '"channels": [')
-
-            for num in hs_nums[i]:
-                for j in range(len(self.curr_pvs[num])):
-                    rule += ('{"channel":} ' +
-                        self.curr_pvs[num][j] + ', "trigger": true}')
-            rule += ']}]'
-            lb_total.rules = rule
 
             lay.addWidget(QLabel(
                 f'<h4>Rack {i}</h4>', alignment=Qt.AlignCenter), row, column)
@@ -243,20 +231,17 @@ class SSACurrentsDetails(SiriusDialog):
 
         # Total
         sum_expr = '"ch[0] + '
-        for i in range(1, 255):
+        for i in range(1, 4):
             sum_expr += f'ch[{i}] + '
-        sum_expr += 'ch[255]"'
+        sum_expr += 'ch[4]"'
 
         lb_total = SiriusLabel(self)
         lb_total.showUnits = True
         rule = ('[{"name": "TextRule", "property": "Text", ' +
-                '"expression": ' + sum_expr + ', ' +
+                '"expression": ' + '"ch[0] + ch[1] + ch[2] + ch[3]", ' +
                 '"channels": [')
-        for i in range(1, 5):
-            for num in hs_nums[i]:
-                for j in range(len(self.curr_pvs[num])):
-                    rule += ('{"channel":} ' +
-                        self.curr_pvs[num][j] + ', "trigger": true}')
+        for pv in total_pvs:
+            rule += ('{"channel": ' + pv + ', "trigger": true}, ')
         rule += ']}]'
         lb_total.rules = rule
 
@@ -316,7 +301,8 @@ class SSACurrentsDetails(SiriusDialog):
 
         return lay
 
-    def _substitute_macros(self, pv_name, hs_num='', letter='', m_num='', curr_num=''):
+    def _substitute_macros(self, pv_name, hs_num='', letter='', m_num='',
+    curr_num='', rack_num=''):
         pv_name = pv_name.replace('$(NB)', str(self.num))
         if hs_num:
             pv_name = pv_name.replace('$(hs_num)', str(hs_num))
@@ -326,4 +312,6 @@ class SSACurrentsDetails(SiriusDialog):
             pv_name = pv_name.replace('$(m_num)', str(m_num))
         if curr_num:
             pv_name = pv_name.replace('$(curr_num)', str(curr_num))
+        if rack_num:
+            pv_name = pv_name.replace('$(rack_num)', str(rack_num))
         return pv_name

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -199,11 +199,17 @@ class SSACurrentsDetails(SiriusDialog):
                 0, 1, 1, 2)
 
             # Currents
-            for i in range(1, 9):
+            for i in range(1, 17):
+                if i < 10:
+                    m_num = f'0{i}'
+                else:
+                    m_num = i
                 pv_curr_1 = self._substitute_macros(
-                    self.prefix+chs_dict['Curr'], hs_num, m_num=i, curr_num=1)
+                    self.prefix+chs_dict['Curr'],
+                    hs_num, m_num=m_num, curr_num=1)
                 pv_curr_2 = self._substitute_macros(
-                    self.prefix+chs_dict['Curr'], hs_num, m_num=i, curr_num=2)
+                    self.prefix+chs_dict['Curr'],
+                    hs_num, m_num=m_num, curr_num=2)
                 if i == 1:
                     self.curr_pvs[hs_num] = [pv_curr_1, pv_curr_2]
                 else:
@@ -217,10 +223,10 @@ class SSACurrentsDetails(SiriusDialog):
 
                 if row_label == 'left':
                     lay.addWidget(QLabel(
-                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 0)
+                        f'M{m_num}', alignment=Qt.AlignCenter), i+1, 0)
                 elif row_label == 'right':
                     lay.addWidget(QLabel(
-                        f'M0{i}', alignment=Qt.AlignCenter), i+1, 5)
+                        f'M{m_num}', alignment=Qt.AlignCenter), i+1, 5)
                 lay.addWidget(lb_curr_1, i+1, 1)
                 lay.addWidget(lb_curr_2, i+1, 2)
                 row = i+2
@@ -306,16 +312,16 @@ class SSACurrentsDetails(SiriusDialog):
         else:
             # Heat Sinks
             hs_nums = [1, 4, 3, 6]
-            m_nums = [1, 1, 17, 17]
+            m_nums = ['01', '01', '17', '17']
             row = 0
             column = 0
             for i, hs_num in enumerate(hs_nums):
                 lb_1 = SiriusLabel(self, self._substitute_macros(
-                    self.prefix+chs_dict['HS'], i, m_num=m_nums[i],
+                    self.prefix+chs_dict['HS'], hs_num=hs_num, m_num=m_nums[i],
                     curr_num='1'))
                 lb_1.showUnits = True
                 lb_2 = SiriusLabel(self, self._substitute_macros(
-                    self.prefix+chs_dict['HS'], i, m_num=m_nums[i],
+                    self.prefix+chs_dict['HS'], hs_num=hs_num, m_num=m_nums[i],
                     curr_num='2'))
                 lb_2.showUnits = True
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -104,6 +104,7 @@ class SSACurrentsDetails(SiriusDialog):
         lay.addWidget(QLabel(
             '<h4>B</h4>', alignment=Qt.AlignCenter), 1, 3, 1, 2)
 
+        # Currents
         for i in range(1, 9):
             pv_a_1 = self._substitute_macros(
                 self.prefix+chs_dict['Curr'], hs_num, 'A', i, 1)
@@ -140,6 +141,22 @@ class SSACurrentsDetails(SiriusDialog):
             lay.addWidget(lb_a_2, i+1, 2)
             lay.addWidget(lb_b_1, i+1, 3)
             lay.addWidget(lb_b_2, i+1, 4)
+            row = i+2
+
+        # Power
+        lay.addWidget(QLabel(
+            '<h4>Power</h4>', alignment=Qt.AlignCenter), row, 1, 1, 4)
+        column = 1
+        for key, val in chs_dict.items():
+            if key != 'Curr':
+                lb_pwr = SiriusLabel(
+                    self, self._substitute_macros(self.prefix+val, hs_num))
+                lb_pwr.showUnits = True
+                lay.addWidget(QLabel(
+                    f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
+                    row+1, column)
+                lay.addWidget(lb_pwr, row+2, column)
+                column += 1
 
         return lay
 
@@ -175,7 +192,7 @@ class SSACurrentsDetails(SiriusDialog):
                         self.prefix+chs_dict['PreAmp'], curr_num='1'))
                     lb_1.showUnits = True
                     lb_2 = SiriusLabel(self, self._substitute_macros(
-                        self.prefix+chs_dict['HS'], curr_num='2'))
+                        self.prefix+chs_dict['PreAmp'], curr_num='2'))
                     lb_2.showUnits = True
 
                     lay.addWidget(label, row, column)

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -2,9 +2,9 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
-    QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox
+    QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox, QHBoxLayout
 
-from ...widgets import SiriusDialog, SiriusLabel, SiriusLedState
+from ...widgets import SiriusDialog, SiriusLabel, SiriusLedState, SiriusSpinbox
 from ..util import SEC_2_CHANNELS
 
 
@@ -47,9 +47,9 @@ class SSACurrentsDetails(SiriusDialog):
         wid_diag.setLayout(self._setupDiagLay())
         dtls.addTab(wid_diag, 'Diagnostics')
 
-        # wid_graphs = QWidget(self)
-        # wid_graphs.setLayout(self._setupGraphsLay())
-        # dtls.addTab(wid_graphs, 'Graphs')
+        wid_graphs = QWidget(self)
+        wid_graphs.setLayout(self._setupAlarmLay())
+        dtls.addTab(wid_graphs, 'Alarm Limits')
 
         lay.addWidget(QLabel(
             f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
@@ -86,7 +86,7 @@ class SSACurrentsDetails(SiriusDialog):
                 row += 2
 
         gbox_total = QGroupBox('Total Current')
-        gbox_total.setLayout(self._setupTotalLay(self.syst_dict['Total']))
+        gbox_total.setLayout(self._setupTotalLay())
         lay.addWidget(gbox_total, 2, 2)
 
         return lay
@@ -199,7 +199,7 @@ class SSACurrentsDetails(SiriusDialog):
 
         return lay
 
-    def _setupTotalLay(self, chs_dict):
+    def _setupTotalLay(self):
         lay = QGridLayout()
         lay.setAlignment(Qt.AlignVCenter)
         lay.setSpacing(9)
@@ -263,6 +263,56 @@ class SSACurrentsDetails(SiriusDialog):
         lay.addWidget(QLabel(
             '<h4>Total</h4>', alignment=Qt.AlignCenter), row, 1)
         lay.addWidget(lb_total, row+1, 1, alignment=Qt.AlignCenter)
+
+        return lay
+
+    def _setupAlarmLay(self):
+        lay = QHBoxLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(18)
+
+        # Offsets
+        lay_off = QGridLayout()
+        lay_off.setAlignment(Qt.AlignCenter)
+        lay_off.setSpacing(9)
+        gbox_off = QGroupBox('Offsets (dB)')
+        gbox_off.setLayout(lay_off)
+
+        row = 0
+        for _, lst in self.syst_dict['Offsets'].items():
+            lay_off.addWidget(QLabel(
+                f'<h4>{lst[0]}</h4>', alignment=Qt.AlignCenter), row, 0)
+            lay_off.addWidget(SiriusSpinbox(
+                self, self._substitute_macros(self.prefix+lst[1])), row, 2)
+            row += 1
+        lay_off.addItem(QSpacerItem(
+            27, 0, QSzPlcy.Fixed, QSzPlcy.Ignored), 0, 1)
+        lay.addWidget(gbox_off)
+
+        # Alarms
+        lay_alarms = QGridLayout()
+        lay_alarms.setAlignment(Qt.AlignTop)
+        lay_alarms.setSpacing(9)
+        gbox_alarms = QGroupBox('Alarms')
+        gbox_alarms.setLayout(lay_alarms)
+
+        column = 0
+        for _, dic in self.syst_dict['Alarms'].items():
+            lay_alarms.addWidget(QLabel(
+                f'<h4>{dic["Label"]}</h4>', alignment=Qt.AlignCenter),
+                0, column, 1, 2)
+            row = 1
+            for key, val in dic.items():
+                if key != 'Label':
+                    lay_alarms.addWidget(QLabel(
+                        f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
+                        row, column)
+                    lay_alarms.addWidget(SiriusSpinbox(
+                        self, self._substitute_macros(self.prefix+val)),
+                        row, column+1)
+                    row += 1
+            column += 2
+        lay.addWidget(gbox_alarms)
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1724,6 +1724,7 @@ class RFMainControl(SiriusMainWindow):
 
     def _handle_curves_visibility(self, state):
         name = self.sender().objectName()
+        print(name)
         if name in self.chs['PwrMtr']:
             name += ' ' + self.cb_units.currentText()
         curve = self.curves[name]

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1722,7 +1722,6 @@ class RFMainControl(SiriusMainWindow):
 
     def _handle_curves_visibility(self, state):
         name = self.sender().objectName()
-        print(name)
         if name in self.chs['PwrMtr']:
             name += ' ' + self.cb_units.currentText()
         curve = self.curves[name]

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -21,8 +21,8 @@ from .advanced_details import ADCDACDetails, AutoStartDetails, \
     RampsDetails, TuningDetails
 from .custom_widgets import RFEnblDsblButton
 from .details import CavityStatusDetails, FDLDetails, LLRFInterlockDetails, \
-    SlowLoopErrorDetails, SlowLoopParametersDetails, SSADetails, TempMonitor, \
-    TransmLineStatusDetails
+    SlowLoopErrorDetails, SlowLoopParametersDetails, SSADetailsBO, \
+    SSADetailsSI, TempMonitor, TransmLineStatusDetails
 from .util import SEC_2_CHANNELS
 
 
@@ -1444,13 +1444,11 @@ class RFMainControl(SiriusMainWindow):
         if self.section == 'SI':
             ssa_num = int(chs_dict['Name'].split()[-1])
             system = ('A' if ssa_num == 1 or ssa_num == 2 else 'B')
-            connect_window(pb_ssadtls, SSADetails, parent=self,
-                        section=self.section, prefix=self.prefix,
-                        num=ssa_num, system=system)
+            connect_window(pb_ssadtls, SSADetailsSI, parent=self,
+                        prefix=self.prefix, num=ssa_num, system=system)
         else:
-            connect_window(pb_ssadtls, SSADetails, parent=self,
-                        section=self.section, prefix=self.prefix,
-                        num='', system='')
+            connect_window(pb_ssadtls, SSADetailsBO, parent=self,
+                        prefix=self.prefix)
 
         lb_pwr = SiriusLabel(self, self.prefix+chs_dict['Power'])
         lb_pwr.showUnits = True

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -21,7 +21,7 @@ from .advanced_details import ADCDACDetails, AutoStartDetails, \
     RampsDetails, TuningDetails
 from .custom_widgets import RFEnblDsblButton
 from .details import CavityStatusDetails, FDLDetails, LLRFInterlockDetails, \
-    SlowLoopErrorDetails, SlowLoopParametersDetails, TempMonitor, \
+    SlowLoopErrorDetails, SlowLoopParametersDetails, SSADetails, TempMonitor, \
     TransmLineStatusDetails
 from .util import SEC_2_CHANNELS
 
@@ -358,19 +358,19 @@ class RFMainControl(SiriusMainWindow):
         lay_amp.addItem(QSpacerItem(
             10, 0, QSzPlcy.Expanding, QSzPlcy.Ignored), 0, 0)
         lay_amp.addWidget(
-            QLabel('<h4>Power</h4>', self, alignment=Qt.AlignCenter), 1, 3)
+            QLabel('<h4>Power</h4>', self, alignment=Qt.AlignCenter), 1, 4)
         lay_amp.addWidget(QLabel(
             '<h4>'+dic['SRC 1']['Label']+'</h4>', self,
-            alignment=Qt.AlignCenter), 1, 4)
-        lay_amp.addWidget(QLabel(
-            '<h4>'+dic['SRC 2']['Label']+'</h4>', self,
             alignment=Qt.AlignCenter), 1, 5)
         lay_amp.addWidget(QLabel(
-            '<h4>Pin Sw</h4>', self, alignment=Qt.AlignCenter), 1, 6)
+            '<h4>'+dic['SRC 2']['Label']+'</h4>', self,
+            alignment=Qt.AlignCenter), 1, 6)
         lay_amp.addWidget(QLabel(
-            '<h4>Pre Drive</h4>', self, alignment=Qt.AlignCenter), 1, 7)
+            '<h4>Pin Sw</h4>', self, alignment=Qt.AlignCenter), 1, 7)
+        lay_amp.addWidget(QLabel(
+            '<h4>Pre Drive</h4>', self, alignment=Qt.AlignCenter), 1, 8)
         lay_amp.addItem(QSpacerItem(
-            10, 0, QSzPlcy.Expanding, QSzPlcy.Ignored), 0, 8)
+            10, 0, QSzPlcy.Expanding, QSzPlcy.Ignored), 0, 9)
 
         if self.section == 'BO':
             self._create_ssa_wid(lay_amp, 2, self.chs['SSA'])
@@ -1432,14 +1432,30 @@ class RFMainControl(SiriusMainWindow):
         lay_amp.addWidget(led_sts, row, 1)
 
         lb_name = QLabel('<h4>'+chs_dict['Name']+'</h4>', self,
-                         alignment=Qt.AlignLeft | Qt.AlignVCenter)
+                         alignment=Qt.AlignCenter)
         lb_name.setStyleSheet('max-height: 1.29em;')
         lay_amp.addWidget(lb_name, row, 2)
+
+        pb_ssadtls = QPushButton(qta.icon('fa5s.ellipsis-v'), '', self)
+        pb_ssadtls.setObjectName('dtls')
+        pb_ssadtls.setStyleSheet(
+            '#dtls{min-width:18px;max-width:18px;icon-size:20px;}')
+        ssa_num = int(chs_dict['Name'].split()[-1])
+        system = ''
+        if self.section == 'SI':
+            if ssa_num == 1 or ssa_num == 2:
+                system = 'A'
+            else:
+                system = 'B'
+        connect_window(pb_ssadtls, SSADetails, parent=self,
+                       section=self.section, prefix=self.prefix,
+                       num=ssa_num, system=system)
+        lay_amp.addWidget(pb_ssadtls, row, 3)
 
         lb_pwr = SiriusLabel(self, self.prefix+chs_dict['Power'])
         lb_pwr.showUnits = True
         lb_pwr.setStyleSheet('min-width: 6em; max-width: 6em;')
-        lay_amp.addWidget(lb_pwr, row, 3)
+        lay_amp.addWidget(lb_pwr, row, 4)
 
         bt_src1 = RFEnblDsblButton(
             parent=self,
@@ -1455,7 +1471,7 @@ class RFMainControl(SiriusMainWindow):
         else:
             led_src1 = SiriusLedState(
                 self, self.prefix+chs_dict['SRC 1']['Mon'])
-        lay_amp.addLayout(self._create_vlay(bt_src1, led_src1), row, 4)
+        lay_amp.addLayout(self._create_vlay(bt_src1, led_src1), row, 5)
 
         bt_src2 = RFEnblDsblButton(
             parent=self,
@@ -1463,7 +1479,7 @@ class RFMainControl(SiriusMainWindow):
                 'on': self.prefix+chs_dict['SRC 2']['Enable'],
                 'off': self.prefix+chs_dict['SRC 2']['Disable']})
         led_src2 = SiriusLedState(self, self.prefix+chs_dict['SRC 2']['Mon'])
-        lay_amp.addLayout(self._create_vlay(bt_src2, led_src2), row, 5)
+        lay_amp.addLayout(self._create_vlay(bt_src2, led_src2), row, 6)
 
         bt_pinsw = RFEnblDsblButton(
             parent=self,
@@ -1477,7 +1493,7 @@ class RFMainControl(SiriusMainWindow):
             '", "trigger": true}]}]')
         bt_pinsw.pb_on.rules = rules
         led_pinsw = SiriusLedState(self, self.prefix+chs_dict['PinSw']['Mon'])
-        lay_amp.addLayout(self._create_vlay(bt_pinsw, led_pinsw), row, 6)
+        lay_amp.addLayout(self._create_vlay(bt_pinsw, led_pinsw), row, 7)
 
         lb_drive = SiriusLabel(self, self.prefix+chs_dict['PreDrive'])
         lb_drive.showUnits = True
@@ -1485,7 +1501,7 @@ class RFMainControl(SiriusMainWindow):
             parent=self, channels2values={
                 self.prefix+chs_dict['PreDrive']: {
                     'comp': 'lt', 'value': chs_dict['PreDriveThrs']}})
-        lay_amp.addLayout(self._create_vlay(lb_drive, led_drive), row, 7)
+        lay_amp.addLayout(self._create_vlay(lb_drive, led_drive), row, 8)
 
         ch_pinsw = SiriusConnectionSignal(self.prefix+chs_dict['PinSw']['Mon'])
         ch_pinsw.new_value_signal[int].connect(

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1440,17 +1440,17 @@ class RFMainControl(SiriusMainWindow):
         pb_ssadtls.setObjectName('dtls')
         pb_ssadtls.setStyleSheet(
             '#dtls{min-width:18px;max-width:18px;icon-size:20px;}')
-        ssa_num = int(chs_dict['Name'].split()[-1])
-        system = ''
-        if self.section == 'SI':
-            if ssa_num == 1 or ssa_num == 2:
-                system = 'A'
-            else:
-                system = 'B'
-        connect_window(pb_ssadtls, SSADetails, parent=self,
-                       section=self.section, prefix=self.prefix,
-                       num=ssa_num, system=system)
         lay_amp.addWidget(pb_ssadtls, row, 3)
+        if self.section == 'SI':
+            ssa_num = int(chs_dict['Name'].split()[-1])
+            system = ('A' if ssa_num == 1 or ssa_num == 2 else 'B')
+            connect_window(pb_ssadtls, SSADetails, parent=self,
+                        section=self.section, prefix=self.prefix,
+                        num=ssa_num, system=system)
+        else:
+            connect_window(pb_ssadtls, SSADetails, parent=self,
+                        section=self.section, prefix=self.prefix,
+                        num='', system='')
 
         lb_pwr = SiriusLabel(self, self.prefix+chs_dict['Power'])
         lb_pwr.showUnits = True

--- a/pyqt-apps/siriushla/as_rf_control/details/__init__.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/__init__.py
@@ -3,6 +3,6 @@ from .fdl import FDLDetails
 from .interlock import LLRFInterlockDetails
 from .sl_err import SlowLoopErrorDetails
 from .sl_param import SlowLoopParametersDetails
-from .ssa import SSADetails
+from .ssa import SSADetailsSI, SSADetailsBO
 from .temp_monitor import TempMonitor
 from .transm_line import TransmLineStatusDetails

--- a/pyqt-apps/siriushla/as_rf_control/details/__init__.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/__init__.py
@@ -3,5 +3,6 @@ from .fdl import FDLDetails
 from .interlock import LLRFInterlockDetails
 from .sl_err import SlowLoopErrorDetails
 from .sl_param import SlowLoopParametersDetails
+from .ssa import SSADetails
 from .temp_monitor import TempMonitor
 from .transm_line import TransmLineStatusDetails

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -23,11 +23,12 @@ class SSADetails(SiriusDialog):
         self.num = num
         self.system = system
         self.setObjectName(self.section+'App')
-        self.setWindowTitle(f'{self.section} SSA 0{self.num} Details')
         if self.section == 'SI':
             self.syst_dict = self.chs['SSADtls'][self.system]
+            self.setWindowTitle(f'{self.section} SSA 0{self.num} Details')
         else:
             self.syst_dict = self.chs['SSADtls']
+            self.setWindowTitle(f'{self.section} SSA Details')
         self._setupUi()
 
     def _setupUi(self):
@@ -50,8 +51,11 @@ class SSADetails(SiriusDialog):
         wid_graphs.setLayout(self._setupGraphsLay())
         dtls.addTab(wid_graphs, 'Graphs')
 
-        lay.addWidget(QLabel(
-            f'<h4>SSA 0{self.num} Details</h4>', alignment=Qt.AlignCenter))
+        if self.section == 'SI':
+            title = f'<h4>SSA 0{self.num} Details</h4>'
+        else:
+            title = '<h4>SSA Details</h4>'
+        lay.addWidget(QLabel(title, alignment=Qt.AlignCenter))
         lay.addWidget(dtls)
 
     def _setupDiagLay(self):
@@ -89,13 +93,13 @@ class SSADetails(SiriusDialog):
 
         # Pre Amp
         lb_preamp = SiriusLabel(
-            self, self.prefix+self.syst_dict[f'Pre Amp {self.num}'][0])
+            self, self.prefix+self.syst_dict[f'Pre Amp{self.num}'][0])
         lb_preamp.showUnits = True
         lay.addWidget(QLabel('Pre Amp', alignment=Qt.AlignRight), 4, 0)
         lay.addWidget(lb_preamp, 4, 1)
         lay.addWidget(QLabel('-', alignment=Qt.AlignCenter), 4, 2)
         lay.addWidget(SiriusLedAlert(
-            self, self.prefix+self.syst_dict[f'Pre Amp {self.num}'][1]),
+            self, self.prefix+self.syst_dict[f'Pre Amp{self.num}'][1]),
             4, 3, alignment=Qt.AlignCenter)
 
         # In and Out Pwr
@@ -120,7 +124,7 @@ class SSADetails(SiriusDialog):
         lay_alerts = QGridLayout()
         row_alerts = 0
         column = 0
-        for key, ls in self.syst_dict['Alerts'].items():
+        for _, ls in self.syst_dict['Alerts'].items():
             lay_alerts.addWidget(QLabel(ls[0]), row_alerts, column)
             lay_alerts.addWidget(SiriusLedAlert(
                 self, self.prefix+ls[1]), row_alerts, column+1)

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -4,7 +4,7 @@ import qtawesome as qta
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
 from qtpy.QtWidgets import QCheckBox, QGridLayout, QLabel, QPushButton, \
-    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget
+    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox
 
 from ...util import connect_window
 from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
@@ -418,10 +418,14 @@ class SSADetailsBO(SiriusDialog):
         lay.addWidget(dtls)
 
     def _setupDiagLay(self):
+        lay = QGridLayout()
+        lay.setSpacing(9)
+        lay.setAlignment(Qt.AlignTop)
+
         # Temperatures
+        gbox_temp = QGroupBox('Temperatures')
         lay_temp = QGridLayout()
-        lay_temp.setSpacing(9)
-        lay_temp.setAlignment(Qt.AlignTop)
+        gbox_temp.setLayout(lay_temp)
         lay_temp.addWidget(QLabel(
             '<h4>TMS</h4>', alignment=Qt.AlignCenter), 1, 2)
         lay_temp.addWidget(QLabel(
@@ -440,7 +444,7 @@ class SSADetailsBO(SiriusDialog):
                 self, self._substitute_pv_macros(
                     self.prefix+self.syst_dict['HeatSink']['TMS'], i)),
                 i+1, 2, alignment=Qt.AlignCenter)
-            # PT-100
+            # # PT-100
             row = i+2
 
         lb_temp = SiriusLabel(self, self.prefix+self.syst_dict['PreAmp'])
@@ -450,9 +454,35 @@ class SSADetailsBO(SiriusDialog):
             '<h4>PreAmp 01</h4>', alignment=Qt.AlignCenter), row, 0)
         lay_temp.addWidget(lb_temp, row, 1)
         lay_temp.addWidget(QLabel('-', alignment=Qt.AlignCenter), row, 2)
-        # PT-100
+        # # PT-100
+        lay.addWidget(gbox_temp, 0, 0, 1, 2)
 
-        return lay_temp
+        # AC Panel
+        gbox_ac = QGroupBox('AC Panel')
+        lay_ac = QGridLayout()
+        gbox_ac.setLayout(lay_ac)
+
+        lay_ac.addWidget(QLabel(
+            '<h4>AC/DC Panel Interlock</h4>',
+            alignment=Qt.AlignRight | Qt.AlignVCenter), 0, 0)
+        lay_ac.addWidget(SiriusLedAlert(
+            self, self.prefix+self.syst_dict['AC']['Intlk']),
+            0, 1, alignment=Qt.AlignCenter)
+        lay_ac.addWidget(QLabel(
+            '<h4>Control Mode</h4>',
+            alignment=Qt.AlignRight | Qt.AlignVCenter), 1, 0)
+        lay_ac.addWidget(SiriusLabel(
+            self, self.prefix+self.syst_dict['AC']['Ctrl']),
+            1, 1, alignment=Qt.AlignCenter)
+        lay_ac.addWidget(QLabel(
+            '<h4>300 Vdc Enable</h4>',
+            alignment=Qt.AlignRight | Qt.AlignVCenter), 2, 0)
+        lay_ac.addWidget(SiriusLedState(
+            self, self.prefix+self.syst_dict['AC']['300Vdc']),
+            2, 1, alignment=Qt.AlignCenter)
+        lay.addWidget(gbox_ac, 1, 0)
+
+        return lay
 
     def _setupGraphsLay(self):
         lay = QVBoxLayout()

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -28,7 +28,8 @@ class SSADetailsSI(SiriusDialog):
         self.system = system
         self.setObjectName(self.section+'App')
         self.syst_dict = self.chs['SSADtls'][self.system]
-        self.setWindowTitle(f'{self.section} SSA 0{self.num} Details')
+        title = f'{self.section}{self.system} SSA 0{self.num} Details'
+        self.setWindowTitle(title)
         self._setupUi()
 
     def _setupUi(self):

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -1,12 +1,15 @@
 """SSA Details."""
 
+import qtawesome as qta
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QCheckBox, QGridLayout, QLabel, \
+from qtpy.QtWidgets import QCheckBox, QGridLayout, QLabel, QPushButton, \
     QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget
 
+from ...util import connect_window
 from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
     SiriusLabel, SiriusLedAlert, SiriusLedState, SiriusTimePlot
+from ..advanced_details import SSACurrentsDetails
 from ..util import SEC_2_CHANNELS
 
 
@@ -120,12 +123,23 @@ class SSADetails(SiriusDialog):
                 row_general, 3, alignment=Qt.AlignCenter)
             row_general += 1
 
+        # Currents
+        pb_curr = QPushButton(
+            qta.icon('fa5s.external-link-alt'), ' Currents', self)
+        connect_window(pb_curr, SSACurrentsDetails, parent=self,
+            prefix=self.prefix, section=self.section, num=self.num,
+            system=self.system)
+        pb_curr.setStyleSheet('min-width: 6em;')
+        lay.addWidget(pb_curr, row_general, 1)
+
+
         # Alerts
         lay_alerts = QGridLayout()
         row_alerts = 0
         column = 0
         for _, ls in self.syst_dict['Alerts'].items():
-            lay_alerts.addWidget(QLabel(ls[0]), row_alerts, column)
+            lay_alerts.addWidget(QLabel(ls[0], alignment=Qt.AlignCenter),
+                row_alerts, column)
             lay_alerts.addWidget(SiriusLedAlert(
                 self, self.prefix+ls[1]), row_alerts, column+1)
             column += 2

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -237,8 +237,13 @@ class SSADetailsSI(SiriusDialog):
                     self, self._substitute_pv_macros(
                         self.prefix+chs_dict['Temp'], suffix))
                 lb_temp.showUnits = True
-                # pt_100_channels = {}
-                # led_pt100 = PyDMLedMultiChannel(self, )
+                pt_100_channels = {
+                    self._substitute_pv_macros(
+                        self.prefix+chs_dict['PT-100'][0], suffix): 0,
+                    self._substitute_pv_macros(
+                        self.prefix+chs_dict['PT-100'][1], suffix): 0
+                }
+                led_pt100 = PyDMLedMultiChannel(self, pt_100_channels)
 
                 lay.addWidget(QLabel(
                     f'HeatSink {self.sink_count}{s}',
@@ -248,7 +253,7 @@ class SSADetailsSI(SiriusDialog):
                     self, self._substitute_pv_macros(
                         self.prefix+chs_dict['Tms'], suffix)),
                     row, 2, alignment=Qt.AlignCenter)
-                # lay.addWidget(led_pt100, row, 3, alignment=Qt.AlignCenter)
+                lay.addWidget(led_pt100, row, 3, alignment=Qt.AlignCenter)
 
                 row += 1
             self.sink_count += 1
@@ -438,6 +443,13 @@ class SSADetailsBO(SiriusDialog):
                 self, self._substitute_pv_macros(
                     self.prefix+self.syst_dict['HeatSink']['Temp'], i))
             lb_temp.showUnits = True
+            pt_100_channels = {
+                self._substitute_pv_macros(
+                    self.prefix+self.syst_dict['HeatSink']['PT-100'][0], i): 0,
+                self._substitute_pv_macros(
+                    self.prefix+self.syst_dict['HeatSink']['PT-100'][1], i): 0
+            }
+            led_pt100 = PyDMLedMultiChannel(self, pt_100_channels)
 
             lay_temp.addWidget(QLabel(
                 f'<h4>HeatSink {i}</h4>', alignment=Qt.AlignCenter), i+1, 0)
@@ -446,17 +458,20 @@ class SSADetailsBO(SiriusDialog):
                 self, self._substitute_pv_macros(
                     self.prefix+self.syst_dict['HeatSink']['TMS'], i)),
                 i+1, 2, alignment=Qt.AlignCenter)
-            # # PT-100
+            lay_temp.addWidget(led_pt100, i+1, 3, alignment=Qt.AlignCenter)
             row = i+2
 
-        lb_temp = SiriusLabel(self, self.prefix+self.syst_dict['PreAmp'])
+        lb_temp = SiriusLabel(
+            self, self.prefix+self.syst_dict['PreAmp']['Temp'])
         lb_temp.showUnits = True
 
         lay_temp.addWidget(QLabel(
             '<h4>PreAmp 01</h4>', alignment=Qt.AlignCenter), row, 0)
         lay_temp.addWidget(lb_temp, row, 1)
         lay_temp.addWidget(QLabel('-', alignment=Qt.AlignCenter), row, 2)
-        # # PT-100
+        lay_temp.addWidget(SiriusLedState(
+            self, self.prefix+self.syst_dict['PreAmp']['PT-100']),
+            row, 3, alignment=Qt.AlignCenter)
         lay.addWidget(gbox_temp, 0, 0, 1, 3)
 
         # AC Panel

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -1,11 +1,12 @@
 """SSA Details."""
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, \
-    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QWidget
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QCheckBox, QGridLayout, QLabel, \
+    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget
 
 from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
-    SiriusLabel, SiriusLedAlert, SiriusLedState
+    SiriusLabel, SiriusLedAlert, SiriusLedState, SiriusTimePlot
 from ..util import SEC_2_CHANNELS
 
 
@@ -30,13 +31,33 @@ class SSADetails(SiriusDialog):
         self._setupUi()
 
     def _setupUi(self):
-        lay = QGridLayout(self)
+        lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
-        lay.setSpacing(9)
+
+        dtls = QTabWidget(self)
+        dtls.setObjectName(self.section+'Tab')
+        dtls.setStyleSheet(
+            "#"+self.section+'Tab'+"::pane {"
+            "    border-left: 2px solid gray;"
+            "    border-bottom: 2px solid gray;"
+            "    border-right: 2px solid gray;}")
+
+        wid_diag = QWidget(self)
+        wid_diag.setLayout(self._setupDiagLay())
+        dtls.addTab(wid_diag, 'Diagnostics')
+
+        wid_graphs = QWidget(self)
+        wid_graphs.setLayout(self._setupGraphsLay())
+        dtls.addTab(wid_graphs, 'Graphs')
 
         lay.addWidget(QLabel(
-            f'<h4>SSA 0{self.num} Details</h4>',
-            alignment=Qt.AlignCenter), 0, 0, 1, 4)
+            f'<h4>SSA 0{self.num} Details</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(dtls)
+
+    def _setupDiagLay(self):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
 
         # Racks
         lay_racks = QGridLayout()
@@ -44,13 +65,13 @@ class SSADetails(SiriusDialog):
         column = 0
         self.sink_count = 1
         for i in range(1, 5):
-            gbox_rack = QGroupBox(f'Rack {i}')
-            gbox_rack.setLayout(self._setupRackLay(
-                str(i), self.syst_dict['Rack']))
-            lay_racks.addWidget(gbox_rack, row, column)
+            lay_racks.addWidget(QLabel(
+                f'<h4>Rack {i}</h4>', alignment=Qt.AlignCenter), row, column)
+            lay_racks.addLayout(self._setupRackLay(
+                str(i), self.syst_dict['Rack']), row+1, column)
             column += 1
             if column >= 2:
-                row += 1
+                row += 2
                 column = 0
 
         lay.addLayout(lay_racks, 1, 0, 1, 4)
@@ -79,7 +100,7 @@ class SSADetails(SiriusDialog):
 
         # In and Out Pwr
         lbs = ['In Pwr Fwd', 'In Pwr Rev', 'Out Pwr Fwd', 'Out Pwr Rev']
-        row = 5
+        row_general = 5
         for lb in lbs:
             lb_pwr = SiriusLabel(self, self._substitute_pv_macros(
                 self.prefix+self.syst_dict[lb][0]))
@@ -87,13 +108,54 @@ class SSADetails(SiriusDialog):
             lb_hw = SiriusLabel(self, self._substitute_pv_macros(
                 self.prefix+self.syst_dict[lb][1]))
             lb_hw.showUnits = True
-            lay.addWidget(QLabel(lb, alignment=Qt.AlignRight), row, 0)
-            lay.addWidget(lb_pwr, row, 1)
-            lay.addWidget(lb_hw, row, 2)
+            lay.addWidget(QLabel(lb, alignment=Qt.AlignRight), row_general, 0)
+            lay.addWidget(lb_pwr, row_general, 1)
+            lay.addWidget(lb_hw, row_general, 2)
             lay.addWidget(SiriusLedAlert(self,
                 self._substitute_pv_macros(self.prefix+self.syst_dict[lb][2])),
-                row, 3, alignment=Qt.AlignCenter)
-            row += 1
+                row_general, 3, alignment=Qt.AlignCenter)
+            row_general += 1
+
+        # Alerts
+        lay_alerts = QGridLayout()
+        row_alerts = 0
+        column = 0
+        for key, ls in self.syst_dict['Alerts'].items():
+            lay_alerts.addWidget(QLabel(ls[0]), row_alerts, column)
+            lay_alerts.addWidget(SiriusLedAlert(
+                self, self.prefix+ls[1]), row_alerts, column+1)
+            column += 2
+            if column == 6:
+                row_alerts += 1
+                column = 0
+
+        lay.addItem(QSpacerItem(
+            0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), row_general, 0)
+        lay.addLayout(lay_alerts, row_general+1, 0, 1, 4)
+        row_general += 2
+
+        return lay
+
+    def _setupGraphsLay(self):
+        lay = QVBoxLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        # Heat Sinks
+        graph_hs, lay_cboxes = self._setup_heat_sink_graph()
+
+        lay.addWidget(QLabel(
+            '<h4>Heat Sinks Temperatures</h4>', alignment=Qt.AlignCenter))
+        lay.addLayout(lay_cboxes)
+        lay.addWidget(graph_hs)
+
+        # Rack Temperatures
+        graph_temp, lay_cboxes = self._setup_rack_temp_graph()
+
+        lay.addWidget(QLabel(
+            '<h4>Rack Temperatures</h4>', alignment=Qt.AlignCenter))
+        lay.addLayout(lay_cboxes)
+        lay.addWidget(graph_temp)
 
         return lay
 
@@ -163,8 +225,8 @@ class SSADetails(SiriusDialog):
                     self, self._substitute_pv_macros(
                         self.prefix+chs_dict['Temp'], suffix))
                 lb_temp.showUnits = True
-                pt_100_channels = {}
-                led_pt100 = PyDMLedMultiChannel(self, )
+                # pt_100_channels = {}
+                # led_pt100 = PyDMLedMultiChannel(self, )
 
                 lay.addWidget(QLabel(
                     f'HeatSink {self.sink_count}{s}',
@@ -174,7 +236,7 @@ class SSADetails(SiriusDialog):
                     self, self._substitute_pv_macros(
                         self.prefix+chs_dict['Tms'], suffix)),
                     row, 2, alignment=Qt.AlignCenter)
-                lay.addWidget(led_pt100, row, 3, alignment=Qt.AlignCenter)
+                # lay.addWidget(led_pt100, row, 3, alignment=Qt.AlignCenter)
 
                 row += 1
             self.sink_count += 1
@@ -183,8 +245,120 @@ class SSADetails(SiriusDialog):
         wid.setLayout(lay)
         return wid
 
+    def _setup_heat_sink_graph(self):
+        graph_hs = SiriusTimePlot(self)
+        graph_hs.setStyleSheet(
+            'min-height:15em;min-width:20em;max-height:40em')
+        graph_hs.maxRedrawRate = 2
+        graph_hs.setShowXGrid(True)
+        graph_hs.setShowYGrid(True)
+        graph_hs.setAutoRangeX(True)
+        graph_hs.setAutoRangeY(True)
+        graph_hs.setBackgroundColor(QColor(255, 255, 255))
+        graph_hs.setTimeSpan(1800)
+        graph_hs.maxRedrawRate = 2
+
+        lay_cboxes = QGridLayout()
+        colors = ['blue', 'red', 'magenta', 'darkGreen', 'darkRed', 'black',
+            'darkBlue', 'yellow', 'orangered', 'darkOliveGreen', 'darkMagenta',
+            'chocolate', 'cyan', 'darkCyan', 'saddlebrown', 'darkSlateGrey']
+        new_sink_count = 1
+        cboxes_row = 0
+        cboxes_column = 0
+        self.curves_hs = {}
+        for i in range(len(colors)):
+            suffix_ending = ('A' if i % 2 == 0 else 'B')
+            suffix = f'{new_sink_count}{suffix_ending}'
+
+            # Table
+            cbx = QCheckBox(self)
+            cbx.setChecked(True)
+            cbx.setStyleSheet('color:'+colors[i]+'; max-width: 1.2em;')
+            cbx.stateChanged.connect(self._handle_hs_curves_visibility)
+            lb_desc = QLabel(suffix)
+            lb_desc.setStyleSheet(
+                'min-height: 1.5em; color:'+colors[i]+'; max-width: 8em;'
+                'qproperty-alignment: AlignCenter;')
+            lay_cboxes.addWidget(cbx, cboxes_row, cboxes_column)
+            lay_cboxes.addWidget(lb_desc, cboxes_row, cboxes_column+1)
+            cboxes_column += 2
+            if cboxes_column == 16:
+                cboxes_row += 1
+                cboxes_column = 0
+
+            # Graph
+            channel = self._substitute_pv_macros(
+                self.prefix+self.syst_dict['Rack']['Temp'], suffix)
+            graph_hs.addYChannel(y_channel=channel, color=colors[i],
+                name=suffix, lineStyle=Qt.SolidLine, lineWidth=1)
+            self.curves_hs[suffix] = graph_hs.curveAtIndex(i)
+            if i % 2 != 0:
+                new_sink_count += 1
+
+        return graph_hs, lay_cboxes
+
+    def _setup_rack_temp_graph(self):
+        graph_temp = SiriusTimePlot(self)
+        graph_temp.setStyleSheet(
+            'min-height:15em;min-width:20em;max-height:40em')
+        graph_temp.maxRedrawRate = 2
+        graph_temp.setShowXGrid(True)
+        graph_temp.setShowYGrid(True)
+        graph_temp.setAutoRangeX(True)
+        graph_temp.setAutoRangeY(True)
+        graph_temp.setBackgroundColor(QColor(255, 255, 255))
+        graph_temp.setTimeSpan(1800)
+        graph_temp.maxRedrawRate = 2
+
+        lay_cboxes = QGridLayout()
+        colors = {'A': ['blue', 'red', 'magenta', 'darkGreen'],
+            'B': ['darkRed', 'black', 'darkBlue', 'yellow']}
+        cboxes_row = 0
+        cboxes_column = 0
+        graph_idx = 0
+        self.curves_temp = {}
+        for i in range(1, 5):
+            keys = ['A', 'B']
+            for k in keys:
+                # Table
+                cbx = QCheckBox(self)
+                cbx.setChecked(True)
+                cbx.setStyleSheet('color:'+colors[k][i-1]+'; max-width: 1.2em;')
+                cbx.stateChanged.connect(self._handle_temp_curves_visibility)
+                lb_desc = QLabel(f'Rack {i} - Temp {k}')
+                lb_desc.setStyleSheet(
+                    'min-height: 1.5em; color:'+colors[k][i-1]+';'
+                    'max-width: 8em;'
+                    'qproperty-alignment: AlignCenter;')
+                lay_cboxes.addWidget(cbx, cboxes_row, cboxes_column)
+                lay_cboxes.addWidget(lb_desc, cboxes_row, cboxes_column+1)
+                cboxes_column += 2
+                if cboxes_column == 8:
+                    cboxes_row += 1
+                    cboxes_column = 0
+
+                # Graph
+                channel = self._substitute_pv_macros(
+                    self.prefix+self.syst_dict['Rack'][f'Temp {k}'], str(i))
+                graph_temp.addYChannel(y_channel=channel, color=colors[k][i-1],
+                    name=i, lineStyle=Qt.SolidLine, lineWidth=1)
+                self.curves_temp[graph_idx] = graph_temp.curveAtIndex(graph_idx)
+                graph_idx += 1
+
+        return graph_temp, lay_cboxes
+
     def _substitute_pv_macros(self, pv_name, suffix=''):
         pv_name = pv_name.replace('$(NB)', str(self.num))
         if suffix:
             pv_name = pv_name.replace('$(suffix)', suffix)
         return pv_name
+
+    def _handle_hs_curves_visibility(self, state):
+        name = self.sender().objectName()
+        curve = self.curves_hs[name]
+        curve.setVisible(state)
+
+    def _handle_temp_curves_visibility(self, state):
+        name = self.sender().objectName()
+        curve = self.curves_temp[name]
+        curve.setVisible(state)

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -1,0 +1,190 @@
+"""SSA Details."""
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, \
+    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QWidget
+
+from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
+    SiriusLabel, SiriusLedAlert, SiriusLedState
+from ..util import SEC_2_CHANNELS
+
+
+class SSADetails(SiriusDialog):
+    """SSA Details."""
+
+    def __init__(self, parent, prefix='', section='', num='', system=''):
+        """Init."""
+        super().__init__(parent)
+        self.prefix = prefix
+        self.prefix += ('-' if prefix and not prefix.endswith('-') else '')
+        self.section = section
+        self.chs = SEC_2_CHANNELS[self.section]
+        self.num = num
+        self.system = system
+        self.setObjectName(self.section+'App')
+        self.setWindowTitle(f'{self.section} SSA 0{self.num} Details')
+        if self.section == 'SI':
+            self.syst_dict = self.chs['SSADtls'][self.system]
+        else:
+            self.syst_dict = self.chs['SSADtls']
+        self._setupUi()
+
+    def _setupUi(self):
+        lay = QGridLayout(self)
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        lay.addWidget(QLabel(
+            f'<h4>SSA 0{self.num} Details</h4>',
+            alignment=Qt.AlignCenter), 0, 0, 1, 4)
+
+        # Racks
+        lay_racks = QGridLayout()
+        row = 0
+        column = 0
+        self.sink_count = 1
+        for i in range(1, 5):
+            gbox_rack = QGroupBox(f'Rack {i}')
+            gbox_rack.setLayout(self._setupRackLay(
+                str(i), self.syst_dict['Rack']))
+            lay_racks.addWidget(gbox_rack, row, column)
+            column += 1
+            if column >= 2:
+                row += 1
+                column = 0
+
+        lay.addLayout(lay_racks, 1, 0, 1, 4)
+        lay.addItem(QSpacerItem(0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), 2, 0)
+
+        # Runtime
+        lb_run = SiriusLabel(
+            self, self._substitute_pv_macros(
+                self.prefix+self.syst_dict['Runtime']))
+        lb_run.showUnits = True
+        lay.addWidget(QLabel('Runtime', alignment=Qt.AlignRight), 3, 0)
+        lay.addWidget(lb_run, 3, 1)
+        lay.addWidget(QLabel('-', alignment=Qt.AlignCenter), 3, 2)
+        lay.addWidget(QLabel('-', alignment=Qt.AlignCenter), 3, 3)
+
+        # Pre Amp
+        lb_preamp = SiriusLabel(
+            self, self.prefix+self.syst_dict[f'Pre Amp {self.num}'][0])
+        lb_preamp.showUnits = True
+        lay.addWidget(QLabel('Pre Amp', alignment=Qt.AlignRight), 4, 0)
+        lay.addWidget(lb_preamp, 4, 1)
+        lay.addWidget(QLabel('-', alignment=Qt.AlignCenter), 4, 2)
+        lay.addWidget(SiriusLedAlert(
+            self, self.prefix+self.syst_dict[f'Pre Amp {self.num}'][1]),
+            4, 3, alignment=Qt.AlignCenter)
+
+        # In and Out Pwr
+        lbs = ['In Pwr Fwd', 'In Pwr Rev', 'Out Pwr Fwd', 'Out Pwr Rev']
+        row = 5
+        for lb in lbs:
+            lb_pwr = SiriusLabel(self, self._substitute_pv_macros(
+                self.prefix+self.syst_dict[lb][0]))
+            lb_pwr.showUnits = True
+            lb_hw = SiriusLabel(self, self._substitute_pv_macros(
+                self.prefix+self.syst_dict[lb][1]))
+            lb_hw.showUnits = True
+            lay.addWidget(QLabel(lb, alignment=Qt.AlignRight), row, 0)
+            lay.addWidget(lb_pwr, row, 1)
+            lay.addWidget(lb_hw, row, 2)
+            lay.addWidget(SiriusLedAlert(self,
+                self._substitute_pv_macros(self.prefix+self.syst_dict[lb][2])),
+                row, 3, alignment=Qt.AlignCenter)
+            row += 1
+
+        return lay
+
+    def _setupRackLay(self, rack_num, chs_dict):
+        lay = QGridLayout()
+        lay.setAlignment(Qt.AlignTop)
+        lay.setSpacing(9)
+
+        tab_wid = QTabWidget(self)
+        tab_wid.setObjectName(self.section+'Tab')
+        tab_wid.setStyleSheet(
+            "#"+self.section+'Tab'+"::pane {"
+            "    border-left: 2px solid gray;"
+            "    border-bottom: 2px solid gray;"
+            "    border-right: 2px solid gray;}")
+
+        # Heat Sinks
+        tab_wid.addTab(self._setup_heat_sink_wid(chs_dict), 'Heat Sinks')
+
+        # Temp A and B, Voltage and Current
+        wid_other = QWidget()
+        lay_other = QGridLayout()
+        lay_other.setSpacing(9)
+        lay_other.setAlignment(Qt.AlignCenter)
+        wid_other.setLayout(lay_other)
+
+        lbs = ['Temp A', 'Temp B', 'Voltage', 'Current']
+        for i, lb in enumerate(lbs):
+            lb_val = SiriusLabel(self, self._substitute_pv_macros(
+                self.prefix+chs_dict[lb], rack_num))
+            lb_val.showUnits = True
+            lay_other.addWidget(QLabel(
+                lb, alignment=Qt.AlignCenter), i, 0)
+            lay_other.addWidget(lb_val, i, 1, alignment=Qt.AlignCenter)
+
+        tab_wid.addTab(wid_other, 'Other')
+        lay.addWidget(tab_wid, 0, 0, 1, 2)
+
+        # Status
+        led_status = SiriusLedState(
+            self, self._substitute_pv_macros(
+                self.prefix+chs_dict['Status'], rack_num))
+        led_status.setOffColor(PyDMLed.LightGreen)
+        led_status.setOnColor(PyDMLed.DarkGreen)
+
+        lay.addWidget(QLabel(
+            'Status AC', alignment=Qt.AlignCenter), 1, 0)
+        lay.addWidget(led_status, 1, 1, alignment=Qt.AlignCenter)
+
+        return lay
+
+    def _setup_heat_sink_wid(self, chs_dict):
+        lay = QGridLayout()
+        lay.setSpacing(9)
+        lay.setAlignment(Qt.AlignTop)
+
+        lay.addWidget(QLabel('TMS', alignment=Qt.AlignCenter), 0, 2)
+        lay.addWidget(QLabel('PT-100', alignment=Qt.AlignCenter), 0, 3)
+
+        row = 1
+        for _ in range(2):
+            suffixes = ['A', 'B']
+            for s in suffixes:
+                suffix = str(self.sink_count)+s
+
+                lb_temp = SiriusLabel(
+                    self, self._substitute_pv_macros(
+                        self.prefix+chs_dict['Temp'], suffix))
+                lb_temp.showUnits = True
+                pt_100_channels = {}
+                led_pt100 = PyDMLedMultiChannel(self, )
+
+                lay.addWidget(QLabel(
+                    f'HeatSink {self.sink_count}{s}',
+                    alignment=Qt.AlignRight | Qt.AlignVCenter), row, 0)
+                lay.addWidget(lb_temp, row, 1, alignment=Qt.AlignCenter)
+                lay.addWidget(SiriusLedAlert(
+                    self, self._substitute_pv_macros(
+                        self.prefix+chs_dict['Tms'], suffix)),
+                    row, 2, alignment=Qt.AlignCenter)
+                lay.addWidget(led_pt100, row, 3, alignment=Qt.AlignCenter)
+
+                row += 1
+            self.sink_count += 1
+
+        wid = QWidget(self)
+        wid.setLayout(lay)
+        return wid
+
+    def _substitute_pv_macros(self, pv_name, suffix=''):
+        pv_name = pv_name.replace('$(NB)', str(self.num))
+        if suffix:
+            pv_name = pv_name.replace('$(suffix)', suffix)
+        return pv_name

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -3,8 +3,9 @@
 import qtawesome as qta
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QCheckBox, QGridLayout, QLabel, QPushButton, \
-    QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget, QGroupBox
+from qtpy.QtWidgets import QCheckBox, QGridLayout, QGroupBox, QLabel, \
+    QPushButton, QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, \
+    QVBoxLayout, QWidget
 
 from ...util import connect_window
 from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
@@ -455,12 +456,17 @@ class SSADetailsBO(SiriusDialog):
         lay_temp.addWidget(lb_temp, row, 1)
         lay_temp.addWidget(QLabel('-', alignment=Qt.AlignCenter), row, 2)
         # # PT-100
-        lay.addWidget(gbox_temp, 0, 0, 1, 2)
+        lay.addWidget(gbox_temp, 0, 0, 1, 3)
 
         # AC Panel
         gbox_ac = QGroupBox('AC Panel')
         lay_ac = QGridLayout()
         gbox_ac.setLayout(lay_ac)
+
+        lb_volt = SiriusLabel(self, self.prefix+self.syst_dict['AC']['Volt'])
+        lb_volt.showUnits = True
+        lb_curr = SiriusLabel(self, self.prefix+self.syst_dict['AC']['Curr'])
+        lb_curr.showUnits = True
 
         lay_ac.addWidget(QLabel(
             '<h4>AC/DC Panel Interlock</h4>',
@@ -480,7 +486,34 @@ class SSADetailsBO(SiriusDialog):
         lay_ac.addWidget(SiriusLedState(
             self, self.prefix+self.syst_dict['AC']['300Vdc']),
             2, 1, alignment=Qt.AlignCenter)
-        lay.addWidget(gbox_ac, 1, 0)
+        lay_ac.addWidget(QLabel(
+            '<h4>AC/DC Voltage</h4>',
+            alignment=Qt.AlignRight | Qt.AlignVCenter), 3, 0)
+        lay_ac.addWidget(lb_volt, 3, 1)
+        lay_ac.addWidget(QLabel(
+            '<h4>AC/DC Current</h4>',
+            alignment=Qt.AlignRight | Qt.AlignVCenter), 4, 0)
+        lay_ac.addWidget(lb_curr, 4, 1)
+        lay.addWidget(gbox_ac, 1, 0, 3, 1)
+
+        # Others
+        lb_pwr = SiriusLabel(self, self.prefix+self.syst_dict['Pwr'])
+        lb_pwr.showUnits = True
+        pb_curr = QPushButton(
+            qta.icon('fa5s.external-link-alt'), ' Currents', self)
+        connect_window(pb_curr, SSACurrentsDetails, parent=self,
+            prefix=self.prefix, section=self.section, num='',
+            system='')
+
+        lay.addWidget(QLabel(
+            '<h4>Rotameter Flow</h4>', alignment=Qt.AlignCenter), 1, 1)
+        lay.addWidget(SiriusLedAlert(
+            self, self.prefix+self.syst_dict['Rot']),
+            1, 2, alignment=Qt.AlignCenter)
+        lay.addWidget(QLabel(
+            '<h4>Power</h4>', alignment=Qt.AlignCenter), 2, 1)
+        lay.addWidget(lb_pwr, 2, 2)
+        lay.addWidget(pb_curr, 3, 1, alignment=Qt.AlignHCenter)
 
         return lay
 
@@ -490,8 +523,6 @@ class SSADetailsBO(SiriusDialog):
         lay.setSpacing(9)
 
         graph_hs = SiriusTimePlot(self)
-        graph_hs.setStyleSheet(
-            'min-height:15em;min-width:20em;max-height:40em')
         graph_hs.maxRedrawRate = 2
         graph_hs.setShowXGrid(True)
         graph_hs.setShowYGrid(True)

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -134,7 +134,8 @@ class SSADetailsSI(SiriusDialog):
             lay_alerts.addWidget(QLabel(ls[0], alignment=Qt.AlignCenter),
                 row_alerts, column)
             lay_alerts.addWidget(SiriusLedAlert(
-                self, self.prefix+ls[1]), row_alerts, column+1)
+                self, self.prefix+self._substitute_pv_macros(ls[1])),
+                row_alerts, column+1)
             column += 2
             if column == 6:
                 row_alerts += 1

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -129,9 +129,6 @@ class SSADetails(SiriusDialog):
                 lb, alignment=Qt.AlignCenter), i, 0)
             lay_other.addWidget(lb_val, i, 1, alignment=Qt.AlignCenter)
 
-        tab_wid.addTab(wid_other, 'Other')
-        lay.addWidget(tab_wid, 0, 0, 1, 2)
-
         # Status
         led_status = SiriusLedState(
             self, self._substitute_pv_macros(
@@ -139,9 +136,12 @@ class SSADetails(SiriusDialog):
         led_status.setOffColor(PyDMLed.LightGreen)
         led_status.setOnColor(PyDMLed.DarkGreen)
 
-        lay.addWidget(QLabel(
-            'Status AC', alignment=Qt.AlignCenter), 1, 0)
-        lay.addWidget(led_status, 1, 1, alignment=Qt.AlignCenter)
+        lay_other.addWidget(QLabel(
+            'Status AC', alignment=Qt.AlignCenter), i+1, 0)
+        lay_other.addWidget(led_status, i+1, 1, alignment=Qt.AlignCenter)
+
+        tab_wid.addTab(wid_other, 'Other')
+        lay.addWidget(tab_wid, 0, 0, 1, 2)
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -132,7 +132,6 @@ class SSADetails(SiriusDialog):
         pb_curr.setStyleSheet('min-width: 6em;')
         lay.addWidget(pb_curr, row_general, 1)
 
-
         # Alerts
         lay_alerts = QGridLayout()
         row_alerts = 0
@@ -291,6 +290,7 @@ class SSADetails(SiriusDialog):
             # Table
             cbx = QCheckBox(self)
             cbx.setChecked(True)
+            cbx.setObjectName(suffix)
             cbx.setStyleSheet('color:'+colors[i]+'; max-width: 1.2em;')
             cbx.stateChanged.connect(self._handle_hs_curves_visibility)
             lb_desc = QLabel(suffix)
@@ -341,6 +341,7 @@ class SSADetails(SiriusDialog):
                 # Table
                 cbx = QCheckBox(self)
                 cbx.setChecked(True)
+                cbx.setObjectName(f'{graph_idx+1}{k}')
                 cbx.setStyleSheet('color:'+colors[k][i-1]+'; max-width: 1.2em;')
                 cbx.stateChanged.connect(self._handle_temp_curves_visibility)
                 lb_desc = QLabel(f'Rack {i} - Temp {k}')
@@ -360,7 +361,8 @@ class SSADetails(SiriusDialog):
                     self.prefix+self.syst_dict['Rack'][f'Temp {k}'], str(i))
                 graph_temp.addYChannel(y_channel=channel, color=colors[k][i-1],
                     name=i, lineStyle=Qt.SolidLine, lineWidth=1)
-                self.curves_temp[graph_idx] = graph_temp.curveAtIndex(graph_idx)
+                self.curves_temp[f'{graph_idx+1}{k}'] = graph_temp.curveAtIndex(
+                    graph_idx)
                 graph_idx += 1
 
         return graph_temp, lay_cboxes

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1855,11 +1855,11 @@ SEC_2_CHANNELS = {
                     'Current': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):CurrentPos5V-Mon'
                 },
                 'Runtime': 'RA-To$(sys)0$(NB):RF-SSAmpTower:RunHour-Mon',
-                'Pre Amp 1': [
+                'Pre Amp1': [
                     'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1-Mon',
                     'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1Up-Mon',
                 ],
-                'Pre Amp 2': [
+                'Pre Amp2': [
                     'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2-Mon',
                     'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2Up-Mon',
                 ],
@@ -1896,16 +1896,59 @@ SEC_2_CHANNELS = {
                 }
             },
             'B': {
-                'Diag': {
-                    'Pre Amp 3': [
-                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1-Mon',
-                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1Up-Mon',
+                'Rack': {
+                    'Temp': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(suffix):T-Mon',
+                    'Tms': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(suffix):Tms-Mon',
+                    'PT-100': [
+                        'RA-ToSIB0$(NB):RF-HeatSink-H0$(suffix):TUp-Mon',
+                        'RA-ToSIB0$(NB):RF-HeatSink-H0$(suffix):TDown-Mon'
                     ],
-                    'Pre Amp 4': [
-                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2-Mon',
-                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2Up-Mon',
-                    ],
+                    'Status': 'RA-ToSIB0$(NB):RF-TDKSource-R$(suffix):StsAC-Mon',
+                    'Temp A': 'RA-ToSIB0$(NB):RF-SSAMux-$(suffix):TempA-Mon',
+                    'Temp B': 'RA-ToSIB0$(NB):RF-SSAMux-$(suffix):TempB-Mon',
+                    'Voltage': 'RA-ToSIB0$(NB):RF-SSAMux-$(suffix):VoltPos5V-Mon',
+                    'Current': 'RA-ToSIB0$(NB):RF-SSAMux-$(suffix):CurrentPos5V-Mon'
                 },
+                'Runtime': 'RA-ToSIB0$(NB):RF-SSAmpTower:RunHour-Mon',
+                'Pre Amp3': [
+                    'RA-RaSIB01:RF-LLRFPreAmp-1:T1-Mon',
+                    'RA-RaSIB01:RF-LLRFPreAmp-1:T1Up-Mon',
+                ],
+                'Pre Amp4': [
+                    'RA-RaSIB01:RF-LLRFPreAmp-1:T2-Mon',
+                    'RA-RaSIB01:RF-LLRFPreAmp-1:T2Up-Mon',
+                ],
+                'In Pwr Fwd': [
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
+                ],
+                'In Pwr Rev': [
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
+                ],
+                'Out Pwr Fwd': [
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
+                ],
+                'Out Pwr Rev': [
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
+                ],
+                'Alerts': {
+                    'PhsFlt': ['Phase Fault', 'RA-ToSIB0$(NB):RF-ACPanel:PhsFlt-Mon'],
+                    'SSAFlwRt': ['SSA Rotameter Flow', 'RA-ToSIB0$(NB):RF-SSAmpTower:HdFlwRt-Mon'],
+                    'LoadFlwRt': ['Load Rotameter Flow', 'RA-ToSIB0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
+                    'PnlFeed': ['AC Panel Feedback', 'RA-ToSIB0$(NB):RF-ACPanel:Intlk-Mon'],
+                    'PnlIntlk': ['AC Panel Interlock', 'RA-ToSIB0$(NB):RF-Intlk:IntlkACPanel-Mon'],
+                    'PnlSts': ['AC Panel Status', 'RA-ToSIB0$(NB):RF-ACPanel:PwrACOp-Mon'],
+                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIB0$(NB):RF-CtrlPanel:PwrSts-Mon'],
+                    'PwrSup': ['24V Power Supply', 'RA-ToSIB0$(NB):RF-ACPanel:StsPos24V-Mon'],
+                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIB0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
+                }
             }
         },
         'SL': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1971,6 +1971,7 @@ SEC_2_CHANNELS = {
                     'FwdPwrBot': ['Forward Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerIncidentPower'],
                     'RevPwrBot': ['Reverse Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerReflectedPower'],
                 },
+                'RacksTotal': 'RA-To$(sys)0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
                 'Alarms': {
                     'General': {
                         'Label': 'General Power',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -183,9 +183,16 @@ SEC_2_CHANNELS = {
         'SSADtls': {
             'HeatSink': {
                 'Temp': 'RA-ToBO:RF-HeatSink-H0$(hs_num):T-Mon',
-                'TMS': 'RA-ToBO:RF-HeatSink-H0$(hs_num):Tms-Mon'
+                'TMS': 'RA-ToBO:RF-HeatSink-H0$(hs_num):Tms-Mon',
+                'PT-100': [
+                        'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):TUp-Mon',
+                        'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):TDown-Mon'
+                ]
             },
-            'PreAmp': 'RA-RaBO01:RF-LLRFPreAmp:T1-Mon',
+            'PreAmp': {
+                'Temp': 'RA-RaBO01:RF-LLRFPreAmp:T1-Mon',
+                'PT-100': 'RA-RaBO01:RF-LLRFPreAmp:T1Up-Mon'
+            },
             'AC': {
                 'Intlk': 'BO-ToBO:RF-ACDCPanel:Intlk-Mon',
                 'Ctrl': 'BO-ToBO:RF-ACDCPanel:CtrlMode-Mon',
@@ -194,14 +201,7 @@ SEC_2_CHANNELS = {
                 'Curr': 'BO-ToBO:RF-ACDCPanel:CurrentVdc-Mon'
             },
             'Rot': 'RA-ToBo:RF-SSAmpTower:HdFlwRt-Mon',
-            'PwrFwdOut': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon',
-            'Pwr': {
-                'Fwd In': '$(SI):RF-SSAmpTower:PwrFwdIn$(MR)-Mon',
-                'Rev In': '$(SI):RF-SSAmpTower:PwrRevIn$(MR)-Mon',
-                'Fwd Out': '$(SI):RF-SSAmpTower:PwrFwdOut$(MR)-Mon',
-                'Rev Out': '$(SI):RF-SSAmpTower:PwrRevOut$(MR)-Mon',
-                'Gain': '$(SI):RF-SSAmpTower:PwrFwdIn$(MR)-Mon',
-            }
+            'Pwr': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon',
         },
         'SSACurr': {
             'HeatSink': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -204,41 +204,54 @@ SEC_2_CHANNELS = {
                 'Fwd Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
                 'Rev Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
             },
-            # 'PreAmp': {
-            #     'HS': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
-            #     'PreAmp': 'RA-ToSIA0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-            #     'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
-            # },
-            # 'Offsets': {
-            #     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperIncidentPower'],
-            #     'RevPwrTop': ['Reverse Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperReflectedPower'],
-            #     'FwdPwrBot': ['Forward Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerIncidentPower'],
-            #     'RevPwrBot': ['Reverse Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerReflectedPower'],
-            # },
-            # 'RacksTotal': 'RA-ToSIA0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
-            # 'Alarms': {
-            #     'General': {
-            #         'Label': 'General Power',
-            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHiHi',
-            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHigh',
-            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLow',
-            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLoLo',
-            #     },
-            #     'Inter': {
-            #         'Label': 'Intermediary Power',
-            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHiHi',
-            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHigh',
-            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLow',
-            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLoLo',
-            #     },
-            #     'High': {
-            #         'Label': 'Current - High Limit',
-            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHiHi',
-            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHigh',
-            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLow',
-            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLoLo',
-            #     },
-            # }
+            'PreAmp': {
+                'HS': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M0$(m_num):Current$(curr_num)-Mon',
+                'DC': 'RA-ToBO:RF-SSAmpTower:PwrDC-Cmd'
+            },
+            'Pwr': {
+                'Input': {
+                    'Fwd': 'RA-ToBO:RF-SSAmpTower:PwrFwdIn-Mon',
+                    'Rev': 'RA-ToBO:RF-SSAmpTower:PwrRevIn-Mon'
+                },
+                'Output': {
+                    'Fwd': 'RA-ToBO:RF-SSAmpTower:PwrFwdOut-Mon',
+                    'Rev': 'RA-ToBO:RF-SSAmpTower:PwrRevOut-Mon'
+                }
+            },
+            'Offsets': {
+                'FwdPwrTop': ['Forward Power - Top', 'RA-ToBO:OffsetConfig:UpperIncidentPower'],
+                'RevPwrTop': ['Reverse Power - Top', 'RA-ToBO:OffsetConfig:UpperReflectedPower'],
+                'FwdPwrBot': ['Forward Power - Bottom', 'RA-ToBO:OffsetConfig:LowerIncidentPower'],
+                'RevPwrBot': ['Reverse Power - Bottom', 'RA-ToBO:OffsetConfig:LowerReflectedPower'],
+                'FwdPwrIn': ['Forward Power In', 'RA-ToBO:OffsetConfig:InputIncidentPower'],
+                'RevPwrIn': ['Reverse Power In', 'RA-ToBO:OffsetConfig:InputReflectedPower'],
+                'FwdPwrOut': ['Forward Power Out', 'RA-ToBO:OffsetConfig:OutputIncidentPower'],
+                'RevPwrOut': ['Reverse Power Out', 'RA-ToBO:OffsetConfig:InputReflectedPower'],
+            },
+            'Total': 'RA-ToBO:RF-SSAmpTower:DCCurrent-Mon',
+            'Alarms': {
+                'General': {
+                    'Label': 'General Power',
+                    'HIHI': 'RA-ToBO:AlarmConfig:GeneralPowerLimHiHi',
+                    'HIGH': 'RA-ToBO:AlarmConfig:GeneralPowerLimHigh',
+                    'LOW': 'RA-ToBO:AlarmConfig:GeneralPowerLimLow',
+                    'LOLO': 'RA-ToBO:AlarmConfig:GeneralPowerLimLoLo',
+                },
+                'Inter': {
+                    'Label': 'Intermediary Power',
+                    'HIHI': 'RA-ToBO:AlarmConfig:InnerPowerLimHiHi',
+                    'HIGH': 'RA-ToBO:AlarmConfig:InnerPowerLimHigh',
+                    'LOW': 'RA-ToBO:AlarmConfig:InnerPowerLimLow',
+                    'LOLO': 'RA-ToBO:AlarmConfig:InnerPowerLimLoLo',
+                },
+                'High': {
+                    'Label': 'Current - High Limit',
+                    'HIHI': 'RA-ToBO:AlarmConfig:CurrentLimHiHi',
+                    'HIGH': 'RA-ToBO:AlarmConfig:CurrentLimHigh',
+                    'LOW': 'RA-ToBO:AlarmConfig:CurrentLimLow',
+                    'LOLO': 'RA-ToBO:AlarmConfig:CurrentLimLoLo',
+                },
+            }
         },
         'SL': {
             'ErrDtls': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1839,6 +1839,64 @@ SEC_2_CHANNELS = {
                 'LLRF': 'B'
             }
         },
+        'SSADtls': {
+            'A': {
+                'Rack': {
+                    'Temp': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):T-Mon',
+                    'Tms': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):Tms-Mon',
+                    'PT-100': [
+                        'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):TUp-Mon',
+                        'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):TDown-Mon'
+                    ],
+                    'Status': 'RA-To$(sys)0$(NB):RF-TDKSource-R$(suffix):StsAC-Mon',
+                    'Temp A': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):TempA-Mon',
+                    'Temp B': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):TempB-Mon',
+                    'Voltage': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):VoltPos5V-Mon',
+                    'Current': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):CurrentPos5V-Mon'
+                },
+                'Runtime': 'RA-To$(sys)0$(NB):RF-SSAmpTower:RunHour-Mon',
+                'Pre Amp 1': [
+                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1-Mon',
+                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1Up-Mon',
+                ],
+                'Pre Amp 2': [
+                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2-Mon',
+                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2Up-Mon',
+                ],
+                'In Pwr Fwd': [
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
+                ],
+                'In Pwr Rev': [
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
+                ],
+                'Out Pwr Fwd': [
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
+                ],
+                'Out Pwr Rev': [
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
+                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
+                ],
+            },
+            'B': {
+                'Diag': {
+                    'Pre Amp 3': [
+                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1-Mon',
+                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1Up-Mon',
+                    ],
+                    'Pre Amp 4': [
+                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2-Mon',
+                        'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2Up-Mon',
+                    ],
+                },
+            }
+        },
         'SL': {
             'ErrDtls': {
                 'A': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -185,7 +185,12 @@ SEC_2_CHANNELS = {
                 'Temp': 'RA-ToBO:RF-HeatSink-H0$(hs_num):T-Mon',
                 'TMS': 'RA-ToBO:RF-HeatSink-H0$(hs_num):Tms-Mon'
             },
-            'PreAmp': 'RA-RaBO01:RF-LLRFPreAmp:T1-Mon'
+            'PreAmp': 'RA-RaBO01:RF-LLRFPreAmp:T1-Mon',
+            'AC': {
+                'Intlk': 'BO-ToBO:RF-ACDCPanel:Intlk-Mon',
+                'Ctrl': 'BO-ToBO:RF-ACDCPanel:CtrlMode-Mon',
+                '300Vdc': 'RA-ToBO:RF-ACDCPanel:300VdcEnbl-Mon'
+            }
         },
         'SL': {
             'ErrDtls': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -201,28 +201,28 @@ SEC_2_CHANNELS = {
                 'Curr': 'BO-ToBO:RF-ACDCPanel:CurrentVdc-Mon'
             },
             'Rot': 'RA-ToBo:RF-SSAmpTower:HdFlwRt-Mon',
-            'Pwr': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon',
+            'Pwr': 'RA-ToBo:RF-SSAmpTower:FwdOut-Mon',
         },
         'SSACurr': {
             'HeatSink': {
                 'Curr': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M$(m_num):Current$(curr_num)-Mon',
-                'Fwd Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
-                'Rev Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
-                'Fwd Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
-                'Rev Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                'Fwd Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):FwdTop-Mon',
+                'Rev Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):RevTop-Mon',
+                'Fwd Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):FwdBot-Mon',
+                'Rev Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):RevBot-Mon'
             },
             'PreAmp': {
                 'HS': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M$(m_num):Current$(curr_num)-Mon',
-                'DC': 'RA-ToBO:RF-SSAmpTower:PwrDC-Cmd'
+                'DC': 'RA-ToBO:RF-SSAmpTower:DC-Cmd'
             },
             'Pwr': {
                 'Input': {
-                    'Fwd': 'RA-ToBO:RF-SSAmpTower:PwrFwdIn-Mon',
-                    'Rev': 'RA-ToBO:RF-SSAmpTower:PwrRevIn-Mon'
+                    'Fwd': 'RA-ToBO:RF-SSAmpTower:FwdIn-Mon',
+                    'Rev': 'RA-ToBO:RF-SSAmpTower:RevIn-Mon'
                 },
                 'Output': {
-                    'Fwd': 'RA-ToBO:RF-SSAmpTower:PwrFwdOut-Mon',
-                    'Rev': 'RA-ToBO:RF-SSAmpTower:PwrRevOut-Mon'
+                    'Fwd': 'RA-ToBO:RF-SSAmpTower:FwdOut-Mon',
+                    'Rev': 'RA-ToBO:RF-SSAmpTower:RevOut-Mon'
                 }
             },
             'Offsets': {
@@ -1944,24 +1944,24 @@ SEC_2_CHANNELS = {
                     'RA-RoSIA01:RF-LLRFPreAmp-1:T2Up-Mon',
                 ],
                 'In Pwr Fwd': [
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:FwdIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwFwdIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:FwdInSts-Mon'
                 ],
                 'In Pwr Rev': [
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:RevIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwRevIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:RevInSts-Mon'
                 ],
                 'Out Pwr Fwd': [
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:FwdOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwFwdOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:FwdOutSts-Mon'
                 ],
                 'Out Pwr Rev': [
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
-                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:RevOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwRevOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:RevOutSts-Mon'
                 ],
                 'Alerts': {
                     'PhsFlt': ['Phase Fault', 'RA-ToSIA0$(NB):RF-ACPanel:PhsFlt-Mon'],
@@ -1969,10 +1969,10 @@ SEC_2_CHANNELS = {
                     'LoadFlwRt': ['Load Rotameter Flow', 'RA-ToSIA0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
                     'PnlFeed': ['AC Panel Feedback', 'RA-ToSIA0$(NB):RF-ACPanel:Intlk-Mon'],
                     'PnlIntlk': ['AC Panel Interlock', 'RA-ToSIA0$(NB):RF-Intlk:IntlkACPanel-Mon'],
-                    'PnlSts': ['AC Panel Status', 'RA-ToSIA0$(NB):RF-ACPanel:PwrACOp-Mon'],
-                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIA0$(NB):RF-CtrlPanel:PwrSts-Mon'],
+                    'PnlSts': ['AC Panel Status', 'RA-ToSIA0$(NB):RF-ACPanel:ACOp-Mon'],
+                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIA0$(NB):RF-CtrlPanel:Sts-Mon'],
                     'PwrSup': ['24V Power Supply', 'RA-ToSIA0$(NB):RF-ACPanel:StsPos24V-Mon'],
-                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIA0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
+                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIA0$(NB):RF-SSAmpTower:RFSts-Mon'],
                 }
             },
             'B': {
@@ -1999,24 +1999,24 @@ SEC_2_CHANNELS = {
                     'RA-RaSIB01:RF-LLRFPreAmp-1:T2Up-Mon',
                 ],
                 'In Pwr Fwd': [
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:FwdIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwFwdIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:FwdInSts-Mon'
                 ],
                 'In Pwr Rev': [
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:RevIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwRevIn-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:RevInSts-Mon'
                 ],
                 'Out Pwr Fwd': [
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:FwdOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwFwdOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:FwdOutSts-Mon'
                 ],
                 'Out Pwr Rev': [
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
-                    'RA-ToSIB0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:RevOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:HwRevOut-Mon',
+                    'RA-ToSIB0$(NB):RF-SSAmpTower:RevOutSts-Mon'
                 ],
                 'Alerts': {
                     'PhsFlt': ['Phase Fault', 'RA-ToSIB0$(NB):RF-ACPanel:PhsFlt-Mon'],
@@ -2024,10 +2024,10 @@ SEC_2_CHANNELS = {
                     'LoadFlwRt': ['Load Rotameter Flow', 'RA-ToSIB0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
                     'PnlFeed': ['AC Panel Feedback', 'RA-ToSIB0$(NB):RF-ACPanel:Intlk-Mon'],
                     'PnlIntlk': ['AC Panel Interlock', 'RA-ToSIB0$(NB):RF-Intlk:IntlkACPanel-Mon'],
-                    'PnlSts': ['AC Panel Status', 'RA-ToSIB0$(NB):RF-ACPanel:PwrACOp-Mon'],
-                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIB0$(NB):RF-CtrlPanel:PwrSts-Mon'],
+                    'PnlSts': ['AC Panel Status', 'RA-ToSIB0$(NB):RF-ACPanel:ACOp-Mon'],
+                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIB0$(NB):RF-CtrlPanel:Sts-Mon'],
                     'PwrSup': ['24V Power Supply', 'RA-ToSIB0$(NB):RF-ACPanel:StsPos24V-Mon'],
-                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIB0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
+                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIB0$(NB):RF-SSAmpTower:RFSts-Mon'],
                 }
             }
         },
@@ -2035,15 +2035,15 @@ SEC_2_CHANNELS = {
             'A': {
                 'HeatSink': {
                     'Curr': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
-                    'Fwd Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
-                    'Rev Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
-                    'Fwd Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
-                    'Rev Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                    'Fwd Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):FwdTop-Mon',
+                    'Rev Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):RevTop-Mon',
+                    'Fwd Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):FwdBot-Mon',
+                    'Rev Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):RevBot-Mon'
                 },
                 'PreAmp': {
                     'HS': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
                     'PreAmp': 'RA-ToSIA0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-                    'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
+                    'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:DCR1-Mon'
                 },
                 'Offsets': {
                     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperIncidentPower'],
@@ -2079,15 +2079,15 @@ SEC_2_CHANNELS = {
             'B': {
                 'HeatSink': {
                     'Curr': 'RA-ToSIB0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
-                    'Fwd Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
-                    'Rev Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
-                    'Fwd Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
-                    'Rev Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                    'Fwd Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):FwdTop-Mon',
+                    'Rev Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):RevTop-Mon',
+                    'Fwd Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):FwdBot-Mon',
+                    'Rev Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):RevBot-Mon'
                 },
                 'PreAmp': {
                     'HS': 'RA-ToSIB0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
                     'PreAmp': 'RA-ToSIB0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-                    'TDK': 'RA-ToSIB0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
+                    'TDK': 'RA-ToSIB0$(NB):RF-SSAmpTower:DCR1-Mon'
                 },
                 'Offsets': {
                     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIB0$(NB):OffsetConfig:UpperIncidentPower'],

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1951,6 +1951,26 @@ SEC_2_CHANNELS = {
                 }
             }
         },
+        'SSACurr': {
+            'A': {
+                'HeatSink': {
+                    'Curr': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
+                    'Fwd Top': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
+                    'Rev Top': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
+                    'Fwd Bot': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
+                    'Rev Bot': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                },
+                'PreAmp': {
+
+                },
+                'Total': {
+                    
+                }
+            },
+            'B': {
+
+            }
+        },
         'SL': {
             'ErrDtls': {
                 'A': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -2052,13 +2052,6 @@ SEC_2_CHANNELS = {
                 },
                 'RacksTotal': 'RA-ToSIA0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
                 'Alarms': {
-                    'General': {
-                        'Label': 'General Power',
-                        'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHiHi',
-                        'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHigh',
-                        'LOW': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLow',
-                        'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLoLo',
-                    },
                     'Inter': {
                         'Label': 'Intermediary Power',
                         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHiHi',
@@ -2095,13 +2088,6 @@ SEC_2_CHANNELS = {
                 },
                 'RacksTotal': 'RA-ToSIB0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
                 'Alarms': {
-                    'General': {
-                        'Label': 'General Power',
-                        'HIHI': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimHiHi',
-                        'HIGH': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimHigh',
-                        'LOW': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimLow',
-                        'LOLO': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimLoLo',
-                    },
                     'Inter': {
                         'Label': 'Intermediary Power',
                         'HIHI': 'RA-ToSIB0$(NB):AlarmConfig:InnerPowerLimHiHi',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1842,57 +1842,57 @@ SEC_2_CHANNELS = {
         'SSADtls': {
             'A': {
                 'Rack': {
-                    'Temp': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):T-Mon',
-                    'Tms': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):Tms-Mon',
+                    'Temp': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(suffix):T-Mon',
+                    'Tms': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(suffix):Tms-Mon',
                     'PT-100': [
-                        'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):TUp-Mon',
-                        'RA-To$(sys)0$(NB):RF-HeatSink-H0$(suffix):TDown-Mon'
+                        'RA-ToSIA0$(NB):RF-HeatSink-H0$(suffix):TUp-Mon',
+                        'RA-ToSIA0$(NB):RF-HeatSink-H0$(suffix):TDown-Mon'
                     ],
-                    'Status': 'RA-To$(sys)0$(NB):RF-TDKSource-R$(suffix):StsAC-Mon',
-                    'Temp A': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):TempA-Mon',
-                    'Temp B': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):TempB-Mon',
-                    'Voltage': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):VoltPos5V-Mon',
-                    'Current': 'RA-To$(sys)0$(NB):RF-SSAMux-$(suffix):CurrentPos5V-Mon'
+                    'Status': 'RA-ToSIA0$(NB):RF-TDKSource-R$(suffix):StsAC-Mon',
+                    'Temp A': 'RA-ToSIA0$(NB):RF-SSAMux-$(suffix):TempA-Mon',
+                    'Temp B': 'RA-ToSIA0$(NB):RF-SSAMux-$(suffix):TempB-Mon',
+                    'Voltage': 'RA-ToSIA0$(NB):RF-SSAMux-$(suffix):VoltPos5V-Mon',
+                    'Current': 'RA-ToSIA0$(NB):RF-SSAMux-$(suffix):CurrentPos5V-Mon'
                 },
-                'Runtime': 'RA-To$(sys)0$(NB):RF-SSAmpTower:RunHour-Mon',
+                'Runtime': 'RA-ToSIA0$(NB):RF-SSAmpTower:RunHour-Mon',
                 'Pre Amp1': [
-                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1-Mon',
-                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T1Up-Mon',
+                    'RA-RoSIA01:RF-LLRFPreAmp-1:T1-Mon',
+                    'RA-RoSIA01:RF-LLRFPreAmp-1:T1Up-Mon',
                 ],
                 'Pre Amp2': [
-                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2-Mon',
-                    'RA-Ra$(sys)01:RF-LLRFPreAmp-1:T2Up-Mon',
+                    'RA-RoSIA01:RF-LLRFPreAmp-1:T2-Mon',
+                    'RA-RoSIA01:RF-LLRFPreAmp-1:T2Up-Mon',
                 ],
                 'In Pwr Fwd': [
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrFwdIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdInSts-Mon'
                 ],
                 'In Pwr Rev': [
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrRevIn-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevInSts-Mon'
                 ],
                 'Out Pwr Fwd': [
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrFwdOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrFwdOutSts-Mon'
                 ],
                 'Out Pwr Rev': [
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
-                    'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
+                    'RA-ToSIA0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
                 ],
                 'Alerts': {
-                    'PhsFlt': ['Phase Fault', 'RA-To$(sys)0$(NB):RF-ACPanel:PhsFlt-Mon'],
-                    'SSAFlwRt': ['SSA Rotameter Flow', 'RA-To$(sys)0$(NB):RF-SSAmpTower:HdFlwRt-Mon'],
-                    'LoadFlwRt': ['Load Rotameter Flow', 'RA-To$(sys)0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
-                    'PnlFeed': ['AC Panel Feedback', 'RA-To$(sys)0$(NB):RF-ACPanel:Intlk-Mon'],
-                    'PnlIntlk': ['AC Panel Interlock', 'RA-To$(sys)0$(NB):RF-Intlk:IntlkACPanel-Mon'],
-                    'PnlSts': ['AC Panel Status', 'RA-To$(sys)0$(NB):RF-ACPanel:PwrACOp-Mon'],
-                    'ElecFuse': ['Electronic Fuse', 'RA-To$(sys)0$(NB):RF-CtrlPanel:PwrSts-Mon'],
-                    'PwrSup': ['24V Power Supply', 'RA-To$(sys)0$(NB):RF-ACPanel:StsPos24V-Mon'],
-                    'PwrIntlk': ['RF Power Interlock', 'RA-To$(sys)0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
+                    'PhsFlt': ['Phase Fault', 'RA-ToSIA0$(NB):RF-ACPanel:PhsFlt-Mon'],
+                    'SSAFlwRt': ['SSA Rotameter Flow', 'RA-ToSIA0$(NB):RF-SSAmpTower:HdFlwRt-Mon'],
+                    'LoadFlwRt': ['Load Rotameter Flow', 'RA-ToSIA0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
+                    'PnlFeed': ['AC Panel Feedback', 'RA-ToSIA0$(NB):RF-ACPanel:Intlk-Mon'],
+                    'PnlIntlk': ['AC Panel Interlock', 'RA-ToSIA0$(NB):RF-Intlk:IntlkACPanel-Mon'],
+                    'PnlSts': ['AC Panel Status', 'RA-ToSIA0$(NB):RF-ACPanel:PwrACOp-Mon'],
+                    'ElecFuse': ['Electronic Fuse', 'RA-ToSIA0$(NB):RF-CtrlPanel:PwrSts-Mon'],
+                    'PwrSup': ['24V Power Supply', 'RA-ToSIA0$(NB):RF-ACPanel:StsPos24V-Mon'],
+                    'PwrIntlk': ['RF Power Interlock', 'RA-ToSIA0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
                 }
             },
             'B': {
@@ -1954,50 +1954,91 @@ SEC_2_CHANNELS = {
         'SSACurr': {
             'A': {
                 'HeatSink': {
-                    'Curr': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
-                    'Fwd Top': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
-                    'Rev Top': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
-                    'Fwd Bot': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
-                    'Rev Bot': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                    'Curr': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
+                    'Fwd Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
+                    'Rev Top': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
+                    'Fwd Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
+                    'Rev Bot': 'RA-ToSIA0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
                 },
                 'PreAmp': {
-                    'HS': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
-                    'PreAmp': 'RA-To$(sys)0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-                    'TDK': 'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
+                    'HS': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
+                    'PreAmp': 'RA-ToSIA0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
+                    'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
                 },
                 'Offsets': {
-                    'FwdPwrTop': ['Forward Power - Top', 'RA-To$(sys)0$(NB):OffsetConfig:UpperIncidentPower'],
-                    'RevPwrTop': ['Reverse Power - Top', 'RA-To$(sys)0$(NB):OffsetConfig:UpperReflectedPower'],
-                    'FwdPwrBot': ['Forward Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerIncidentPower'],
-                    'RevPwrBot': ['Reverse Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerReflectedPower'],
+                    'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperIncidentPower'],
+                    'RevPwrTop': ['Reverse Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperReflectedPower'],
+                    'FwdPwrBot': ['Forward Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerIncidentPower'],
+                    'RevPwrBot': ['Reverse Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerReflectedPower'],
                 },
-                'RacksTotal': 'RA-To$(sys)0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
+                'RacksTotal': 'RA-ToSIA0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
                 'Alarms': {
                     'General': {
                         'Label': 'General Power',
-                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimHiHi',
-                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimHigh',
-                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimLow',
-                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimLoLo',
+                        'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHiHi',
+                        'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHigh',
+                        'LOW': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLow',
+                        'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLoLo',
                     },
                     'Inter': {
                         'Label': 'Intermediary Power',
-                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimHiHi',
-                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimHigh',
-                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimLow',
-                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimLoLo',
+                        'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHiHi',
+                        'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHigh',
+                        'LOW': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLow',
+                        'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLoLo',
                     },
                     'High': {
                         'Label': 'Current - High Limit',
-                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimHiHi',
-                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimHigh',
-                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimLow',
-                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimLoLo',
+                        'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHiHi',
+                        'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHigh',
+                        'LOW': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLow',
+                        'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLoLo',
                     },
                 }
             },
             'B': {
-
+                'HeatSink': {
+                    'Curr': 'RA-ToSIB0$(NB):RF-SSAmp-H0$(hs_num)$(letter)M0$(m_num):Current$(curr_num)-Mon',
+                    'Fwd Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
+                    'Rev Top': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
+                    'Fwd Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
+                    'Rev Bot': 'RA-ToSIB0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+                },
+                'PreAmp': {
+                    'HS': 'RA-ToSIB0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
+                    'PreAmp': 'RA-ToSIB0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
+                    'TDK': 'RA-ToSIB0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
+                },
+                'Offsets': {
+                    'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIB0$(NB):OffsetConfig:UpperIncidentPower'],
+                    'RevPwrTop': ['Reverse Power - Top', 'RA-ToSIB0$(NB):OffsetConfig:UpperReflectedPower'],
+                    'FwdPwrBot': ['Forward Power - Bottom', 'RA-ToSIB0$(NB):OffsetConfig:LowerIncidentPower'],
+                    'RevPwrBot': ['Reverse Power - Bottom', 'RA-ToSIB0$(NB):OffsetConfig:LowerReflectedPower'],
+                },
+                'RacksTotal': 'RA-ToSIB0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
+                'Alarms': {
+                    'General': {
+                        'Label': 'General Power',
+                        'HIHI': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimHiHi',
+                        'HIGH': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimHigh',
+                        'LOW': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimLow',
+                        'LOLO': 'RA-ToSIB0$(NB):AlarmConfig:GeneralPowerLimLoLo',
+                    },
+                    'Inter': {
+                        'Label': 'Intermediary Power',
+                        'HIHI': 'RA-ToSIB0$(NB):AlarmConfig:InnerPowerLimHiHi',
+                        'HIGH': 'RA-ToSIB0$(NB):AlarmConfig:InnerPowerLimHigh',
+                        'LOW': 'RA-ToSIB0$(NB):AlarmConfig:InnerPowerLimLow',
+                        'LOLO': 'RA-ToSIB0$(NB):AlarmConfig:InnerPowerLimLoLo',
+                    },
+                    'High': {
+                        'Label': 'Current - High Limit',
+                        'HIHI': 'RA-ToSIB0$(NB):AlarmConfig:CurrentLimHiHi',
+                        'HIGH': 'RA-ToSIB0$(NB):AlarmConfig:CurrentLimHigh',
+                        'LOW': 'RA-ToSIB0$(NB):AlarmConfig:CurrentLimLow',
+                        'LOLO': 'RA-ToSIB0$(NB):AlarmConfig:CurrentLimLoLo',
+                    },
+                }
             }
         },
         'SL': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -189,8 +189,12 @@ SEC_2_CHANNELS = {
             'AC': {
                 'Intlk': 'BO-ToBO:RF-ACDCPanel:Intlk-Mon',
                 'Ctrl': 'BO-ToBO:RF-ACDCPanel:CtrlMode-Mon',
-                '300Vdc': 'RA-ToBO:RF-ACDCPanel:300VdcEnbl-Mon'
-            }
+                '300Vdc': 'RA-ToBO:RF-ACDCPanel:300VdcEnbl-Mon',
+                'Volt': 'BO-ToBO:RF-ACDCPanel:300Vdc-Mon',
+                'Curr': 'BO-ToBO:RF-ACDCPanel:CurrentVdc-Mon'
+            },
+            'Rot': 'RA-ToBo:RF-SSAmpTower:HdFlwRt-Mon',
+            'Pwr': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon'
         },
         'SL': {
             'ErrDtls': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -196,6 +196,50 @@ SEC_2_CHANNELS = {
             'Rot': 'RA-ToBo:RF-SSAmpTower:HdFlwRt-Mon',
             'Pwr': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon'
         },
+        'SSACurr': {
+            'HeatSink': {
+                'Curr': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M0$(m_num):Current$(curr_num)-Mon',
+                'Fwd Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
+                'Rev Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
+                'Fwd Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
+                'Rev Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
+            },
+            # 'PreAmp': {
+            #     'HS': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
+            #     'PreAmp': 'RA-ToSIA0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
+            #     'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
+            # },
+            # 'Offsets': {
+            #     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperIncidentPower'],
+            #     'RevPwrTop': ['Reverse Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperReflectedPower'],
+            #     'FwdPwrBot': ['Forward Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerIncidentPower'],
+            #     'RevPwrBot': ['Reverse Power - Bottom', 'RA-ToSIA0$(NB):OffsetConfig:LowerReflectedPower'],
+            # },
+            # 'RacksTotal': 'RA-ToSIA0$(NB):RF-SSAMux-$(rack_num):DCCurrent-Mon',
+            # 'Alarms': {
+            #     'General': {
+            #         'Label': 'General Power',
+            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHiHi',
+            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimHigh',
+            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLow',
+            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:GeneralPowerLimLoLo',
+            #     },
+            #     'Inter': {
+            #         'Label': 'Intermediary Power',
+            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHiHi',
+            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimHigh',
+            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLow',
+            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:InnerPowerLimLoLo',
+            #     },
+            #     'High': {
+            #         'Label': 'Current - High Limit',
+            #         'HIHI': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHiHi',
+            #         'HIGH': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimHigh',
+            #         'LOW': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLow',
+            #         'LOLO': 'RA-ToSIA0$(NB):AlarmConfig:CurrentLimLoLo',
+            #     },
+            # }
+        },
         'SL': {
             'ErrDtls': {
                 'IRef': 'RA-RaBO01:RF-LLRF:SLRefI-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -158,7 +158,7 @@ SEC_2_CHANNELS = {
         'SSA': {
             'Name': 'SSA',
             'Status': 'RA-ToBO:RF-SSAmpTower:Sts-Mon',
-            'Power': 'RA-ToBO:RF-SSAmpTower:PwrFwdOutLLRF-Mon',
+            'Power': 'RA-ToBO:RF-SSAmpTower:FwdOutLLRF-Mon',
             'SRC 1': {
                 'Label': '300VDC',
                 'Enable': 'RA-ToBO:RF-ACDCPanel:300VdcEnbl-Sel',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -2043,7 +2043,6 @@ SEC_2_CHANNELS = {
                 'PreAmp': {
                     'HS': 'RA-ToSIA0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
                     'PreAmp': 'RA-ToSIA0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-                    'TDK': 'RA-ToSIA0$(NB):RF-SSAmpTower:DCR1-Mon'
                 },
                 'Offsets': {
                     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIA0$(NB):OffsetConfig:UpperIncidentPower'],
@@ -2087,7 +2086,6 @@ SEC_2_CHANNELS = {
                 'PreAmp': {
                     'HS': 'RA-ToSIB0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
                     'PreAmp': 'RA-ToSIB0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
-                    'TDK': 'RA-ToSIB0$(NB):RF-SSAmpTower:DCR1-Mon'
                 },
                 'Offsets': {
                     'FwdPwrTop': ['Forward Power - Top', 'RA-ToSIB0$(NB):OffsetConfig:UpperIncidentPower'],

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -194,18 +194,25 @@ SEC_2_CHANNELS = {
                 'Curr': 'BO-ToBO:RF-ACDCPanel:CurrentVdc-Mon'
             },
             'Rot': 'RA-ToBo:RF-SSAmpTower:HdFlwRt-Mon',
-            'Pwr': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon'
+            'PwrFwdOut': 'RA-ToBo:RF-SSAmpTower:PwrFwdOut-Mon',
+            'Pwr': {
+                'Fwd In': '$(SI):RF-SSAmpTower:PwrFwdIn$(MR)-Mon',
+                'Rev In': '$(SI):RF-SSAmpTower:PwrRevIn$(MR)-Mon',
+                'Fwd Out': '$(SI):RF-SSAmpTower:PwrFwdOut$(MR)-Mon',
+                'Rev Out': '$(SI):RF-SSAmpTower:PwrRevOut$(MR)-Mon',
+                'Gain': '$(SI):RF-SSAmpTower:PwrFwdIn$(MR)-Mon',
+            }
         },
         'SSACurr': {
             'HeatSink': {
-                'Curr': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M0$(m_num):Current$(curr_num)-Mon',
+                'Curr': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M$(m_num):Current$(curr_num)-Mon',
                 'Fwd Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdTop-Mon',
                 'Rev Top': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevTop-Mon',
                 'Fwd Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrFwdBot-Mon',
                 'Rev Bot': 'RA-ToBO:RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
             },
             'PreAmp': {
-                'HS': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M0$(m_num):Current$(curr_num)-Mon',
+                'HS': 'RA-ToBO:RF-SSAmp-H0$(hs_num)M$(m_num):Current$(curr_num)-Mon',
                 'DC': 'RA-ToBO:RF-SSAmpTower:PwrDC-Cmd'
             },
             'Pwr': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -180,6 +180,13 @@ SEC_2_CHANNELS = {
             'PreDrive': 'RA-RaBO01:RF-LLRFPreAmp:PwrFwdInAmp-Mon',
             'PreDriveThrs': 4,  # mV
         },
+        'SSADtls': {
+            'HeatSink': {
+                'Temp': 'RA-ToBO:RF-HeatSink-H0$(hs_num):T-Mon',
+                'TMS': 'RA-ToBO:RF-HeatSink-H0$(hs_num):Tms-Mon'
+            },
+            'PreAmp': 'RA-RaBO01:RF-LLRFPreAmp:T1-Mon'
+        },
         'SL': {
             'ErrDtls': {
                 'IRef': 'RA-RaBO01:RF-LLRF:SLRefI-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1961,10 +1961,12 @@ SEC_2_CHANNELS = {
                     'Rev Bot': 'RA-To$(sys)0$(NB):RF-HeatSink-H0$(hs_num):PwrRevBot-Mon'
                 },
                 'PreAmp': {
-
+                    'HS': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
+                    'PreAmp': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(PREP)PreAmp:Current$(curr_num)-Mon',
+                    'TDK': 'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
                 },
                 'Total': {
-                    
+
                 }
             },
             'B': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1962,11 +1962,37 @@ SEC_2_CHANNELS = {
                 },
                 'PreAmp': {
                     'HS': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(hs_num)PreAmp:Current$(curr_num)-Mon',
-                    'PreAmp': 'RA-To$(sys)0$(NB):RF-SSAmp-H0$(PREP)PreAmp:Current$(curr_num)-Mon',
+                    'PreAmp': 'RA-To$(sys)0$(NB):RF-SSAmp-H05PreAmp:Current$(curr_num)-Mon',
                     'TDK': 'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrDCR1-Mon'
                 },
-                'Total': {
-
+                'Offsets': {
+                    'FwdPwrTop': ['Forward Power - Top', 'RA-To$(sys)0$(NB):OffsetConfig:UpperIncidentPower'],
+                    'RevPwrTop': ['Reverse Power - Top', 'RA-To$(sys)0$(NB):OffsetConfig:UpperReflectedPower'],
+                    'FwdPwrBot': ['Forward Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerIncidentPower'],
+                    'RevPwrBot': ['Reverse Power - Bottom', 'RA-To$(sys)0$(NB):OffsetConfig:LowerReflectedPower'],
+                },
+                'Alarms': {
+                    'General': {
+                        'Label': 'General Power',
+                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimHiHi',
+                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimHigh',
+                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimLow',
+                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:GeneralPowerLimLoLo',
+                    },
+                    'Inter': {
+                        'Label': 'Intermediary Power',
+                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimHiHi',
+                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimHigh',
+                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimLow',
+                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:InnerPowerLimLoLo',
+                    },
+                    'High': {
+                        'Label': 'Current - High Limit',
+                        'HIHI': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimHiHi',
+                        'HIGH': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimHigh',
+                        'LOW': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimLow',
+                        'LOLO': 'RA-To$(sys)0$(NB):AlarmConfig:CurrentLimLoLo',
+                    },
                 }
             },
             'B': {

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1883,6 +1883,17 @@ SEC_2_CHANNELS = {
                     'RA-To$(sys)0$(NB):RF-SSAmpTower:HwPwrRevOut-Mon',
                     'RA-To$(sys)0$(NB):RF-SSAmpTower:PwrRevOutSts-Mon'
                 ],
+                'Alerts': {
+                    'PhsFlt': ['Phase Fault', 'RA-To$(sys)0$(NB):RF-ACPanel:PhsFlt-Mon'],
+                    'SSAFlwRt': ['SSA Rotameter Flow', 'RA-To$(sys)0$(NB):RF-SSAmpTower:HdFlwRt-Mon'],
+                    'LoadFlwRt': ['Load Rotameter Flow', 'RA-To$(sys)0$(NB):RF-WaterLoad:HdFlwRt-Mon'],
+                    'PnlFeed': ['AC Panel Feedback', 'RA-To$(sys)0$(NB):RF-ACPanel:Intlk-Mon'],
+                    'PnlIntlk': ['AC Panel Interlock', 'RA-To$(sys)0$(NB):RF-Intlk:IntlkACPanel-Mon'],
+                    'PnlSts': ['AC Panel Status', 'RA-To$(sys)0$(NB):RF-ACPanel:PwrACOp-Mon'],
+                    'ElecFuse': ['Electronic Fuse', 'RA-To$(sys)0$(NB):RF-CtrlPanel:PwrSts-Mon'],
+                    'PwrSup': ['24V Power Supply', 'RA-To$(sys)0$(NB):RF-ACPanel:StsPos24V-Mon'],
+                    'PwrIntlk': ['RF Power Interlock', 'RA-To$(sys)0$(NB):RF-SSAmpTower:RFPwrSts-Mon'],
+                }
             },
             'B': {
                 'Diag': {


### PR DESCRIPTION
Adds an additional detail window with more information for SSAs. This window also includes a separate window that details currents.

For the booster ring:

- SSA Details Diagnostics
![Captura de tela de 2024-09-13 11-51-05](https://github.com/user-attachments/assets/5552d880-f015-4f7b-b3e5-4d689ceda4bb)

- SSA Details Graphs
![Captura de tela de 2024-09-13 11-51-14](https://github.com/user-attachments/assets/f4b3cc8c-5e7c-49ce-a80b-d0a6cbda608a)

- SSA Currents Diagnostics
![Captura de tela de 2024-09-13 11-51-21](https://github.com/user-attachments/assets/54fb1d6f-b3cb-4a29-b6ca-b65d09cc28cf)

- SSA Currents Alarm Limits
![Captura de tela de 2024-09-13 11-51-29](https://github.com/user-attachments/assets/ed4b6361-0e29-433c-873a-ccbbd2de9721)

For the storage ring:
- SSA Details Diagnostics
![Captura de tela de 2024-09-13 11-51-46](https://github.com/user-attachments/assets/d0e67bd8-da7b-412a-b676-f2776b5e6c9a)

![Captura de tela de 2024-09-13 11-51-54](https://github.com/user-attachments/assets/87ccbe38-b3b9-4e93-99a0-924c49bf6a36)


- SSA Details Graphs
![Captura de tela de 2024-09-13 11-52-01](https://github.com/user-attachments/assets/0c9d1dbe-bdca-4148-b264-2ea6e6a2d04b)

- SSA Currents Diagnostics
![Captura de tela de 2024-09-13 11-52-10](https://github.com/user-attachments/assets/d2ed4277-0070-47ad-be4e-e8f0e69a3504)

- SSA Currents Alarm Limits
![Captura de tela de 2024-09-13 11-52-17](https://github.com/user-attachments/assets/f40f3cf6-d6bc-4e12-90cf-ece43c13c001)

