### PR TITLE
Add High Level Interface for controlling AFC PVs

### DIFF
--- a/pyqt-apps/siriushla/as_di_bpms/main.py
+++ b/pyqt-apps/siriushla/as_di_bpms/main.py
@@ -9,6 +9,7 @@ from siriushla.as_di_bpms.monit import MonitData
 from siriushla.as_di_bpms.trig_acq_config import BPMGENAcquisition, \
     BPMPMAcquisition, PBPMGENAcquisition, PBPMPMAcquisition
 from siriushla.si_ap_orbintlk import BPMOrbIntlkDetailWindow
+from siriushla.common.afc_board.afc_settings import AFCAdvancedSettings
 
 
 class BPMMain(BaseWidget):
@@ -45,6 +46,19 @@ class BPMMain(BaseWidget):
         self.layoutv.addWidget(grpbx)
         self.layoutv.addSpacing(20)
         self.layoutv.addStretch()
+
+        grbx = CustomGroupBox('AFC Details', self)
+        grbx_lay = QHBoxLayout(grbx)
+        grbx_lay.setSpacing(20)
+        pbt = QPushButton('AFC Settings')
+        pbt.setFixedSize(90, 23)
+        Window = create_window_from_widget(
+            AFCAdvancedSettings, title=self.bpm+': AFC Settings')
+        util.connect_window(
+            pbt, Window, parent=self, prefix=self.prefix, display=self.bpm)
+        grbx_lay.addWidget(pbt)
+        self.layoutv.addWidget(grbx)
+        self.layoutv.addSpacing(20)
 
         grpbx = CustomGroupBox('Triggered Acquisitions', self)
         hbl = QHBoxLayout(grpbx)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import QLabel, QPushButton, QGroupBox, QVBoxLayout, \
 import qtawesome as qta
 from pydm.widgets import PyDMLineEdit, PyDMPushButton
 
-from siriuspy.search import LLTimeSearch, HLTimeSearch
+from siriuspy.search import LLTimeSearch, HLTimeSearch, RaBPMSearch
 from siriuspy.namesys import SiriusPVName as _PVName
 from siriuspy.timesys import csdev as _cstime
 from siriuspy.epics import PV as _PV
@@ -25,6 +25,8 @@ from ..util import connect_window, get_appropriate_color
 
 from .base import BaseList, BaseWidget
 from .allowed_buckets import AllowedBucketsMatrix
+
+from ..common.afc_board.afc_settings import AFCAdvancedSettings
 
 
 # ###################### Event Generator ######################
@@ -1496,7 +1498,8 @@ class AFC(BaseWidget):
         self.status_wid = self._setup_status_wid()
         stattab.addTab(self.status_wid, 'Status')
         self.info_wid = self._setup_info_wid()
-        stattab.addTab(self.info_wid, 'Fw && IOC')
+        stattab.addTab(self.info_wid, 'Fw && IOC && AFC Details')
+
         self.my_layout.addWidget(stattab, 2, 0)
         stattab.setSizePolicy(QSzPol.Preferred, QSzPol.Maximum)
 
@@ -1669,6 +1672,29 @@ class AFC(BaseWidget):
         hldbg.addWidget(but)
         gb = self._create_small_group('', info_wid, (lb, dbg))
         info_lay.addWidget(gb, 0, 1)
+
+        lb = QLabel("<b>AFC Settings Details</b>")
+        pbt = QPushButton(qta.icon('fa5s.ellipsis-v'), '', self)
+        pbt.setObjectName('pbt')
+        pbt.setStyleSheet(
+            '#pbt{min-width:25px; max-width:25px; icon-size:20px;}')
+        pbt.setDefault(False)
+        pbt.setAutoDefault(False)
+        Window = create_window_from_widget(
+            AFCAdvancedSettings, title='AFC Advanced Settings'
+        )
+        connect_window(
+            pbt, Window, parent=None, prefix=self.prefix, display=self.device
+        )
+        crate = RaBPMSearch.conv_devname_2_cratename(self.device)
+        lbl = QLabel(f"{crate}", self, alignment=Qt.AlignCenter)
+        proc = QWidget()
+        hlproc = QHBoxLayout(proc)
+        hlproc.setContentsMargins(0, 0, 0, 0)
+        hlproc.addWidget(pbt)
+        hlproc.addWidget(lbl)
+        gb = self._create_small_group('', info_wid, (lb, proc))
+        info_lay.addWidget(gb, 0, 2)
 
         return info_wid
 

