### PR TITLE
EVG log UTC Buffer in datetime format and subsec buffer in seconds

### DIFF
--- a/pyqt-apps/siriushla/as_ti_control/base.py
+++ b/pyqt-apps/siriushla/as_ti_control/base.py
@@ -71,8 +71,10 @@ class BaseWidget(QWidget):
             lay.setContentsMargins(0, 0, 0, 0)
         return group
 
-    def _create_logbuffer_table(self, prop):
-        table = SiriusWaveformTable(self, self.get_pvname(prop))
+    def _create_logbuffer_table(self, prop, transform=None):
+        table = SiriusWaveformTable(
+            self, self.get_pvname(prop), transform=transform
+        )
         table.setObjectName('tb')
         table.setEnabled(False)
         table.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -758,7 +758,9 @@ class EVG(BaseWidget):
             '', gbox_buf, (ld_bufutc, self.tb_bufutc))
 
         ld_bufsub = QLabel('<b>Subsec buffer</b>', self)
-        self.tb_bufsub = self._create_logbuffer_table('SUBSECbuffer')
+        func = lambda vec: vec * 8e-9  # from EVG clock to seconds
+        self.tb_bufsub = self._create_logbuffer_table(
+            prop='SUBSECbuffer', transform=func)
         gb_bufsub = self._create_small_group(
             '', gbox_buf, (ld_bufsub, self.tb_bufsub))
 

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -14,7 +14,7 @@ from pydm.widgets import PyDMLineEdit, PyDMPushButton
 from siriuspy.search import LLTimeSearch, HLTimeSearch
 from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.timesys import csdev as _cstime
-from siriuspy.devices import PV as _PV
+from siriuspy.epics import PV as _PV
 
 from ..widgets import PyDMLed, PyDMStateButton, SiriusLedState, \
     SiriusEnumComboBox, SiriusLedAlert, SiriusLabel, \

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -14,6 +14,7 @@ from pydm.widgets import PyDMLineEdit, PyDMPushButton
 from siriuspy.search import LLTimeSearch, HLTimeSearch
 from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.timesys import csdev as _cstime
+from siriuspy.devices import PV as _PV
 
 from ..widgets import PyDMLed, PyDMStateButton, SiriusLedState, \
     SiriusEnumComboBox, SiriusLedAlert, SiriusLabel, \
@@ -758,7 +759,9 @@ class EVG(BaseWidget):
             '', gbox_buf, (ld_bufutc, self.tb_bufutc))
 
         ld_bufsub = QLabel('<b>Subsec buffer</b>', self)
-        func = lambda vec: vec * 8e-9  # from EVG clock to seconds
+        rffreq = _PV("RF-Gen:GeneralFreq-RB").value
+        func = lambda vec: _np.round(vec * 4 / rffreq, decimals=10)  
+        # from EVG clock to seconds
         self.tb_bufsub = self._create_logbuffer_table(
             prop='SUBSECbuffer', transform=func)
         gb_bufsub = self._create_small_group(

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -1,6 +1,7 @@
 """."""
 import logging as _log
 import numpy as _np
+from datetime import datetime as _datetime
 
 from qtpy.QtCore import Qt, Slot
 from qtpy.QtGui import QColor, QBrush
@@ -744,7 +745,15 @@ class EVG(BaseWidget):
             '', gbox_buf, (ld_bufrst, self.bt_bufrst))
 
         ld_bufutc = QLabel('<b>UTC buffer</b>', self)
-        self.tb_bufutc = self._create_logbuffer_table('UTCbuffer')
+        fmt = "%d/%m/%y %H:%M:%S"
+        func = _np.vectorize(
+            lambda tstp: _datetime.fromtimestamp(tstp).strftime(fmt)
+            if tstp != 0
+            else 0
+        )  # from timestamp to datetime format
+        self.tb_bufutc = self._create_logbuffer_table(
+            prop='UTCbuffer', transform=func
+        )
         gb_bufutc = self._create_small_group(
             '', gbox_buf, (ld_bufutc, self.tb_bufutc))
 

--- a/pyqt-apps/siriushla/widgets/waveformtable.py
+++ b/pyqt-apps/siriushla/widgets/waveformtable.py
@@ -8,6 +8,11 @@ from pydm.widgets import PyDMWaveformTable
 class SiriusWaveformTable(PyDMWaveformTable):
     """Handle bugs for None, float and int values."""
 
+    def __init__(self, parent=None, init_channel=None, transform=None):
+        """."""
+        super().__init__(parent, init_channel)
+        self.transform = transform
+
     def value_changed(self, new_waveform):
         """
         Callback invoked when the Channel value is changed.
@@ -21,4 +26,6 @@ class SiriusWaveformTable(PyDMWaveformTable):
             return
         elif isinstance(new_waveform, (float, int)):
             new_waveform = _np.array([new_waveform])
+        if self.transform is not None:
+            new_waveform = self.transform(new_waveform)
         super().value_changed(new_waveform)


### PR DESCRIPTION
This is a workaround I found to display the EVG UTC log and subsec buffers in datetime format and seconds, respectively.

The solution is based on allowing a function to be set as the `transform` property of the `SiriusWaveformTable` class. This function is then applied to the waveform. In this case, the function is a conversion transformation.

I'm not sure if this is the easiest or most adequate solution. Pleas let me know if you have any other approach or feel free to commit on this PR.