### PR TITLE
Fix util.check_window_by_pid

### DIFF
--- a/pyqt-apps/siriushla/as_ap_launcher/menu.py
+++ b/pyqt-apps/siriushla/as_ap_launcher/menu.py
@@ -193,7 +193,9 @@ def get_object(ismenubar=True, parent=None):
 
             try:
                 host = _sbp.getoutput('hostname')
-                exist_xrandr = not bool(_sbp.getoutput('xrandr | grep missing'))
+                exist_xrandr = not bool(
+                    _sbp.getoutput('xrandr | grep missing')
+                )
                 hosts = {'lnls449-linux', 'lnls451-linux', 'lnls454-linux'}
             except Exception:
                 return menu
@@ -985,7 +987,7 @@ def get_object(ismenubar=True, parent=None):
             disps = [o for o in out if ' connected' in o]
             ds_names = [d.split(' ')[0] for d in disps]
 
-            reg = '[0-9]{4}x[0-9]{4}\+([0-9]{1,4})\+[0-9]{1,4}'
+            reg = r'[0-9]{4}x[0-9]{4}\+([0-9]{1,4})\+[0-9]{1,4}'
             ds_pos = [
                 _re.findall(reg, d)[0] for di in disps
                 for d in di.split(' ') if _re.match(reg, d)]

--- a/pyqt-apps/siriushla/util.py
+++ b/pyqt-apps/siriushla/util.py
@@ -121,10 +121,12 @@ def check_process(cmd, is_window=True, is_pydm=False):
 
 def check_window_by_pid(pid, comm):
     if 'edm' in comm:
-        wind = _subprocess.getoutput('wmctrl -lpx | grep edm | grep SIRIUS')
+        sts, wind = _subprocess.getstatusoutput(
+            'wmctrl -lpx | grep edm | grep SIRIUS'
+        )
     else:
-        wind = _subprocess.getoutput('wmctrl -lpx | grep ' + pid)
-    if not wind:
+        sts, wind = _subprocess.getstatusoutput('wmctrl -lpx | grep ' + pid)
+    if sts or not wind:
         return ''
     window = wind.split('\n')[0].split()[0]
     return window
@@ -134,7 +136,8 @@ def run_newprocess(cmd, is_window=True, is_pydm=False, **kwargs):
     pid, window = check_process(cmd, is_window=is_window, is_pydm=is_pydm)
     if window:
         _subprocess.run(
-            "wmctrl -iR " + window, stdin=_subprocess.PIPE, shell=True)
+            "wmctrl -iR " + window, stdin=_subprocess.PIPE, shell=True
+        )
     elif not pid:
         _subprocess.Popen(cmd, **kwargs)
 


### PR DESCRIPTION
When trying to run our main launcher on [WSL](https://learn.microsoft.com/en-us/windows/wsl/), I ran into a bug related to the fact that wmctrl can not run properly on systems that does not have a traditional X server with an appropriate window manager.

This PR fixes this issue. However, in systems where wmctrl does not work, the "Loading Window" Dialog will never be closed within the timeout and windows already opened will not be brought to first plane.