### PR TITLE
Add RFTitleFrame and Minor Visual Tweaks

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ac_panel.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ac_panel.py
@@ -5,6 +5,7 @@ from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
     QSpacerItem
 
 from ...widgets import SiriusDialog, SiriusLabel
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -38,8 +39,12 @@ class ACPanelDetails(SiriusDialog):
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 7)
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+
+        lay.addWidget(title_frame, 0, 0, 1, 7)
         lay.addItem(QSpacerItem(0, 18, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, 0)
 
         # Phases

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adcs_dacs.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adcs_dacs.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
 
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusEnumComboBox, \
     SiriusLabel, SiriusLedState, SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -35,8 +36,12 @@ class ADCDACDetails(SiriusDialog):
         lay = QGridLayout(self)
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 9)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+        lay.addWidget(title_frame, 0, 0, 1, 9)
 
         for k, sub_dict in self.syst_dict.items():
             row = 1

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -75,10 +75,6 @@ class AdvancedInterlockDetails(SiriusDialog):
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
 
-        # General
-        gbox_gen = QGroupBox('General Controls')
-        gbox_gen.setLayout(self._genDiagLayout(chs_dict['General']))
-
         # Levels
         gbox_lvls = QGroupBox('Levels')
         lay_lvls = QGridLayout()
@@ -155,11 +151,41 @@ class AdvancedInterlockDetails(SiriusDialog):
             self, self.prefix+chs_dict['GPIO']['Out']),
             0, 0, 1, 2, alignment=Qt.AlignCenter)
 
