### PR TITLE
Filter the new Correctors in the PS Cycle GUI

### DIFF
--- a/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
+++ b/pyqt-apps/siriushla/as_ps_cycle/cycle_window.py
@@ -43,7 +43,9 @@ class CycleWindow(SiriusMainWindow):
         self.setWindowIcon(qta.icon('mdi.recycle', color=cor))
         self._is_adv_mode = adv_mode
         # Data structs
-        self._psnames = get_psnames(isadv=self._is_adv_mode)
+        self._psnames = Filter.process_filters(
+            get_psnames(isadv=self._is_adv_mode),
+            filters={'sub': '((?!SB).)*'})
         self._timing = Timing()
         self._ps2cycle = list()
         self._ps_ready = list()


### PR DESCRIPTION
Remove the following Correctors from the GUI:
![image](https://github.com/user-attachments/assets/41459a26-f72b-4ede-acbf-3761b3fede7b)

![image](https://github.com/user-attachments/assets/46a58acb-9874-4ddc-a5fd-7b08f18094f0)
