### PR TITLE
IDFF.FIX: add pressValue to Clear Alarms button

### DIFF
--- a/pyqt-apps/siriushla/si_ap_idff/main.py
+++ b/pyqt-apps/siriushla/si_ap_idff/main.py
@@ -119,7 +119,7 @@ class IDFFWindow(SiriusMainWindow):
             section='ID', title='FeedForward Status')
 
         self.clear_alarms = PyDMPushButton(
-            self, "Clear Alarms",
+            self, "Clear Alarms", pressValue=1,
             init_channel=self.dev_pref.substitute(propty='ClearFlags-Cmd'))
 
         lbl_plc_counter = QLabel('PLC Counter: ', self)


### PR DESCRIPTION
Fix Clear Alarms button. If the button doesn't have a pressValue defined, nothing is sent.