### PR TITLE
RF system interface update, including E-Quench parameters.

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -175,6 +175,9 @@ class AdvancedInterlockDetails(SiriusDialog):
         tab1_layout.setSpacing(9)
 
         rv_ch = self.prefix+chs_dict['Quench1']['Rv']
+        lb_rv = SiriusLabel(self, rv_ch+'-RB')
+        lb_rv.showUnits = True
+
         dly_ch = self.prefix+chs_dict['Quench1']['Dly']
         lb_dly = SiriusLabel(self, dly_ch+'-RB')
         lb_dly.showUnits = True
@@ -183,8 +186,8 @@ class AdvancedInterlockDetails(SiriusDialog):
             'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab1_layout.addWidget(SiriusSpinbox(
             self, rv_ch + '-SP'), 0, 1, alignment=Qt.AlignCenter)
-        tab1_layout.addWidget(SiriusLabel(
-            self, rv_ch + '-RB'), 0, 2, alignment=Qt.AlignCenter)
+        tab1_layout.addWidget(lb_rv, 0, 2, alignment=Qt.AlignCenter)
+        
         tab1_layout.addWidget(QLabel(
             'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab1_layout.addWidget(SiriusSpinbox(
@@ -199,6 +202,9 @@ class AdvancedInterlockDetails(SiriusDialog):
         tab2_layout.setSpacing(9)
 
         fw_ch = self.prefix+chs_dict['E-Quench']['Fw']
+        lb_fw = SiriusLabel(self, fw_ch+'-RB')
+        lb_fw.showUnits = True
+
         dly_ch_e = self.prefix+chs_dict['E-Quench']['Dly']
         lb_dly_e = SiriusLabel(self, dly_ch_e+'-RB')
         lb_dly_e.showUnits = True
@@ -207,8 +213,8 @@ class AdvancedInterlockDetails(SiriusDialog):
             'Fw Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab2_layout.addWidget(SiriusSpinbox(
             self, fw_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
-        tab2_layout.addWidget(SiriusLabel(
-            self, self.prefix+fw_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
+        tab2_layout.addWidget(lb_fw, 0, 2, alignment=Qt.AlignCenter)
+        
         tab2_layout.addWidget(QLabel(
             'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab2_layout.addWidget(SiriusSpinbox(

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -155,28 +155,67 @@ class AdvancedInterlockDetails(SiriusDialog):
         gbox_gen = QGroupBox('General Controls')
         gbox_gen.setLayout(self._genDiagLayout(chs_dict['General']))
 
-        # Quench Cond. 1
-        gbox_quench = QGroupBox('Quench Cond. 1', self)
-        lay_quench = QGridLayout(gbox_quench)
+        #Quench
+        gbox_quench = QGroupBox('Quench', self)
+        lay_quench = QVBoxLayout(gbox_quench)
         lay_quench.setAlignment(Qt.AlignTop)
         lay_quench.setSpacing(9)
+
+        tabwidget = QTabWidget(gbox_quench)
+        lay_quench.addWidget(tabwidget)
+        tabwidget.setStyleSheet(
+            "#"+self.section+'Tab'+"::pane {"
+            "    border-left: 2px solid gray;"
+            "    border-bottom: 2px solid gray;"
+            "    border-right: 2px solid gray;}")
+        
+        tab1 = QWidget()
+        tab1_layout = QGridLayout(tab1)
+        tab1_layout.setAlignment(Qt.AlignTop)
+        tab1_layout.setSpacing(9)
 
         rv_ch = self.prefix+chs_dict['Quench1']['Rv']
         dly_ch = self.prefix+chs_dict['Quench1']['Dly']
         lb_dly = SiriusLabel(self, dly_ch+'-RB')
         lb_dly.showUnits = True
 
-        lay_quench.addWidget(QLabel(
+        tab1_layout.addWidget(QLabel(
             'Rv Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        lay_quench.addWidget(SiriusSpinbox(
-            self, rv_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
-        lay_quench.addWidget(SiriusLabel(
-            self, self.prefix+rv_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
-        lay_quench.addWidget(QLabel(
+        tab1_layout.addWidget(SiriusSpinbox(
+            self, rv_ch + '-SP'), 0, 1, alignment=Qt.AlignCenter)
+        tab1_layout.addWidget(SiriusLabel(
+            self, rv_ch + '-RB'), 0, 2, alignment=Qt.AlignCenter)
+        tab1_layout.addWidget(QLabel(
             'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        lay_quench.addWidget(SiriusSpinbox(
-            self, dly_ch+'-SP'), 1, 1, alignment=Qt.AlignCenter)
-        lay_quench.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
+        tab1_layout.addWidget(SiriusSpinbox(
+            self, dly_ch + '-SP'), 1, 1, alignment=Qt.AlignCenter)
+        tab1_layout.addWidget(lb_dly, 1, 2, alignment=Qt.AlignCenter)
+
+        tabwidget.addTab(tab1, 'Quench Cond. 1')
+
+        tab2 = QWidget()
+        tab2_layout = QGridLayout(tab2)
+        tab2_layout.setAlignment(Qt.AlignTop)
+        tab2_layout.setSpacing(9)
+
+        fw_ch = self.prefix+chs_dict['E-Quench']['Fw']
+        dly_ch_e = self.prefix+chs_dict['E-Quench']['Dly']
+        lb_dly_e = SiriusLabel(self, dly_ch_e+'-RB')
+        lb_dly_e.showUnits = True
+
+        tab2_layout.addWidget(QLabel(
+            'Fw Ratio'), 0, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        tab2_layout.addWidget(SiriusSpinbox(
+            self, fw_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
+        tab2_layout.addWidget(SiriusLabel(
+            self, self.prefix+fw_ch+'-RB'), 0, 2, alignment=Qt.AlignCenter)
+        tab2_layout.addWidget(QLabel(
+            'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
+        tab2_layout.addWidget(SiriusSpinbox(
+            self, dly_ch_e+'-SP'), 1, 1, alignment=Qt.AlignCenter)
+        tab2_layout.addWidget(lb_dly_e, 1, 2, alignment=Qt.AlignCenter)
+
+        tabwidget.addTab(tab2, 'E-Quench')
 
         lay.addWidget(gbox_lvls, 0, 0)
         lay.addWidget(gbox_inp, 0, 1)
@@ -268,8 +307,8 @@ class AdvancedInterlockDetails(SiriusDialog):
             '<h4>Offset</h4>', alignment=Qt.AlignCenter), 3, 5, 1, 2)
 
         # # Body
-        keys = ['Fwd Cav', 'Rev Cav', 'Quench']
-        row = 4
+        keys = ['Fwd Cav', 'Rev Cav', 'Quench', 'E-Quench']
+        row = 5
         for key in keys:
             chs = chs_dict[key]
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -177,6 +177,7 @@ class AdvancedInterlockDetails(SiriusDialog):
         rv_ch = self.prefix+chs_dict['Quench1']['Rv']
         lb_rv = SiriusLabel(self, rv_ch+'-RB')
         lb_rv.showUnits = True
+        lb_rv._keep_unit = True
 
         dly_ch = self.prefix+chs_dict['Quench1']['Dly']
         lb_dly = SiriusLabel(self, dly_ch+'-RB')
@@ -204,6 +205,7 @@ class AdvancedInterlockDetails(SiriusDialog):
         fw_ch = self.prefix+chs_dict['E-Quench']['Fw']
         lb_fw = SiriusLabel(self, fw_ch+'-RB')
         lb_fw.showUnits = True
+        lb_fw._keep_unit = True 
 
         dly_ch_e = self.prefix+chs_dict['E-Quench']['Dly']
         lb_dly_e = SiriusLabel(self, dly_ch_e+'-RB')

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
@@ -77,10 +77,12 @@ class RFInputsDetails(SiriusDialog):
             quench_ratio = SiriusLabel(
                 self, self.prefix+self.syst_dict_2['Quench Cond 1'])
             quench_ratio.showUnits = True
+            quench_ratio._keep_unit = True
 
             equench_ratio = SiriusLabel(
                 self, self.prefix+self.syst_dict_2['E-quench'])
             equench_ratio.showUnits = True
+            equench_ratio._keep_unit = True
 
             lay.addWidget(self.horizontal_separator(), row, 0, 1, 9)
             row += 1

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
@@ -74,21 +74,25 @@ class RFInputsDetails(SiriusDialog):
 
         # Ratio Calculation
         if self.section == 'SI':
+            quench_ratio = SiriusLabel(
+                self, self.prefix+self.syst_dict_2['Quench Cond 1'])
+            quench_ratio.showUnits = True
+
+            equench_ratio = SiriusLabel(
+                self, self.prefix+self.syst_dict_2['E-quench'])
+            equench_ratio.showUnits = True
+
             lay.addWidget(self.horizontal_separator(), row, 0, 1, 9)
             row += 1
             lay.addWidget(QLabel(
                 'Quench Condition 1 (Rev Cav/Fwd Cav)', alignment=Qt.AlignRight), 
                 row, 0, 1, 2)
-            lay.addWidget(SiriusLabel(
-                self, self.prefix+self.syst_dict_2['Quench Cond 1']),
-                row, 4, 1, 6, alignment=Qt.AlignLeft)
+            lay.addWidget(quench_ratio, row, 4, 1, 6, alignment=Qt.AlignLeft)
             row += 1
             lay.addWidget(QLabel(
                 'E-Quench (Fwd Cav/V Cav)', alignment=Qt.AlignRight), 
                 row, 0, 1, 2)
-            lay.addWidget(SiriusLabel(
-                self, self.prefix+self.syst_dict_2['E-quench']),
-                row, 4, 1, 6, alignment=Qt.AlignLeft)
+            lay.addWidget(equench_ratio, row, 4, 1, 6, alignment=Qt.AlignLeft)
             row += 1
             lay.addWidget(self.horizontal_separator(), row, 0, 1, 9)
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/rf_inputs.py
@@ -2,7 +2,7 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QGridLayout, QLabel, QSizePolicy as QSzPlcy, \
-    QSpacerItem
+    QSpacerItem, QFrame
 
 from ...widgets import SiriusDialog, SiriusLabel
 from ..custom_widgets import RFTitleFrame
@@ -26,6 +26,7 @@ class RFInputsDetails(SiriusDialog):
         self.setWindowTitle(self.title)
         if self.section == 'SI':
             self.syst_dict = self.chs['RF Inputs'][self.system]
+            self.syst_dict_2 = self.chs['Quench Ratio'][self.system]
         else:
             self.syst_dict = self.chs['RF Inputs']
         self._setupUi()
@@ -70,3 +71,29 @@ class RFInputsDetails(SiriusDialog):
                 if column == 6:
                     column += 1
             row += 1
+
+        # Ratio Calculation
+        if self.section == 'SI':
+            lay.addWidget(self.horizontal_separator(), row, 0, 1, 9)
+            row += 1
+            lay.addWidget(QLabel(
+                'Quench Condition 1 (Rev Cav/Fwd Cav)', alignment=Qt.AlignRight), 
+                row, 0, 1, 2)
+            lay.addWidget(SiriusLabel(
+                self, self.prefix+self.syst_dict_2['Quench Cond 1']),
+                row, 4, 1, 6, alignment=Qt.AlignLeft)
+            row += 1
+            lay.addWidget(QLabel(
+                'E-Quench (Fwd Cav/V Cav)', alignment=Qt.AlignRight), 
+                row, 0, 1, 2)
+            lay.addWidget(SiriusLabel(
+                self, self.prefix+self.syst_dict_2['E-quench']),
+                row, 4, 1, 6, alignment=Qt.AlignLeft)
+            row += 1
+            lay.addWidget(self.horizontal_separator(), row, 0, 1, 9)
+
+    def horizontal_separator(self):
+            line = QFrame()
+            line.setFrameShape(QFrame.HLine)
+            line.setFrameShadow(QFrame.Sunken)
+            return line

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -2558,7 +2558,7 @@ SEC_2_CHANNELS = {
         'Quench Ratio': {
             'A': {
                 'Quench Cond 1': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatio-Mon',
-                'E-quench': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatio-Mon',        
+                'E-quench': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatio-Mon',
             },
             'B': {
                 'Quench Cond 1': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatio-Mon',

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -87,7 +87,8 @@ SEC_2_CHANNELS = {
                         'Circulator Out Fwd (RF In 14)',
                         'Circulator Out Rev (RF In 15)',
                         'Not Used (old beam trip)',
-                        'Quench Condition 1'
+                        'Quench Condition 1',
+                        'E-Quench'
                     ),
                 }
             },
@@ -1255,6 +1256,10 @@ SEC_2_CHANNELS = {
                 'Quench1': {
                     'Rv': 'RA-RaBO01:RF-LLRF:QuenchCond1RvRatio',
                     'Dly': 'RA-RaBO01:RF-LLRF:QuenchCond1Dly'
+                },
+                'E-Quench': {
+                    'Fw': 'RA-RaBO01:RF-LLRF:EQuenchFwRatio',
+                    'Dly': 'RA-RaBO01:RF-LLRF:EQuenchDly'
                 }
             },
             'Bypass': {
@@ -1273,6 +1278,7 @@ SEC_2_CHANNELS = {
                 '816 2': ['End Switch Up 2', 'RA-RaBO01:RF-LLRF:FIMPLG2Up'],
                 '817 2': ['End Switch Down 2', 'RA-RaBO01:RF-LLRF:FIMPLG2Down'],
                 '853': ['Quench Condition 1', 'RA-RaBO01:RF-LLRF:FIMQuenchCond1'],
+                '857': ['E-Quench', 'RA-RaBO01:RF-LLRF:FIMEQuench'],
                 '835': ['ILK VCav', 'RA-RaBO01:RF-LLRF:FIMCav'],
                 '836': ['ILK Fwd Cav', 'RA-RaBO01:RF-LLRF:FIMFwdCav'],
                 '837': ['ILK Fw SSA 1', 'RA-RaBO01:RF-LLRF:FIMFwdSSA1'],
@@ -1588,7 +1594,8 @@ SEC_2_CHANNELS = {
                             'Fwd Load (RF In 14)',
                             'Rev In Load (RF In 15)',
                             'Not Used (old beam trip)',
-                            'Quench Condition 1'
+                            'Quench Condition 1',
+                            'E-Quench'
                         ),
                     },
                 },
@@ -1659,7 +1666,8 @@ SEC_2_CHANNELS = {
                             'Fwd Load (RF In 14)',
                             'Rev In Load (RF In 15)',
                             'Not Used (old beam trip)',
-                            'Quench Condition 1'
+                            'Quench Condition 1',
+                            'E-Quench'
                         ),
                     },
                 },
@@ -2545,6 +2553,16 @@ SEC_2_CHANNELS = {
                         '35': ['Gain', 'RA-RaSIB01:RF-LLRF:CavMonGain'],
                     }
                 }
+            }
+        },
+        'Quench Ratio': {
+            'A': {
+                'Quench Cond 1': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatio-Mon',
+                'E-quench': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatio-Mon',        
+            },
+            'B': {
+                'Quench Cond 1': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatio-Mon',
+                'E-quench': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatio-Mon', 
             }
         },
         'RF Inputs': {
@@ -4158,6 +4176,10 @@ SEC_2_CHANNELS = {
                     'Quench1': {
                         'Rv': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatio',
                         'Dly': 'RA-RaSIA01:RF-LLRF:QuenchCond1Dly'
+                    },
+                    'E-Quench': {
+                        'Fw': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatio',
+                        'Dly': 'RA-RaSIA01:RF-LLRF:EQuenchDly'
                     }
                 },
                 'Dynamic': {
@@ -4184,6 +4206,13 @@ SEC_2_CHANNELS = {
                         'Coeff': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatioCoeff',
                         'Offset': 'RA-RaSIA01:RF-LLRF:QuenchCond1RvRatioOffset'
                     },
+                    'E-Quench': {
+                        'Label': 'E-Quench Ratio',
+                        'Value': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatio-RB',
+                        'Enable': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatioEn',
+                        'Coeff': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatioCoeff',
+                        'Offset': 'RA-RaSIA01:RF-LLRF:EQuenchFwRatioOffset'
+                    }
                 },
                 'Bypass': {
                     '806': ['Rev SSA 1', 'RA-RaSIA01:RF-LLRF:FIMRevSSA1'],
@@ -4201,6 +4230,7 @@ SEC_2_CHANNELS = {
                     '816 2': ['End Switch Up 2', 'RA-RaSIA01:RF-LLRF:FIMPLG2Up'],
                     '817 2': ['End Switch Down 2', 'RA-RaSIA01:RF-LLRF:FIMPLG2Down'],
                     '853': ['Quench Condition 1', 'RA-RaSIA01:RF-LLRF:FIMQuenchCond1'],
+                    '857': ['E-Quench', 'RA-RaSIA01:RF-LLRF:FIMEQuench'],
                     '835': ['ILK VCav', 'RA-RaSIA01:RF-LLRF:FIMCav'],
                     '836': ['ILK Fwd Cav', 'RA-RaSIA01:RF-LLRF:FIMFwdCav'],
                     '837': ['ILK Fw SSA 1', 'RA-RaSIA01:RF-LLRF:FIMFwdSSA1'],
@@ -4255,6 +4285,10 @@ SEC_2_CHANNELS = {
                     'Quench1': {
                         'Rv': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatio',
                         'Dly': 'RA-RaSIB01:RF-LLRF:QuenchCond1Dly'
+                    },
+                    'E-Quench': {
+                        'Fw': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatio',
+                        'Dly': 'RA-RaSIB01:RF-LLRF:EQuenchDly'
                     }
                 },
                 'Dynamic': {
@@ -4281,6 +4315,13 @@ SEC_2_CHANNELS = {
                         'Coeff': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatioCoeff',
                         'Offset': 'RA-RaSIB01:RF-LLRF:QuenchCond1RvRatioOffset'
                     },
+                    'E-Quench': {
+                        'Label': 'E-Quench Ratio',
+                        'Value': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatio-RB',
+                        'Enable': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatioEn',
+                        'Coeff': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatioCoeff',
+                        'Offset': 'RA-RaSIB01:RF-LLRF:EQuenchFwRatioOffset'
+                    }
                 },
                 'Bypass': {
                     '806': ['Rev SSA 1', 'RA-RaSIB01:RF-LLRF:FIMRevSSA1'],
@@ -4298,6 +4339,7 @@ SEC_2_CHANNELS = {
                     '816 2': ['End Switch Up 2', 'RA-RaSIB01:RF-LLRF:FIMPLG2Up'],
                     '817 2': ['End Switch Down 2', 'RA-RaSIB01:RF-LLRF:FIMPLG2Down'],
                     '853': ['Quench Condition 1', 'RA-RaSIB01:RF-LLRF:FIMQuenchCond1'],
+                    '857': ['E-Quench', 'RA-RaSIB01:RF-LLRF:FIMEQuench'],
                     '835': ['ILK VCav', 'RA-RaSIB01:RF-LLRF:FIMCav'],
                     '836': ['ILK Fwd Cav', 'RA-RaSIB01:RF-LLRF:FIMFwdCav'],
                     '837': ['ILK Fw SSA 1', 'RA-RaSIB01:RF-LLRF:FIMFwdSSA1'],


### PR DESCRIPTION
**1. Updates in LLRF Interlock Details:**

_E-Quench interlock line added at Input 2_

- SI
![image](https://github.com/user-attachments/assets/3fbbfe58-10bd-4c7c-ac92-e45263aa017e)
- BO
![image](https://github.com/user-attachments/assets/908426ce-ea1b-406e-a3b5-fa453a5a2e81)

**2. Updates in Advanced Interlock Details:**

   **2.1. Diagnostics**

   _"Quench Cond. 1" box name changed to just "Quench", and added one tab for Quench Cond. 1 and E-Quench_

   - SI

     - A    
   ![image](https://github.com/user-attachments/assets/3fd63dd5-b969-45c9-b498-95a806ef83b5)
   ![image](https://github.com/user-attachments/assets/47ecc25c-ca71-4676-859b-0e21c6a14d5d)

     - B   
   ![image](https://github.com/user-attachments/assets/1308a101-cc72-452e-ac1d-de0c682c342f)
   ![image](https://github.com/user-attachments/assets/23472665-f279-411d-9323-03c31a54d609)

   - BO
   ![image](https://github.com/user-attachments/assets/e2d34345-eaff-4ee3-b911-41cb9e03be40)
   ![image](https://github.com/user-attachments/assets/6755edc2-8c6f-46ab-81c1-bcb8b586bc18)

   **2.2. Dynamic Interlock**

   _E-Quench dynamic variables added_

   - SI
     
     - A     
   ![image](https://github.com/user-attachments/assets/fe958859-ace9-4b4e-a96e-97affaf31031)
   
     - B   
   ![image](https://github.com/user-attachments/assets/e45bab49-4fa9-429e-8260-37b116e772db)

   **2.3. Interlock Bypass**

   _E-Quench by-pass added_

   - SI

     - A
   ![image](https://github.com/user-attachments/assets/63e8c2b6-f3b2-49a7-a974-f8cb94c8606c)

     - B
   ![image](https://github.com/user-attachments/assets/f6b371b5-97f1-43b6-9de8-a58db9617254)

   - BO   
   ![image](https://github.com/user-attachments/assets/be55f885-31c0-4630-8bb8-09bcb0a1cec0)

**3. Updates in Advanced Details (RF Inputs):**

_Added section with calculation of ratio variables_

- SI 
   
   - A
 ![image](https://github.com/user-attachments/assets/55f445fa-fd8d-4fe0-ac9f-fe2033ba6b2d)

   - B
 ![image](https://github.com/user-attachments/assets/fe5301f0-0e5e-4373-98b8-d7c0c00e8067)