--- a/pyqt-apps/siriushla/common/afc_board/__init__.py
+++ b/pyqt-apps/siriushla/common/afc_board/__init__.py
@@ -1,0 +1,1 @@
+"""Common components for AFC board control"""

--- a/pyqt-apps/siriushla/common/afc_board/afc_settings.py
+++ b/pyqt-apps/siriushla/common/afc_board/afc_settings.py
@@ -1,0 +1,269 @@
+from qtpy.QtWidgets import QVBoxLayout, QGridLayout, QLabel, \
+    QWidget, QGroupBox, QHBoxLayout
+
+from qtpy.QtCore import Qt
+
+from ...widgets import SiriusLabel, SiriusEnumComboBox, \
+    SiriusPushButton, SiriusLedAlert, PyDMLed
+from siriuspy.namesys import SiriusPVName as _PVName
+from siriuspy.search import RaBPMSearch
+
+import qtawesome as qta
+
+from ...common.afc_board import ipmi_mngr_pvs
+
+
+class AFCAdvancedSettings(QWidget):
+    def __init__(self, parent=None, prefix='', display='', data_prefix=''):
+        super().__init__(parent)
+        self.prefix = prefix
+        self.display = _PVName(display)
+        self.data_prefix = data_prefix
+        if display.sec == 'IA':
+            if display.dev == 'AMCFPGAEVR':
+                sec = 'AS'
+            elif display.dev == 'FOFBCtrl':
+                sec = 'SI'
+        else:
+            sec = display.sec
+        self.setObjectName(f'{sec}App')
+        self.setupui()
+
+    def setupui(self):
+        lay = QVBoxLayout(self)
+        if self.display.dev == 'FOFBCtrl':
+            tag = 'AFCv4.0 Settings'
+        else:
+            tag = 'AFCv3.1 Settings'
+        lab = QLabel(
+            f'<h2>{self.display} {tag}</h2>', self, alignment=Qt.AlignCenter)
+        lay.addWidget(lab)
+
+        slot = RaBPMSearch.conv_devname_2_slot(self.display)
+
+        lab_num = QLabel(
+            f'<h4>AMC-{slot}</h4>', self, alignment=Qt.AlignCenter)
+        lay.addWidget(lab_num)
+
+        pv_help = RaBPMSearch.get_bpm_pair(self.display)
+        if pv_help is None:
+            pass
+        else:
+            lab_help = QLabel(
+                f'<h3>(also refers to {pv_help})</h3>',
+                    self, alignment=Qt.AlignCenter)
+            lay.addWidget(lab_help)
+
+        amc_lay = QHBoxLayout()
+
+        sensors_widget = self._sensorsAFC(slot)
+        fru_widget = self._fruAFC(slot)
+
+        amc_lay.addWidget(sensors_widget)
+        amc_lay.addWidget(fru_widget)
+
+        lay.addLayout(amc_lay)
+
+    def _sensorsAFC(self, amc_number):
+        if self.display.dev == 'FOFBCtrl':
+            pv_list_sensors = ipmi_mngr_pvs.AFCv4_0_PV_LIST['sensors']
+
+        else:
+            pv_list_sensors = ipmi_mngr_pvs.AFCv3_1_PV_LIST['sensors']
+
+        group = self._setup_pv_group(
+            self.display, amc_number, pv_list_sensors)
+
+        return group
+
+    def _setup_pv_group(self, device, slot, pv_dict):
+        device = _PVName(device)
+        crate = RaBPMSearch.conv_devname_2_cratename(device)
+        amc_number = slot
+
+        sections = {
+            "Pwr": QGroupBox("Power Module", self),
+            "12V": QGroupBox("12V", self),
+            "VADJ": QGroupBox("VADJ", self),
+            "3V3": QGroupBox("3V3", self),
+            "Temp": QGroupBox("Temperature", self)
+        }
+        layouts = {k: QGridLayout(sections[k]) for k in sections}
+
+        wid = QWidget(self)
+        lay_sensor = QGridLayout(wid)
+
+        def add_volt_widgets(label, k, pv_name):
+            lay = QGridLayout()
+            lbl_title = QLabel(f"<h5>{label}</h5>", alignment=Qt.AlignCenter)
+            if k[:3] in ['AMC', 'RTM']:
+                lab_pv = QLabel(k[:3], alignment=Qt.AlignCenter)
+            else:
+                lab_pv = QLabel(k[:4], alignment=Qt.AlignCenter)
+            slab_pv = SiriusLabel(
+                self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}")
+            slab_pv.showUnits = True
+            lay.addWidget(lab_pv, 0, 0, alignment=Qt.AlignCenter)
+            lay.addWidget(slab_pv, 0, 1, alignment=Qt.AlignCenter)
+            return lbl_title, lay
+
+        def add_curr_widgets(label, pv_name):
+            lay = QGridLayout()
+            lbl_title = QLabel(f"<h5>{label}</h5>", alignment=Qt.AlignCenter)
+            slab_pv = SiriusLabel(
+                self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}")
+            slab_pv.showUnits = True
+            lay.addWidget(slab_pv, 0, 0, alignment=Qt.AlignCenter)
+            return lbl_title, lay
+
+        def add_temp_widgets(k, pv_name):
+            lay = QGridLayout()
+            lab_pv = QLabel(k[4:], alignment=Qt.AlignCenter)
+            slab_pv = SiriusLabel(
+                self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}")
+            slab_pv.showUnits = True
+            lay.addWidget(lab_pv, 0, 0, 1, 2, alignment=Qt.AlignLeft)
+            lay.addWidget(slab_pv, 0, 2, 1, 2, alignment=Qt.AlignRight)
+            return lay
+
+        def add_led_alert(pv_name):
+            led = SiriusLedAlert(
+                self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}")
+            led.onColor = PyDMLed.LightGreen
+            led.offColor = PyDMLed.Red
+            return led
+
+        row = {
+            "12V": 1,
+            "VADJ": 1,
+            "3V3": 1,
+            "Temp": 1
+        }
+
+        for k, pv_name in pv_dict.items():
+            for section in sections:
+                if section in pv_name and section in str(k):
+                    layout = layouts[section]
+                    if 'Mon' in pv_name:
+                        if 'Pwr' in pv_name and 'Pwr' in str(k):
+                            lay = QGridLayout()
+                            lay.setHorizontalSpacing(40)
+                            lab_pv = QLabel("<h5>Current</h5>",
+                                            alignment=Qt.AlignCenter)
+                            slab_pv = SiriusLabel(
+                                self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}")
+                            slab_pv.showUnits = True
+                            lay.addWidget(lab_pv, 0, 0, 1, 2,
+                                          alignment=Qt.AlignLeft)
+                            lay.addWidget(slab_pv, 0, 2, 1, 2,
+                                          alignment=Qt.AlignRight)
+                            layout.addLayout(lay, 0, 0)
+                        if 'Volt' in pv_name and 'Volt' in str(k):
+                            volt_title, volt_lay = add_volt_widgets(
+                                "Voltage", k, pv_name)
+                            layout.addWidget(volt_title, 0, 0,
+                                             alignment=Qt.AlignCenter)
+                        if 'Curr' in pv_name and 'Curr' in str(k):
+                            curr_title, curr_lay = add_curr_widgets(
+                                "Current", pv_name)
+                            layout.addWidget(curr_title, 0, 1,
+                                             alignment=Qt.AlignCenter)
+                            layout.addLayout(
+                                volt_lay, row[section], 0, alignment=Qt.AlignCenter)
+                            layout.addLayout(
+                                curr_lay, row[section], 1, alignment=Qt.AlignCenter)
+                            row[section] += 1
+                        if section == 'Temp':
+                            temp_lay = add_temp_widgets(k, pv_name)
+                            layout.addLayout(temp_lay, row[section], 0)
+                            row[section] += 1
+
+                    elif 'Cte' in pv_name:
+                        led = add_led_alert(pv_name)
+                        if 'Volt' in pv_name and 'Volt' in str(k):
+                            volt_lay.addWidget(
+                                led, 0, 2, alignment=Qt.AlignCenter)
+                        elif 'Curr' in pv_name and 'Curr' in str(k):
+                            curr_lay.addWidget(
+                                led, 0, 2, alignment=Qt.AlignCenter)
+                        elif 'Temp' in pv_name and 'Temp' in str(k):
+                            temp_lay.addWidget(
+                                led, 0, 4, alignment=Qt.AlignRight)
+
+        lay_sensor.addWidget(sections['Pwr'], 0, 0, alignment=Qt.AlignCenter)
+        lay_sensor.addWidget(sections['12V'], 1, 0, alignment=Qt.AlignCenter)
+        lay_sensor.addWidget(sections['VADJ'], 2, 0, alignment=Qt.AlignCenter)
+        lay_sensor.addWidget(sections['3V3'], 3, 0, alignment=Qt.AlignCenter)
+        lay_sensor.addWidget(sections['Temp'], 4, 0, alignment=Qt.AlignCenter)
+
+        area = QGroupBox('Sensors', self)
+        lay_area = QHBoxLayout(area)
+        lay_area.addWidget(wid)
+        return area
+
+    def _fruAFC(self, amc_number):
+        wid = QWidget(self)
+        lay_fru = QGridLayout(wid)
+        lay_fru.addWidget(
+            QLabel('<h4>Device</h4>', self, alignment=Qt.AlignCenter),
+            0, 0, alignment=Qt.AlignLeft)
+        lay_fru.addWidget(
+            QLabel('<h4>Measurement</h4>', self, alignment=Qt.AlignCenter), 0, 1)
+
+        row = 1
+        if self.display.dev == 'FOFBCtrl':
+            pv_list_fru = ipmi_mngr_pvs.AFCv4_0_PV_LIST['FRU']
+        else:
+            pv_list_fru = ipmi_mngr_pvs.AFCv3_1_PV_LIST['FRU']
+
+        for k, pv_name in pv_list_fru.items():
+            if 'PowerCtl-Sel' in pv_name:
+                grbx = QGroupBox('Power Control', self)
+                grbx_lay = QGridLayout(grbx)
+                grbx_lay.setSpacing(30)
+                crate = RaBPMSearch.conv_devname_2_cratename(self.display)
+                scbx_pv = SiriusEnumComboBox(
+                    self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_list_fru['PowerCtl']}"
+                )
+                grbx_lay.addWidget(scbx_pv, 0, 1)
+                lay_fru.addWidget(grbx, row, 0, 1, 2)
+                row += 1
+
+            elif 'SoftRst-Cmd' in pv_name:
+                grbx = QGroupBox('Soft. Reset', self)
+                grbx_lay = QGridLayout(grbx)
+                grbx_lay.setSpacing(30)
+                crate = RaBPMSearch.conv_devname_2_cratename(self.display)
+
+                cmd_button = SiriusPushButton(
+                    self, label='Reset', icon=qta.icon('mdi.restart'),
+                    init_channel=f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_list_fru['SoftRst']}"
+                )
+                grbx_lay.addWidget(cmd_button, 0, 1)
+
+                label_mon = SiriusLabel(
+                    self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_list_fru['SoftRstSts']}"
+                )
+                grbx_lay.addWidget(label_mon, 0, 2)
+
+                lay_fru.addWidget(grbx, row, 0, 1, 2)
+                row += 1
+
+            elif 'Cte' in pv_name:
+                crate = RaBPMSearch.conv_devname_2_cratename(self.display)
+                label = QLabel(k, alignment=Qt.AlignCenter)
+                slab_pv = SiriusLabel(
+                    self, f"{crate}:{ipmi_mngr_pvs.DIS}-AMC-{amc_number}:{pv_name}"
+                )
+
+                lay_fru.addWidget(label, row, 0, alignment=Qt.AlignLeft)
+                lay_fru.addWidget(slab_pv, row, 1, alignment=Qt.AlignCenter)
+                row += 1
+
+        return self._group_area(wid, 'FRU')
+
+    def _group_area(self, widget, name):
+        area = QGroupBox(f'{name}', self)
+        lay_area = QHBoxLayout(area)
+        lay_area.addWidget(widget)
+        return area

