### PR TITLE
Update MachShiftLabel and fix PosAng warning

### DIFF
--- a/pyqt-apps/siriushla/as_ap_machshift/widgets.py
+++ b/pyqt-apps/siriushla/as_ap_machshift/widgets.py
@@ -32,6 +32,7 @@ class MachShiftLabel(QWidget):
             SiriusFrame.DarkGray,  # Shutdown
             SiriusFrame.MediumBlue,  # MachineStartup
             SiriusFrame.LightSalmon,  # BeamlineCommissioning
+            SiriusFrame.DarkGray,  # Unattended
         ]
         self.frame = SiriusFrame(
             self, pvname,

--- a/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
+++ b/pyqt-apps/siriushla/as_ap_posang/HLPosAng.py
@@ -116,12 +116,13 @@ class PosAngCorr(SiriusMainWindow):
                               stop:1 rgba(213, 213, 213, 255));""")
 
         # warning
-        self.lb_rule_warning = CALabel(self)
-        self.lb_rule_warning.setText(
-            "WARNING:Disable injection standby mode to change PosAng.")
         if self._tl != 'TB':
+            self.lb_rule_warning = CALabel(self)
+            self.lb_rule_warning.setText(
+                "WARNING:Disable injection standby mode to change PosAng.")
             self.lb_rule_warning.rules = self.injctrl_vis_rules
-        self.lb_rule_warning.setStyleSheet("color: yellow; font-weight: bold;")
+            self.lb_rule_warning.setStyleSheet(
+                "QLabel{font-weight: bold; background-color: orange;}")
 
         # update reference button
         self.pb_updateref = PyDMPushButton(
@@ -164,7 +165,8 @@ class PosAngCorr(SiriusMainWindow):
         glay.setHorizontalSpacing(12)
         glay.setVerticalSpacing(12)
         glay.addWidget(lab, 0, 0, 1, 2)
-        glay.addWidget(self.lb_rule_warning, 1, 0, 1, 2)
+        if self._tl != 'TB':
+            glay.addWidget(self.lb_rule_warning, 1, 0, 1, 2)
         glay.addLayout(box_ref, 2, 0, 1, 2)
         glay.addWidget(self.hgbox, 3, 0)
         glay.addWidget(self.vgbox, 3, 1)


### PR DESCRIPTION
- Add a new color for Unattended shift type in MachShiftLabel
![Screenshot from 2025-07-04 19-24-13](https://github.com/user-attachments/assets/22034dbb-e4c4-4829-bcfb-012d850b0adf)

- Remove warning label for TB PosAng, once TB Kicker is not included in PU standby in injection procedure
- Change label color (GOP request)
![image](https://github.com/user-attachments/assets/84b7594c-97ba-47ac-b03c-6606f3078a11)