### PR TITLE
HLA.WIDGETS.FIX: don't run transform function if waveform is empty

### DIFF
--- a/pyqt-apps/siriushla/widgets/waveformtable.py
+++ b/pyqt-apps/siriushla/widgets/waveformtable.py
@@ -26,6 +26,6 @@ class SiriusWaveformTable(PyDMWaveformTable):
             return
         elif isinstance(new_waveform, (float, int)):
             new_waveform = _np.array([new_waveform])
-        if self.transform is not None:
+        if self.transform is not None and len(new_waveform) > 0:
             new_waveform = self.transform(new_waveform)
         super().value_changed(new_waveform)


### PR DESCRIPTION
The waveform might be connected, so the new value isn't None, but it can be empty (zero elements). In such cases, it's possible that the implementation of the transform function, for example, when using numpy.vectorize, to raise an exception.

Since the value is empty, we can simply pass it forward without running a transform function.

This was noticed in the interface for the EVG log, when the timestamp buffer was empty.