--- a/pyqt-apps/siriushla/common/afc_board/ipmi_mngr_pvs.py
+++ b/pyqt-apps/siriushla/common/afc_board/ipmi_mngr_pvs.py
@@ -1,0 +1,125 @@
+# For AFCv3.1., the PV name follows - $(AREA):$(DIS)-AMC-{1, 3, ..., 12}:
+# For AFCv4.0., the PV name follows - $(AREA):$(DIS)-AMC-2:
+
+# AREA=IA-{{01, ..., 20}RaBPM|20RaBPMTL} # Area = LNLS uTCA crates
+# DIS=CO  # Discipline = Control
+
+DIS = 'CO'
+
+list_3_1_sensors = [
+    'FMC1Volt12V',
+    'FMC1Volt12VPrs',
+    'FMC1Curr12V',
+    'FMC1Curr12VPrs',
+    'FMC2Volt12V',
+    'FMC2Volt12VPrs',
+    'FMC2Curr12V',
+    'FMC2Curr12VPrs',
+    'FMC1VoltVADJ',
+    'FMC1VoltVADJPrs',
+    'FMC1CurrVADJ',
+    'FMC1CurrVADJPrs',
+    'FMC2VoltVADJ',
+    'FMC2VoltVADJPrs',
+    'FMC2CurrVADJ',
+    'FMC2CurrVADJPrs',
+    'FMC1Volt3V3',
+    'FMC1Volt3V3Prs',
+    'FMC1Curr3V3',
+    'FMC1Curr3V3Prs',
+    'FMC2Volt3V3',
+    'FMC2Volt3V3Prs',
+    'FMC2Curr3V3',
+    'FMC2Curr3V3Prs',
+    'TempFPGA',
+    'TempFPGAPrs',
+    'TempUC',
+    'TempUCPrs',
+    'TempClkSwitch',
+    'TempClkSwitchPrs',
+    'TempDCDC',
+    'TempDCDCPrs',
+    'TempRAM',
+    'TempRAMPrs',
+    'Pwr'
+]
+
+list_4_0_sensors = [
+    'AMCVolt12V',
+    'AMCVolt12VPrs',
+    'AMCCurr12V',
+    'AMCCurr12VPrs',
+    'RTMVolt12V',
+    'RTMVolt12VPrs',
+    'RTMCurr12V',
+    'RTMCurr12VPrs',
+    'FMC1VoltVADJ',
+    'FMC1VoltVADJPrs',
+    'FMC1CurrVADJ',
+    'FMC1CurrVADJPrs',
+    'FMC2VoltVADJ',
+    'FMC2VoltVADJPrs',
+    'FMC2CurrVADJ',
+    'FMC2CurrVADJPrs',
+    'FMC1Volt3V3',
+    'FMC1Volt3V3Prs',
+    'FMC1Curr3V3',
+    'FMC1Curr3V3Prs',
+    'FMC2Volt3V3',
+    'FMC2Volt3V3Prs',
+    'FMC2Curr3V3',
+    'FMC2Curr3V3Prs',
+    'TempFPGA',
+    'TempFPGAPrs',
+    'TempUC',
+    'TempUCPrs',
+    'TempClkSwitch',
+    'TempClkSwitchPrs',
+    'TempDCDC',
+    'TempDCDCPrs',
+    'TempRAM',
+    'TempRAMPrs',
+    'Pwr'
+]
+
+AFCv3_1_PV_LIST = {
+    'sensors': {},
+    'FRU': {
+        'Status': 'Status-Cte',
+        'FruId': 'FruId-Cte',
+        'BoardManuf': 'BoardManuf-Cte',
+        'BoardName': 'BoardName-Cte',
+        'BoardSN': 'BoardSN-Cte',
+        'BoardPN': 'BoardPN-Cte',
+        'ProdManuf': 'ProdManuf-Cte',
+        'ProdName': 'ProdName-Cte',
+        'ProdSN': 'ProdSN-Cte',
+        'ProdPN': 'ProdPN-Cte',
+        'PowerCtl': 'PowerCtl-Sel',
+        'SoftRst': 'SoftRst-Cmd',
+        'SoftRstSts': 'SoftRstSts-Mon'
+    }
+}
+
+AFCv4_0_PV_LIST = {
+    'sensors': {},
+    'FRU': {
+        'Status': 'Status-Cte',
+        'FruId': 'FruId-Cte',
+        'BoardManuf': 'BoardManuf-Cte',
+        'BoardName': 'BoardName-Cte',
+        'BoardSN': 'BoardSN-Cte',
+        'BoardPN': 'BoardPN-Cte',
+        'ProdManuf': 'ProdManuf-Cte',
+        'ProdName': 'ProdName-Cte',
+        'ProdSN': 'ProdSN-Cte',
+        'ProdPN': 'ProdPN-Cte',
+        'PowerCtl': 'PowerCtl-Sel',
+        'SoftRst': 'SoftRst-Cmd',
+        'SoftRstSts': 'SoftRstSts-Mon'
+    }
+}
+
+AFCv3_1_PV_LIST['sensors'] = {sen: sen + ('-Cte' if sen.endswith('Prs') else '-Mon') for sen in list_3_1_sensors}
+
+AFCv4_0_PV_LIST['sensors'] = {sen: sen + ('-Cte' if sen.endswith('Prs') else '-Mon') for sen in list_4_0_sensors}