+        # General Controls
+        gbox_gen = QGroupBox('General Controls')
+        gbox_gen.setLayout(self._genDiagLayout(chs_dict['General']))
+
+        # Quench Cond. 1
+        if self.section == 'SI':
+            gbox_quench = QGroupBox('Quench Cond. 1', self)
+            lay_quench = QGridLayout(gbox_quench)
+            lay_quench.setAlignment(Qt.AlignTop)
+            lay_quench.setSpacing(9)
+
+            rv_ch = self.prefix+chs_dict['Quench1']['Rv']
+            dly_ch = self.prefix+chs_dict['Quench1']['Dly']
+            lb_dly = SiriusLabel(self, dly_ch+'-RB')
+            lb_dly.showUnits = True
+
+            lay_quench.addWidget(QLabel(
+                'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+            lay_quench.addWidget(SiriusSpinbox(
+                self, rv_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
+            lay_quench.addWidget(SiriusLabel(
+                self, self.prefix+rv_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
+            lay_quench.addWidget(QLabel(
+                'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+            lay_quench.addWidget(SiriusSpinbox(
+                self, dly_ch+'-SP'), 1, 1, alignment=Qt.AlignCenter)
+            lay_quench.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
+
         lay.addWidget(gbox_lvls, 0, 0)
         lay.addWidget(gbox_inp, 0, 1)
         lay.addWidget(gbox_intlk, 0, 2)
         lay.addWidget(gbox_out, 0, 3)
         lay.addWidget(gbox_gen, 1, 0, 1, 2)
+        if self.section == 'SI':
+            lay.addWidget(gbox_quench, 1, 2, 1, 2)
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -209,7 +209,6 @@ class AdvancedInterlockDetails(SiriusDialog):
         lb_curr.showUnits = True
         lb_delta = SiriusLabel(self, self.prefix+chs_dict['Curr Delta']+'-RB')
         lb_delta.showUnits = True
-        lb_delta.setStyleSheet('background-color: white')
 
         lay.addWidget(QLabel(
             '<h4>Readback</h4>', alignment=Qt.AlignCenter), 0, 1)
@@ -237,7 +236,7 @@ class AdvancedInterlockDetails(SiriusDialog):
             '<h4>Offset</h4>', alignment=Qt.AlignCenter), 3, 5, 1, 2)
 
         # # Body
-        keys = ['Rev Cav', 'Fwd Cav', 'Quench']
+        keys = ['Fwd Cav', 'Rev Cav', 'Quench']
         row = 4
         for key in keys:
             chs = chs_dict[key]
@@ -251,10 +250,10 @@ class AdvancedInterlockDetails(SiriusDialog):
 
             lay_enable = QHBoxLayout()
             lay_enable.addWidget(PyDMStateButton(
-                self, self.prefix+chs['Enable']+'-SP'),
+                self, self.prefix+chs['Enable']+'-Sel'),
                 alignment=Qt.AlignCenter)
             lay_enable.addWidget(SiriusLedState(
-                self, self.prefix+chs['Enable']+'-RB'),
+                self, self.prefix+chs['Enable']+'-Sts'),
                 alignment=Qt.AlignCenter)
 
             lay.addWidget(QLabel(f'<h4>{chs["Label"]}</h4>',
@@ -271,6 +270,12 @@ class AdvancedInterlockDetails(SiriusDialog):
             lay.addWidget(lb_ofs, row, 6, alignment=Qt.AlignCenter)
 
             row += 1
+
+        lay.addItem(QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
+        lay.addWidget(QLabel(
+            "Out = Coef * Current + Offset",
+            alignment=Qt.AlignCenter), row+1, 0, 1, 2)
+        row += 2
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, \
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusLabel, \
     SiriusLedAlert, SiriusLedState, SiriusLineEdit, SiriusPushButton, \
     SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -36,6 +37,12 @@ class AdvancedInterlockDetails(SiriusDialog):
         self.setStyleSheet(DEFAULT_STYLESHEET)
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -49,17 +56,17 @@ class AdvancedInterlockDetails(SiriusDialog):
             self._diagnosticsLayout(self.syst_dict['Diagnostics']))
         dtls.addTab(wid_diag, 'Diagnostics')
 
-        wid_dyn = QWidget(self)
-        wid_dyn.setLayout(
-            self._dynamicInterlockLayout(self.syst_dict['Dynamic']))
-        dtls.addTab(wid_dyn, 'Dynamic Interlock')
+        if self.section == 'SI':
+            wid_dyn = QWidget(self)
+            wid_dyn.setLayout(
+                self._dynamicInterlockLayout(self.syst_dict['Dynamic']))
+            dtls.addTab(wid_dyn, 'Dynamic Interlock')
 
         wid_bypass = QWidget(self)
         wid_bypass.setLayout(self._bypassLayout(self.syst_dict['Bypass']))
         dtls.addTab(wid_bypass, 'Interlock Bypass')
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _diagnosticsLayout(self, chs_dict):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -156,36 +156,34 @@ class AdvancedInterlockDetails(SiriusDialog):
         gbox_gen.setLayout(self._genDiagLayout(chs_dict['General']))
 
         # Quench Cond. 1
-        if self.section == 'SI':
-            gbox_quench = QGroupBox('Quench Cond. 1', self)
-            lay_quench = QGridLayout(gbox_quench)
-            lay_quench.setAlignment(Qt.AlignTop)
-            lay_quench.setSpacing(9)
+        gbox_quench = QGroupBox('Quench Cond. 1', self)
+        lay_quench = QGridLayout(gbox_quench)
+        lay_quench.setAlignment(Qt.AlignTop)
+        lay_quench.setSpacing(9)
 
-            rv_ch = self.prefix+chs_dict['Quench1']['Rv']
-            dly_ch = self.prefix+chs_dict['Quench1']['Dly']
-            lb_dly = SiriusLabel(self, dly_ch+'-RB')
-            lb_dly.showUnits = True
+        rv_ch = self.prefix+chs_dict['Quench1']['Rv']
+        dly_ch = self.prefix+chs_dict['Quench1']['Dly']
+        lb_dly = SiriusLabel(self, dly_ch+'-RB')
+        lb_dly.showUnits = True
 
-            lay_quench.addWidget(QLabel(
-                'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-            lay_quench.addWidget(SiriusSpinbox(
-                self, rv_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(SiriusLabel(
-                self, self.prefix+rv_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(QLabel(
-                'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-            lay_quench.addWidget(SiriusSpinbox(
-                self, dly_ch+'-SP'), 1, 1, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
+        lay_quench.addWidget(QLabel(
+            'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        lay_quench.addWidget(SiriusSpinbox(
+            self, rv_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
+        lay_quench.addWidget(SiriusLabel(
+            self, self.prefix+rv_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
+        lay_quench.addWidget(QLabel(
+            'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        lay_quench.addWidget(SiriusSpinbox(
+            self, dly_ch+'-SP'), 1, 1, alignment=Qt.AlignCenter)
+        lay_quench.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
 
         lay.addWidget(gbox_lvls, 0, 0)
         lay.addWidget(gbox_inp, 0, 1)
         lay.addWidget(gbox_intlk, 0, 2)
         lay.addWidget(gbox_out, 0, 3)
         lay.addWidget(gbox_gen, 1, 0, 1, 2)
-        if self.section == 'SI':
-            lay.addWidget(gbox_quench, 1, 2, 1, 2)
+        lay.addWidget(gbox_quench, 1, 2, 1, 2)
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -1,5 +1,6 @@
 """Advanced details related to interlocks."""
 
+from pydm.widgets import PyDMLabel
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, \
     QScrollArea, QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, \
@@ -212,9 +213,9 @@ class AdvancedInterlockDetails(SiriusDialog):
         lay.setSpacing(9)
 
         # Current
-        lb_curr = SiriusLabel(self, self.prefix+chs_dict['Curr'])
+        lb_curr = PyDMLabel(self, self.prefix+chs_dict['Curr'])
         lb_curr.showUnits = True
-        lb_delta = SiriusLabel(self, self.prefix+chs_dict['Curr Delta']+'-RB')
+        lb_delta = PyDMLabel(self, self.prefix+chs_dict['Curr Delta']+'-RB')
         lb_delta.showUnits = True
 
         lay.addWidget(QLabel(
@@ -248,11 +249,11 @@ class AdvancedInterlockDetails(SiriusDialog):
         for key in keys:
             chs = chs_dict[key]
 
-            lb_value = SiriusLabel(self, self.prefix+chs['Value'])
+            lb_value = PyDMLabel(self, self.prefix+chs['Value'])
             lb_value.showUnits = True
-            lb_coeff = SiriusLabel(self, self.prefix+chs['Coeff']+'-RB')
+            lb_coeff = PyDMLabel(self, self.prefix+chs['Coeff']+'-RB')
             lb_coeff.showUnits = True
-            lb_ofs = SiriusLabel(self, self.prefix+chs['Offset']+'-RB')
+            lb_ofs = PyDMLabel(self, self.prefix+chs['Offset']+'-RB')
             lb_ofs.showUnits = True
 
             lay_enable = QHBoxLayout()
@@ -265,7 +266,7 @@ class AdvancedInterlockDetails(SiriusDialog):
 
             lay.addWidget(QLabel(f'<h4>{chs["Label"]}</h4>',
                 alignment=Qt.AlignRight | Qt.AlignVCenter), row, 0)
-            lay.addWidget(lb_value, row, 1)
+            lay.addWidget(lb_value, row, 1, alignment=Qt.AlignCenter)
             lay.addLayout(lay_enable, row, 2)
             lay.addWidget(SiriusLineEdit(
                 self, self.prefix+chs['Coeff']+'-SP'),
@@ -280,7 +281,7 @@ class AdvancedInterlockDetails(SiriusDialog):
 
         lay.addItem(QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
         lay.addWidget(QLabel(
-            "Out = Coef * Current + Offset",
+            "Out = Coeff * Current + Offset",
             alignment=Qt.AlignCenter), row+1, 0, 1, 2)
         row += 2
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/auto_start.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/auto_start.py
@@ -5,6 +5,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QVBoxLayout
 
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusEnumComboBox, \
     SiriusLabel, SiriusLedAlert, SiriusLedState
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -34,6 +35,12 @@ class AutoStartDetails(SiriusDialog):
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
+
+        # Title
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
 
         # General
         gbox_gen = QGroupBox('General')
@@ -75,8 +82,7 @@ class AutoStartDetails(SiriusDialog):
             self._setupLabelLed(diag_lay, key, val, row, key == '401')
             row += 1
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(gbox_gen)
         lay.addWidget(gbox_diag)
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/cal_eq.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/cal_eq.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, \
     QSizePolicy as QSzPlcy, QSpacerItem
 
 from ...widgets import SiriusDialog, SiriusLabel
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -36,8 +37,11 @@ class CalEqDetails(SiriusDialog):
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 3)
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+        lay.addWidget(title_frame, 0, 0, 1, 3)
 
         row = 1
         column = 0

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/cal_sys.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/cal_sys.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QCheckBox, QComboBox, QGridLayout, QHBoxLayout, \
 
 from ...widgets import SiriusDialog, SiriusLabel, SiriusLineEdit, \
     SiriusTimePlot
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -36,6 +37,12 @@ class CalSysDetails(SiriusDialog):
         self.setStyleSheet(DEFAULT_STYLESHEET)
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -58,8 +65,7 @@ class CalSysDetails(SiriusDialog):
         wid_iq.setLayout(self._graphLayout())
         dtls.addTab(wid_iq, 'Graph')
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _signalsLayout(self):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/hardware.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/hardware.py
@@ -1,6 +1,7 @@
 """Advanced details related to the hardware."""
 
 from pydm.widgets import PyDMEnumComboBox
+from pydm.widgets.display_format import DisplayFormat
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QVBoxLayout
 
@@ -157,6 +158,9 @@ class HardwareDetails(SiriusDialog):
         for key, val in chs_dict.items():
             lb_value = SiriusLabel(self, self.prefix+val)
             lb_value.showUnits = True
+            if key == 'Firmware':
+                lb_value.displayFormat = DisplayFormat.Hex
+
             lay.addWidget(QLabel(key, alignment=Qt.AlignRight), row, 0)
             lay.addWidget(lb_value, row, 1)
             row += 1

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/hardware.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/hardware.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QVBoxLayout
 
 from ...widgets import SiriusDialog, SiriusLabel, SiriusLedAlert, \
     SiriusLedState, SiriusPushButton, SiriusScaleIndicator
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -37,8 +38,11 @@ class HardwareDetails(SiriusDialog):
         lay.setHorizontalSpacing(18)
         lay.setVerticalSpacing(9)
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 5)
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame, 0, 0, 1, 5)
 
         # FPGA Temps
         gbox_fpga = QGroupBox('FPGA Temps', self)

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/limits.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/limits.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QLabel
 
 from ...widgets import SiriusDialog, SiriusLabel, SiriusLineEdit, SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -38,8 +39,12 @@ class LimitsDetails(SiriusDialog):
         lay = QGridLayout(self)
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 4)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+        lay.addWidget(title_frame, 0, 0, 1, 4)
 
         row = 1
         for key, val in self.syst_dict.items():

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/loops.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/loops.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, \
 from ...util import connect_window
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusEnumComboBox, \
     SiriusLabel, SiriusLedState, SiriusPushButton, SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 from .limits import LimitsDetails
 
@@ -38,6 +39,12 @@ class LoopsDetails(SiriusDialog):
         self.setStyleSheet(DEFAULT_STYLESHEET)
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -58,8 +65,7 @@ class LoopsDetails(SiriusDialog):
         wid_polar.setLayout(self._specificLoopsLayout('Polar'))
         dtls.addTab(wid_polar, 'Polar Loops')
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _loopsControlLayout(self):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ramps.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QPushButton, \
 from ...util import connect_window
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusLabel, \
     SiriusLedState, SiriusSpinbox, SiriusTimePlot
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 from .limits import LimitsDetails
 
@@ -46,6 +47,11 @@ class RampsDetails(SiriusDialog):
             "    border-bottom: 2px solid gray;"
             "    border-right: 2px solid gray;}")
 
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
         wid_controls = QWidget(self)
         wid_controls.setLayout(
             self._rampsControlLayout(self.syst_dict['Control']))
@@ -56,8 +62,7 @@ class RampsDetails(SiriusDialog):
             self._diagnosticsRampLayout(self.syst_dict['Diagnostics']))
         dtls.addTab(wid_top, 'Ramp Diagnostics')
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _rampsControlLayout(self, chs_dict):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
@@ -5,6 +5,7 @@ from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
     QSpacerItem
 
 from ...widgets import SiriusDialog, SiriusLabel
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -36,8 +37,12 @@ class RFInputsDetails(SiriusDialog):
         lay.setVerticalSpacing(9)
         lay.setHorizontalSpacing(18)
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 9)
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+        lay.addWidget(title_frame, 0, 0, 1, 9)
+
         lay.addWidget(QLabel('In-Phase', alignment=Qt.AlignCenter), 1, 2)
         lay.addWidget(QLabel('Quadrature', alignment=Qt.AlignCenter), 1, 3)
         lay.addWidget(QLabel('Amp', alignment=Qt.AlignCenter), 1, 4)

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QHBoxLayout, QLabel, \
     QVBoxLayout, QWidget
 
 from ...widgets import SiriusDialog, SiriusLabel, SiriusLedState, SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -39,6 +40,11 @@ class SSACurrentsDetails(SiriusDialog):
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
 
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QHBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -55,8 +61,7 @@ class SSACurrentsDetails(SiriusDialog):
         wid_graphs.setLayout(self._setupAlarmLay())
         dtls.addTab(wid_graphs, 'Alarm Limits')
 
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _setupDiagLay(self):

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/tuning.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/tuning.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, \
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusEnumComboBox, \
     SiriusLabel, SiriusLedAlert, SiriusLedState, SiriusPushButton, \
     SiriusSpinbox
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -37,8 +38,12 @@ class TuningDetails(SiriusDialog):
         lay = QGridLayout(self)
         lay.setAlignment(Qt.AlignTop)
         lay.setSpacing(9)
-        lay.addWidget(QLabel(
-            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0, 1, 3)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QGridLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter), 0, 0)
+        lay.addWidget(title_frame, 0, 0, 1, 3)
 
         gbox_gen = QGroupBox('General')
         gbox_gen.setLayout(self._generalLayout(self.syst_dict['General']))

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -16,7 +16,7 @@ from ..widgets import PyDMLed, PyDMLedMultiChannel, PyDMStateButton, \
     SiriusConnectionSignal, SiriusLabel, SiriusLedAlert, SiriusLedState, \
     SiriusMainWindow, SiriusPushButton, SiriusSpinbox, SiriusTimePlot, \
     SiriusWaveformPlot
-from .custom_widgets import RFEnblDsblButton
+from .custom_widgets import RFEnblDsblButton, RFTitleFrame
 from .util import DEFAULT_STYLESHEET, SEC_2_CHANNELS, SYSTEM_COLORS
 
 
@@ -1751,9 +1751,11 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_slc_lay(self, lay_slc, key, chs_dict, offset):
         if key:
-            lay_slc.addWidget(QLabel(
-                f'<h4>{key}<h4>', self, alignment=Qt.AlignRight),
-                1, offset)
+            frame_key = RFTitleFrame(system=key)
+            frame_lay = QHBoxLayout(frame_key)
+            frame_lay.addWidget(QLabel(
+                f'<h4>{key}</h4>', alignment=Qt.AlignCenter))
+            lay_slc.addWidget(frame_key, 1, offset, 1, 2)
 
         lb_slmode = SiriusLabel(
             self, self.prefix+chs_dict['Mode']+'-Sts')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -530,6 +530,7 @@ class RFMainControl(SiriusMainWindow):
             offset = 2
             for key, chs_dict in self.chs['Tun'].items():
                 lb_plg = QLabel(key, alignment=Qt.AlignCenter)
+                lb_plg.setStyleSheet(f'background-color: {SYSTEM_COLORS[key]}')
                 led_plg_dn = PyDMLed(
                     self, self.prefix+chs_dict['Pl1Down'])
                 led_plg_dn.offColor = QColor(64, 64, 64)
@@ -1622,9 +1623,11 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_tun_set_wid(self, lay_tunset, column, chs_dict, offset):
         if column:
-            lay_tunset.addWidget(QLabel(
-                f'<h4>{column}</h4>', self, alignment=Qt.AlignCenter),
-                0, offset)
+            frame_title = RFTitleFrame(system=column)
+            frame_lay = QHBoxLayout(frame_title)
+            frame_lay.addWidget(QLabel(
+                f'<h4>{column}</h4>', self, alignment=Qt.AlignCenter))
+            lay_tunset.addWidget(frame_title, 0, offset)
 
         bt_autotun = PyDMStateButton(
             self, self.prefix+chs_dict['Auto']+'-Sel')
@@ -1715,12 +1718,16 @@ class RFMainControl(SiriusMainWindow):
             pb_fdldtls, cmd.split(" "), is_window=True, parent=self)
 
         if key:
-            title = key
+            frame_title = RFTitleFrame(system=key)
+            frame_lay = QHBoxLayout(frame_title)
+            frame_lay.addWidget(QLabel(f'<h4> • {key} - Amplitude</h4>',
+                self, alignment=Qt.AlignLeft | Qt.AlignVCenter))
+            frame_lay.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
+            lay_section.addWidget(frame_title)
         else:
-            title = 'FDL Data'
-        lay_section.addWidget(QLabel(
-            f'<h4> • {title} - Amplitude</h4>', self, alignment=Qt.AlignLeft))
-        lay_section.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
+            lay_section.addWidget(QLabel('<h4> • FDL Data - Amplitude</h4>',
+                self, alignment=Qt.AlignLeft))
+            lay_section.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
 
         lay_fdl.addLayout(lay_section)
         lay_fdl.addLayout(lay_checks)
@@ -1728,11 +1735,11 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_diag_lay(self, lay_diag, key, chs, column):
         if key is not None:
-            lay_diag.addWidget(QLabel(
-                f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
-                0, column, 1, 2)
-            lay_diag.addItem(QSpacerItem(
-                0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, column)
+            frame_diag = RFTitleFrame(system=key)
+            frame_lay = QHBoxLayout(frame_diag)
+            frame_lay.addWidget(QLabel(
+                f'<h4>{key}</h4>', alignment=Qt.AlignCenter))
+            lay_diag.addWidget(frame_diag, 0, column, 1, 2)
         else:
             lay_diag.addItem(QSpacerItem(
                 0, 18, QSzPlcy.Ignored, QSzPlcy.Fixed), 0, column)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -17,7 +17,7 @@ from ..widgets import PyDMLed, PyDMLedMultiChannel, PyDMStateButton, \
     SiriusMainWindow, SiriusPushButton, SiriusSpinbox, SiriusTimePlot, \
     SiriusWaveformPlot
 from .custom_widgets import RFEnblDsblButton
-from .util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
+from .util import DEFAULT_STYLESHEET, SEC_2_CHANNELS, SYSTEM_COLORS
 
 
 class RFMainControl(SiriusMainWindow):
@@ -1239,15 +1239,23 @@ class RFMainControl(SiriusMainWindow):
             for key, val in self.chs['CavVGap'].items():
                 ld_cavvgap = QLabel(
                     f'Gap Voltage {key}:', self, alignment=Qt.AlignCenter)
-                ld_cavvgap.setStyleSheet('QLabel{font-size: 15pt;}')
+                ld_cavvgap.setStyleSheet(
+                    f"""QLabel{{font-size: 15pt; background-color:
+                     {SYSTEM_COLORS[key]}}}""")
                 lb_cavvgap = SiriusLabel(self, self.prefix+val)
-                lb_cavvgap.setStyleSheet('QLabel{font-size: 15pt;}')
+                lb_cavvgap.setStyleSheet(
+                    f"""QLabel{{font-size: 15pt; background-color:
+                     {SYSTEM_COLORS[key]}}}""")
                 lb_cavvgap.showUnits = True
                 lbl_refvol = QLabel(
                     f'Ref Voltage {key}:', self, alignment=Qt.AlignCenter)
+                lbl_refvol.setStyleSheet(
+                    f'background-color: {SYSTEM_COLORS[key]}')
                 rb_refvol = SiriusLabel(
                     self, self.prefix+self.chs['SL']['ASet'][key]+'-RB')
                 rb_refvol.showUnits = True
+                rb_refvol.setStyleSheet(
+                    f'background-color: {SYSTEM_COLORS[key]}')
                 lay_cavvgap.addWidget(ld_cavvgap, offset, 0)
                 lay_cavvgap.addWidget(lb_cavvgap, offset, 1)
                 lay_cavvgap.addWidget(lbl_refvol, offset+1, 0)

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -7,8 +7,8 @@ from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
 from pyqtgraph import InfiniteLine, mkPen
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QCheckBox, QComboBox, QGridLayout, QGroupBox, \
-    QHBoxLayout, QLabel, QPushButton, QRadioButton, QScrollArea, \
+from qtpy.QtWidgets import QCheckBox, QComboBox, QFrame, QGridLayout, \
+    QGroupBox, QHBoxLayout, QLabel, QPushButton, QRadioButton, QScrollArea, \
     QSizePolicy as QSzPlcy, QSpacerItem, QTabWidget, QVBoxLayout, QWidget
 
 from ..util import connect_newprocess, get_appropriate_color
@@ -420,9 +420,14 @@ class RFMainControl(SiriusMainWindow):
         # # Slow Loop Control
         wid_sl = QWidget()
         lay_slc = QGridLayout(wid_sl)
-        lay_slc.setAlignment(Qt.AlignTop | Qt.AlignHCenter)
+        lay_slc.setAlignment(Qt.AlignTop)
         lay_slc.setVerticalSpacing(6)
         lay_slc.setHorizontalSpacing(20)
+
+        if self.section == 'BO':
+            lay_slc.setColumnStretch(0, 1)
+            lay_slc.setColumnStretch(1, 2)
+            lay_slc.setColumnStretch(2, 2)
 
         lay_slc.addWidget(QLabel(
             '<h4>Mode</h4>', self, alignment=Qt.AlignCenter), 2, 0)
@@ -446,7 +451,13 @@ class RFMainControl(SiriusMainWindow):
         offset = 1
         if self.section == 'SI':
             for key, chs_dict in self.chs['SL']['Over'].items():
-                self._create_slc_lay(lay_slc, key, chs_dict, offset)
+                line = QFrame()
+                line.setFrameShape(QFrame.VLine)
+                line.setFrameShadow(QFrame.Plain)
+                line.setLineWidth(2)
+                line.setStyleSheet('color: gray')
+                lay_slc.addWidget(line, 0, offset, 17, 1)
+                self._create_slc_lay(lay_slc, key, chs_dict, offset+1)
                 offset += 3
         else:
             self._create_slc_lay(lay_slc, None, self.chs['SL']['Over'], 1)
@@ -473,7 +484,7 @@ class RFMainControl(SiriusMainWindow):
         lay_details.addWidget(self.pb_errdtls, alignment=Qt.AlignCenter)
         lay_details.addWidget(self.pb_paramdtls, alignment=Qt.AlignCenter)
 
-        lay_slc.addWidget(gbox_details, 17, 0, 2, offset)
+        lay_slc.addWidget(gbox_details, 17, 0, 1, offset)
 
         # # Tuning
         # # # Tuning settings

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -16,8 +16,8 @@ from ..widgets import PyDMLed, PyDMLedMultiChannel, PyDMStateButton, \
     SiriusConnectionSignal, SiriusLabel, SiriusLedAlert, SiriusLedState, \
     SiriusMainWindow, SiriusPushButton, SiriusSpinbox, SiriusTimePlot, \
     SiriusWaveformPlot
-from .custom_widgets import RFEnblDsblButton, RFTitleFrame
-from .util import DEFAULT_STYLESHEET, SEC_2_CHANNELS, SYSTEM_COLORS
+from .custom_widgets import RFEnblDsblButton
+from .util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
 class RFMainControl(SiriusMainWindow):
@@ -530,7 +530,6 @@ class RFMainControl(SiriusMainWindow):
             offset = 2
             for key, chs_dict in self.chs['Tun'].items():
                 lb_plg = QLabel(key, alignment=Qt.AlignCenter)
-                lb_plg.setStyleSheet(f'background-color: {SYSTEM_COLORS[key]}')
                 led_plg_dn = PyDMLed(
                     self, self.prefix+chs_dict['Pl1Down'])
                 led_plg_dn.offColor = QColor(64, 64, 64)
@@ -1240,23 +1239,15 @@ class RFMainControl(SiriusMainWindow):
             for key, val in self.chs['CavVGap'].items():
                 ld_cavvgap = QLabel(
                     f'Gap Voltage {key}:', self, alignment=Qt.AlignCenter)
-                ld_cavvgap.setStyleSheet(
-                    f"""QLabel{{font-size: 15pt; background-color:
-                     {SYSTEM_COLORS[key]}}}""")
+                ld_cavvgap.setStyleSheet('QLabel{font-size: 15pt;}')
                 lb_cavvgap = SiriusLabel(self, self.prefix+val)
-                lb_cavvgap.setStyleSheet(
-                    f"""QLabel{{font-size: 15pt; background-color:
-                     {SYSTEM_COLORS[key]}}}""")
+                lb_cavvgap.setStyleSheet('QLabel{font-size: 15pt;}')
                 lb_cavvgap.showUnits = True
                 lbl_refvol = QLabel(
                     f'Ref Voltage {key}:', self, alignment=Qt.AlignCenter)
-                lbl_refvol.setStyleSheet(
-                    f'background-color: {SYSTEM_COLORS[key]}')
                 rb_refvol = SiriusLabel(
                     self, self.prefix+self.chs['SL']['ASet'][key]+'-RB')
                 rb_refvol.showUnits = True
-                rb_refvol.setStyleSheet(
-                    f'background-color: {SYSTEM_COLORS[key]}')
                 lay_cavvgap.addWidget(ld_cavvgap, offset, 0)
                 lay_cavvgap.addWidget(lb_cavvgap, offset, 1)
                 lay_cavvgap.addWidget(lbl_refvol, offset+1, 0)
@@ -1623,11 +1614,9 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_tun_set_wid(self, lay_tunset, column, chs_dict, offset):
         if column:
-            frame_title = RFTitleFrame(system=column)
-            frame_lay = QHBoxLayout(frame_title)
-            frame_lay.addWidget(QLabel(
-                f'<h4>{column}</h4>', self, alignment=Qt.AlignCenter))
-            lay_tunset.addWidget(frame_title, 0, offset)
+            lay_tunset.addWidget(QLabel(
+                f'<h4>{column}</h4>', self, alignment=Qt.AlignCenter),
+                0, offset)
 
         bt_autotun = PyDMStateButton(
             self, self.prefix+chs_dict['Auto']+'-Sel')
@@ -1718,16 +1707,12 @@ class RFMainControl(SiriusMainWindow):
             pb_fdldtls, cmd.split(" "), is_window=True, parent=self)
 
         if key:
-            frame_title = RFTitleFrame(system=key)
-            frame_lay = QHBoxLayout(frame_title)
-            frame_lay.addWidget(QLabel(f'<h4> • {key} - Amplitude</h4>',
-                self, alignment=Qt.AlignLeft | Qt.AlignVCenter))
-            frame_lay.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
-            lay_section.addWidget(frame_title)
+            title = key
         else:
-            lay_section.addWidget(QLabel('<h4> • FDL Data - Amplitude</h4>',
-                self, alignment=Qt.AlignLeft))
-            lay_section.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
+            title = 'FDL Data'
+        lay_section.addWidget(QLabel(
+            f'<h4> • {title} - Amplitude</h4>', self, alignment=Qt.AlignLeft))
+        lay_section.addWidget(pb_fdldtls, alignment=Qt.AlignRight)
 
         lay_fdl.addLayout(lay_section)
         lay_fdl.addLayout(lay_checks)
@@ -1735,11 +1720,11 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_diag_lay(self, lay_diag, key, chs, column):
         if key is not None:
-            frame_diag = RFTitleFrame(system=key)
-            frame_lay = QHBoxLayout(frame_diag)
-            frame_lay.addWidget(QLabel(
-                f'<h4>{key}</h4>', alignment=Qt.AlignCenter))
-            lay_diag.addWidget(frame_diag, 0, column, 1, 2)
+            lay_diag.addWidget(QLabel(
+                f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
+                0, column, 1, 2)
+            lay_diag.addItem(QSpacerItem(
+                0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, column)
         else:
             lay_diag.addItem(QSpacerItem(
                 0, 18, QSzPlcy.Ignored, QSzPlcy.Fixed), 0, column)
@@ -1758,11 +1743,8 @@ class RFMainControl(SiriusMainWindow):
 
     def _create_slc_lay(self, lay_slc, key, chs_dict, offset):
         if key:
-            frame_key = RFTitleFrame(system=key)
-            frame_lay = QHBoxLayout(frame_key)
-            frame_lay.addWidget(QLabel(
-                f'<h4>{key}</h4>', alignment=Qt.AlignCenter))
-            lay_slc.addWidget(frame_key, 1, offset, 1, 2)
+            lay_slc.addWidget(QLabel(
+                f'<h4>{key}</h4>', alignment=Qt.AlignCenter), 1, offset, 1, 2)
 
         lb_slmode = SiriusLabel(
             self, self.prefix+chs_dict['Mode']+'-Sts')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -691,13 +691,18 @@ class RFMainControl(SiriusMainWindow):
         lay_diag = QGridLayout(wid_diag)
         lay_diag.setAlignment(Qt.AlignTop)
         lay_diag.setSpacing(9)
+
+        add_labels = True
         if self.section == 'SI':
             column = 1
             for k, chs in self.chs['Diagnostics'].items():
-                self._create_diag_lay(lay_diag, k, chs, column)
-                column += 2
+                self._create_diag_lay(lay_diag, k, chs, column, add_labels)
+                if add_labels:
+                    add_labels = False
+                column += 1
         else:
-            self._create_diag_lay(lay_diag, None, self.chs['Diagnostics'], 0)
+            self._create_diag_lay(
+                lay_diag, None, self.chs['Diagnostics'], 1, add_labels)
 
         # # FDL
         wid_fdl = QWidget()
@@ -1718,11 +1723,19 @@ class RFMainControl(SiriusMainWindow):
         lay_fdl.addLayout(lay_checks)
         lay_fdl.addWidget(self.amp_graph)
 
-    def _create_diag_lay(self, lay_diag, key, chs, column):
+    def _create_diag_lay(self, lay_diag, key, chs, column, add_labels):
+        if add_labels:
+            row = 2
+            for _, val in chs.items():
+                lay_diag.addWidget(
+                    QLabel(val[0], alignment=Qt.AlignRight | Qt.AlignVCenter),
+                    row, column-1)
+                row += 1
+
         if key is not None:
             lay_diag.addWidget(QLabel(
                 f'<h4>{key}</h4>', alignment=Qt.AlignCenter),
-                0, column, 1, 2)
+                0, column)
             lay_diag.addItem(QSpacerItem(
                 0, 9, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, column)
         else:
@@ -1735,10 +1748,7 @@ class RFMainControl(SiriusMainWindow):
                 led = SiriusLedAlert(self, self.prefix+val[1])
             else:
                 led = SiriusLedState(self, self.prefix+val[1])
-            lay_diag.addWidget(QLabel(
-                val[0], alignment=Qt.AlignRight), row, column)
-            lay_diag.addWidget(led, row, column+1,
-                alignment=Qt.AlignCenter)
+            lay_diag.addWidget(led, row, column, alignment=Qt.AlignCenter)
             row += 1
 
     def _create_slc_lay(self, lay_slc, key, chs_dict, offset):

--- a/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
+++ b/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
@@ -1,7 +1,7 @@
-
-
-from qtpy.QtWidgets import QHBoxLayout, QWidget
+from qtpy.QtWidgets import QFrame, QHBoxLayout, QWidget
 from siriushla.widgets import SiriusPushButton
+
+from .util import SYSTEM_COLORS
 
 
 class RFEnblDsblButton(QWidget):
@@ -24,3 +24,15 @@ class RFEnblDsblButton(QWidget):
         lay.addWidget(self.pb_off)
         lay.addWidget(self.pb_on)
         lay.addStretch()
+
+
+class RFTitleFrame(QFrame):
+    """QFrame with background color set depending on the specific system."""
+
+    def __init__(self, parent=None, system=None):
+        super().__init__(parent)
+        if system is not None:
+            self.setStyleSheet(f"""
+                background-color: {SYSTEM_COLORS[system]};
+                margin: 2px
+            """)

--- a/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
+++ b/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
@@ -32,7 +32,4 @@ class RFTitleFrame(QFrame):
     def __init__(self, parent=None, system=None):
         super().__init__(parent)
         if system is not None:
-            self.setStyleSheet(f"""
-                background-color: {SYSTEM_COLORS[system]};
-                margin: 2px
-            """)
+            self.setStyleSheet(f'background-color: {SYSTEM_COLORS[system]};')

--- a/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
+++ b/pyqt-apps/siriushla/as_rf_control/custom_widgets.py
@@ -29,7 +29,7 @@ class RFEnblDsblButton(QWidget):
 class RFTitleFrame(QFrame):
     """QFrame with background color set depending on the specific system."""
 
-    def __init__(self, parent=None, system=None):
+    def __init__(self, parent=None, system=''):
         super().__init__(parent)
-        if system is not None:
+        if system != '':
             self.setStyleSheet(f'background-color: {SYSTEM_COLORS[system]};')

--- a/pyqt-apps/siriushla/as_rf_control/details/fdl.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/fdl.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QCheckBox, QComboBox, QGridLayout, QGroupBox, \
 from ...widgets import PyDMStateButton, SiriusDialog, SiriusLabel, \
     SiriusLedAlert, SiriusLedState, SiriusLineEdit, SiriusPushButton, \
     SiriusSpinbox, SiriusWaveformPlot
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -39,7 +40,9 @@ class FDLDetails(SiriusDialog):
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
 
-        lay.addWidget(QLabel(
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QHBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
             f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
 
         controls = QGroupBox('Controls', self)
@@ -48,6 +51,7 @@ class FDLDetails(SiriusDialog):
         graphs = QGroupBox('Graphs', self)
         graphs.setLayout(self._graphsLayout())
 
+        lay.addWidget(title_frame)
         lay.addWidget(controls)
         lay.addWidget(graphs)
 

--- a/pyqt-apps/siriushla/as_rf_control/details/interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/interlock.py
@@ -52,12 +52,12 @@ class LLRFInterlockDetails(SiriusDialog):
         if self.section == 'SI':
             offset = 1
             for key, chs_dict in self.chs['LLRF Intlk Details'].items():
-                self._setupDetails(lay_scr, key, chs_dict, offset)
+                self._setupDetails(lay_scr, chs_dict, offset, key)
                 offset += 4
         else:
-            self._setupDetails(lay_scr, None, self.chs['LLRF Intlk Details'], 1)
+            self._setupDetails(lay_scr, self.chs['LLRF Intlk Details'], 1)
 
-    def _setupDetails(self, lay, system, chs_dict, offset):
+    def _setupDetails(self, lay, chs_dict, offset, system=''):
         if system:
             lay.addWidget(QLabel(
                 f'<h4>LLRF {system}</h4>', self,

--- a/pyqt-apps/siriushla/as_rf_control/details/interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/interlock.py
@@ -53,7 +53,7 @@ class LLRFInterlockDetails(SiriusDialog):
             offset = 1
             for key, chs_dict in self.chs['LLRF Intlk Details'].items():
                 self._setupDetails(lay_scr, chs_dict, offset, key)
-                offset += 4
+                offset += 3
         else:
             self._setupDetails(lay_scr, self.chs['LLRF Intlk Details'], 1)
 
@@ -94,7 +94,7 @@ class LLRFInterlockDetails(SiriusDialog):
                 lbl.setStyleSheet('QLabel{min-width:12em;}')
                 lay_intlk.addWidget(lbl, irow, icol)
 
-            lay.addWidget(gbox, offset+1, col, 3, 1)
+            lay.addWidget(gbox, offset+1, col, 2, 1)
             col += 1
 
         # timestamps
@@ -113,31 +113,6 @@ class LLRFInterlockDetails(SiriusDialog):
             lay_time.addWidget(lbl, irow, 1)
         lay.addWidget(gbox_time, offset+1, col)
 
-        # quench
-        if self.section == 'SI':
-            gbox_quench = QGroupBox('Quench Cond. 1', self)
-            lay_quench = QGridLayout(gbox_quench)
-            lay_quench.setAlignment(Qt.AlignTop)
-            lay_quench.setSpacing(9)
-
-            rv_ch = self.prefix+chs_dict['Quench1']['Rv']
-            dly_ch = self.prefix+chs_dict['Quench1']['Dly']
-            lb_dly = SiriusLabel(self, dly_ch+'-RB')
-            lb_dly.showUnits = True
-
-            lay_quench.addWidget(QLabel(
-                'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-            lay_quench.addWidget(SiriusSpinbox(
-                self, rv_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(SiriusLabel(
-                self, self.prefix+rv_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(QLabel(
-                'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-            lay_quench.addWidget(SiriusSpinbox(
-                self, dly_ch+'-SP'), 1, 1, alignment=Qt.AlignCenter)
-            lay_quench.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
-            lay.addWidget(gbox_quench, offset+2, col)
-
         # advanced details
         pb_dtls = QPushButton(
             qta.icon('fa5s.external-link-alt'), ' Advanced Details', self)
@@ -145,4 +120,4 @@ class LLRFInterlockDetails(SiriusDialog):
         connect_window(
             pb_dtls, AdvancedInterlockDetails, parent=self,
             prefix=self.prefix, section=self.section, system=system)
-        lay.addWidget(pb_dtls, offset+3, col, alignment=Qt.AlignCenter)
+        lay.addWidget(pb_dtls, offset+2, col, alignment=Qt.AlignCenter)

--- a/pyqt-apps/siriushla/as_rf_control/details/interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/interlock.py
@@ -6,7 +6,7 @@ from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QPushButton, \
     QScrollArea, QVBoxLayout, QWidget
 
 from ...util import connect_window
-from ...widgets import SiriusDialog, SiriusLabel, SiriusLedAlert, SiriusSpinbox
+from ...widgets import SiriusDialog, SiriusLabel, SiriusLedAlert
 from ..advanced_details import AdvancedInterlockDetails
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 

--- a/pyqt-apps/siriushla/as_rf_control/details/ssa.py
+++ b/pyqt-apps/siriushla/as_rf_control/details/ssa.py
@@ -10,7 +10,8 @@ from qtpy.QtWidgets import QCheckBox, QGridLayout, QGroupBox, QHBoxLayout, \
 from ...util import connect_window
 from ...widgets import PyDMLed, PyDMLedMultiChannel, SiriusDialog, \
     SiriusLabel, SiriusLedAlert, SiriusLedState, SiriusTimePlot
-from ..advanced_details import SSACurrentsDetails, ACPanelDetails
+from ..advanced_details import ACPanelDetails, SSACurrentsDetails
+from ..custom_widgets import RFTitleFrame
 from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
 
 
@@ -37,6 +38,11 @@ class SSADetailsSI(SiriusDialog):
         lay = QVBoxLayout(self)
         lay.setAlignment(Qt.AlignTop)
 
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QHBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>SSA 0{self.num} Details</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -53,8 +59,7 @@ class SSADetailsSI(SiriusDialog):
         wid_graphs.setLayout(self._setupGraphsLay())
         dtls.addTab(wid_graphs, 'Graphs')
 
-        title = f'<h4>SSA 0{self.num} Details</h4>'
-        lay.addWidget(QLabel(title, alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _setupDiagLay(self):
@@ -418,6 +423,11 @@ class SSADetailsBO(SiriusDialog):
         lay.setSpacing(9)
         lay.setAlignment(Qt.AlignTop)
 
+        title_frame = RFTitleFrame(self)
+        lay_title = QHBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            '<h4>SSA Details</h4>', alignment=Qt.AlignCenter))
+
         dtls = QTabWidget(self)
         dtls.setObjectName(self.section+'Tab')
         dtls.setStyleSheet(
@@ -434,8 +444,7 @@ class SSADetailsBO(SiriusDialog):
         wid_graphs.setLayout(self._setupGraphsLay())
         dtls.addTab(wid_graphs, 'Graphs')
 
-        title = '<h4>SSA Details</h4>'
-        lay.addWidget(QLabel(title, alignment=Qt.AlignCenter))
+        lay.addWidget(title_frame)
         lay.addWidget(dtls)
 
     def _setupDiagLay(self):

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -87,6 +87,7 @@ SEC_2_CHANNELS = {
                         'Circulator Out Fwd (RF In 14)',
                         'Circulator Out Rev (RF In 15)',
                         'LLRF Beam Trip',
+                        'Quench Condition 1'
                     ),
                 }
             },
@@ -1250,6 +1251,10 @@ SEC_2_CHANNELS = {
                     'Inp': 'RA-RaBO01:RF-LLRF:GPIOInp-Mon',
                     'Intlk': 'RA-RaBO01:RF-LLRF:GPIOIntlk-Mon',
                     'Out': 'RA-RaBO01:RF-LLRF:GPIOOut-Mon'
+                },
+                'Quench1': {
+                    'Rv': 'RA-RaBO01:RF-LLRF:QuenchCond1RvRatio',
+                    'Dly': 'RA-RaBO01:RF-LLRF:QuenchCond1Dly'
                 }
             },
             'Bypass': {
@@ -1267,6 +1272,7 @@ SEC_2_CHANNELS = {
                 '817 1': ['End Switch Down 1', 'RA-RaBO01:RF-LLRF:FIMPLG1Down'],
                 '816 2': ['End Switch Up 2', 'RA-RaBO01:RF-LLRF:FIMPLG2Up'],
                 '817 2': ['End Switch Down 2', 'RA-RaBO01:RF-LLRF:FIMPLG2Down'],
+                '853': ['Quench Condition 1', 'RA-RaBO01:RF-LLRF:FIMQuenchCond1'],
                 '835': ['ILK VCav', 'RA-RaBO01:RF-LLRF:FIMCav'],
                 '836': ['ILK Fwd Cav', 'RA-RaBO01:RF-LLRF:FIMFwdCav'],
                 '837': ['ILK Fw SSA 1', 'RA-RaBO01:RF-LLRF:FIMFwdSSA1'],

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -20,6 +20,11 @@ DEFAULT_STYLESHEET = """
                 max-height:1.5em; min-width:4em;
             }"""
 
+SYSTEM_COLORS = {
+    'A': 'royalBlue',
+    'B': 'lightBlue'
+}
+
 SEC_2_CHANNELS = {
     'BO': {
         'Emergency': 'BO-05D:RF-Intlk:EStop-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -1595,10 +1595,6 @@ SEC_2_CHANNELS = {
                     '6': 'RA-RaSIA01:RF-LLRF:IntlkTs6-Mon',
                     '7': 'RA-RaSIA01:RF-LLRF:IntlkTs7-Mon',
                 },
-                'Quench1': {
-                    'Rv': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatio',
-                    'Dly': 'RA-RaSIA01:RF-LLRF:QuenchCond1Dly'
-                }
             },
             'B': {
                 'Inputs': {
@@ -1669,10 +1665,6 @@ SEC_2_CHANNELS = {
                     '5': 'RA-RaSIB01:RF-LLRF:IntlkTs5-Mon',
                     '6': 'RA-RaSIB01:RF-LLRF:IntlkTs6-Mon',
                     '7': 'RA-RaSIB01:RF-LLRF:IntlkTs7-Mon',
-                },
-                'Quench1': {
-                    'Rv': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatio',
-                    'Dly': 'RA-RaSIB01:RF-LLRF:QuenchCond1Dly'
                 }
             }
         },
@@ -4156,6 +4148,10 @@ SEC_2_CHANNELS = {
                         'Inp': 'RA-RaSIA01:RF-LLRF:GPIOInp-Mon',
                         'Intlk': 'RA-RaSIA01:RF-LLRF:GPIOIntlk-Mon',
                         'Out': 'RA-RaSIA01:RF-LLRF:GPIOOut-Mon'
+                    },
+                    'Quench1': {
+                        'Rv': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatio',
+                        'Dly': 'RA-RaSIA01:RF-LLRF:QuenchCond1Dly'
                     }
                 },
                 'Dynamic': {
@@ -4249,6 +4245,10 @@ SEC_2_CHANNELS = {
                         'Inp': 'RA-RaSIB01:RF-LLRF:GPIOInp-Mon',
                         'Intlk': 'RA-RaSIB01:RF-LLRF:GPIOIntlk-Mon',
                         'Out': 'RA-RaSIB01:RF-LLRF:GPIOOut-Mon'
+                    },
+                    'Quench1': {
+                        'Rv': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatio',
+                        'Dly': 'RA-RaSIB01:RF-LLRF:QuenchCond1Dly'
                     }
                 },
                 'Dynamic': {


### PR DESCRIPTION
Adds the RFTitleFrame class and uses it in detail windows to more easily recognize if the window represents the A or B system. Removes repeated labels on Diagnostics tab, simplifying the layout. Moved Quench Cond. 1 from Interlock to Advanced Interlock, and added it on booster.

- RFTitleFrame Example
![image](https://github.com/user-attachments/assets/33e3c5cf-1785-421f-b72d-94bfba171bf5)

- Diagnostics
![image](https://github.com/user-attachments/assets/67429587-95ee-4775-842e-9d7178e2a0f8)

- Advanced Interlock
![image](https://github.com/user-attachments/assets/24d8bb8f-ac95-495a-93e4-50326d07120f)
