### PR TITLE
Fix RF PVs' position on configuration tree

### DIFF
--- a/pyqt-apps/siriushla/widgets/pvnames_tree.py
+++ b/pyqt-apps/siriushla/widgets/pvnames_tree.py
@@ -410,7 +410,6 @@ class PVNameTree(QWidget):
                 key = dic_.get(p, 'LLRF')
                 if key:
                     item_key = parent_key + key
-                    # item = self._item_map.symbol(item_key)
                     item = self._item_map[item_key] \
                         if item_key in self._item_map else None
                     if item is not None:
@@ -418,9 +417,7 @@ class PVNameTree(QWidget):
                     else:
                         new_item = QTreeItem([key], parent)
                         new_item.setCheckState(0, Qt.Unchecked)
-                        # self._item_map.add_symbol(item_key, new_item)
                         self._item_map[item_key] = new_item
-                        # parent.addChild(new_item)
                         parent = new_item
                     parent_key = item_key
         elif isinstance(pvname, SiriusPVName):

--- a/pyqt-apps/siriushla/widgets/pvnames_tree.py
+++ b/pyqt-apps/siriushla/widgets/pvnames_tree.py
@@ -403,6 +403,26 @@ class PVNameTree(QWidget):
                         # parent.addChild(new_item)
                         parent = new_item
                     parent_key = item_key
+        elif pvname.startswith('RA'):
+            sec = 'BO' if pvname.startswith('RA-RaBO') else 'SI'
+            dic_ = {'sec': sec, 'dis': 'RF', 'dev': 'LLRF'}
+            for p in self._pnames:
+                key = dic_.get(p, 'LLRF')
+                if key:
+                    item_key = parent_key + key
+                    # item = self._item_map.symbol(item_key)
+                    item = self._item_map[item_key] \
+                        if item_key in self._item_map else None
+                    if item is not None:
+                        parent = item
+                    else:
+                        new_item = QTreeItem([key], parent)
+                        new_item.setCheckState(0, Qt.Unchecked)
+                        # self._item_map.add_symbol(item_key, new_item)
+                        self._item_map[item_key] = new_item
+                        # parent.addChild(new_item)
+                        parent = new_item
+                    parent_key = item_key
         elif isinstance(pvname, SiriusPVName):
             # Parse it with SiriusPVName
             pvname = SiriusPVName(pvname)


### PR DESCRIPTION
Modified tree structure to include RF PVs inside BO and SI. For example:

![image](https://github.com/user-attachments/assets/95cc3438-cf2a-422f-a9a2-29ad37f4df8d)

![image](https://github.com/user-attachments/assets/d3a0fa71-ac41-44f2-8408-6414225e52ef)