### PR DESCRIPTION
**RaBPM Monitor Updates**

**_Timing / EVR_**

1. _Add a new tab (**AFC Details**) in the Timing interface_:
<img width="1010" height="853" alt="image" src="https://github.com/user-attachments/assets/c186b052-3d2e-4b08-a560-49f019de980d" />


   1.1 _Add a shortcut and Reset button to AFC settings details GUI_:
   <img width="1384" height="850" alt="image" src="https://github.com/user-attachments/assets/4356e835-4a5e-43ef-a413-6db63edb77fe" />

   <img width="1384" height="850" alt="image" src="https://github.com/user-attachments/assets/a5e55edd-7d51-4b01-8c14-64baf6a72f8a" />


**_FOFB / Controller_**

1. _Add a new tab (**AFC Details**) in the FOFB - Controllers Details Dialog window_:

<img width="544" height="541" alt="image" src="https://github.com/user-attachments/assets/a90ddf7a-0c60-4402-804e-cae9efe3f4c0" />

   1.1 _Following the standard of the FOFB interface, it was added a list of the all 20 shortcuts and Reset buttons to AFC Settings_:

   <img width="922" height="541" alt="image" src="https://github.com/user-attachments/assets/085fd4d3-056d-4f37-aa8e-4430cd69c238" />

   <img width="922" height="546" alt="image" src="https://github.com/user-attachments/assets/7f4e8068-8339-47dc-905e-f7e3a392a1cc" />

**_BPM_**

1. _Add a new group (**AFC Details**) with the AFC Settings and Reset buttons, and a detailed AFC window_:

   1.1 **PBPM**
   
<img width="799" height="668" alt="image" src="https://github.com/user-attachments/assets/61ebc3de-7db1-43b9-bfe4-0eddd64de284" />
<img width="799" height="668" alt="image" src="https://github.com/user-attachments/assets/35c9a32a-1960-4f45-bdfa-dad736f2429f" />

   1.2 **ID BPM**
      
<img width="763" height="672" alt="image" src="https://github.com/user-attachments/assets/e9177eec-13b4-474d-9c1f-83f18afc8535" />
<img width="763" height="672" alt="image" src="https://github.com/user-attachments/assets/037da8d1-0feb-4dc4-b012-daa7b6fe1530" />

   1.3 **SI BPM**
      
<img width="763" height="672" alt="image" src="https://github.com/user-attachments/assets/37eff964-d628-46c7-9450-436b22c99684" />
<img width="763" height="672" alt="image" src="https://github.com/user-attachments/assets/9eb53437-deb4-47d5-8535-ee6b01c3d214" />

   1.4 **BO BPM**
   
<img width="763" height="589" alt="image" src="https://github.com/user-attachments/assets/0be4eb72-abf1-41af-9f3d-15d0f7e2b83b" />
<img width="763" height="589" alt="image" src="https://github.com/user-attachments/assets/f8a2973e-7a7a-4bc5-b521-5dc44aafe81a" />

   1.5 **TB BPM**
   
<img width="729" height="589" alt="image" src="https://github.com/user-attachments/assets/95753a4b-3721-4dc3-bdf1-c197c08f0ee4" />
<img width="729" height="589" alt="image" src="https://github.com/user-attachments/assets/7889f4ed-337b-4317-9c61-579f1dddeb44" />

   1.6 **TS BPM**
   
<img width="717" height="589" alt="image" src="https://github.com/user-attachments/assets/c0fb19e7-25b1-40c5-9c5a-dd9a506aa8f5" />
<img width="717" height="589" alt="image" src="https://github.com/user-attachments/assets/e58eccfe-a526-4780-8d75-9f2ed6e6b694" />


   