### PR TITLE
Add changes in labels style, precision and details in the RF Operation GUI

### DIFF
--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/adv_interlock.py
@@ -168,7 +168,7 @@ class AdvancedInterlockDetails(SiriusDialog):
             "    border-left: 2px solid gray;"
             "    border-bottom: 2px solid gray;"
             "    border-right: 2px solid gray;}")
-        
+
         tab1 = QWidget()
         tab1_layout = QGridLayout(tab1)
         tab1_layout.setAlignment(Qt.AlignTop)
@@ -188,7 +188,7 @@ class AdvancedInterlockDetails(SiriusDialog):
         tab1_layout.addWidget(SiriusSpinbox(
             self, rv_ch + '-SP'), 0, 1, alignment=Qt.AlignCenter)
         tab1_layout.addWidget(lb_rv, 0, 2, alignment=Qt.AlignCenter)
-        
+
         tab1_layout.addWidget(QLabel(
             'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab1_layout.addWidget(SiriusSpinbox(
@@ -205,7 +205,7 @@ class AdvancedInterlockDetails(SiriusDialog):
         fw_ch = self.prefix+chs_dict['E-Quench']['Fw']
         lb_fw = SiriusLabel(self, fw_ch+'-RB')
         lb_fw.showUnits = True
-        lb_fw._keep_unit = True 
+        lb_fw._keep_unit = True
 
         dly_ch_e = self.prefix+chs_dict['E-Quench']['Dly']
         lb_dly_e = SiriusLabel(self, dly_ch_e+'-RB')
@@ -216,7 +216,7 @@ class AdvancedInterlockDetails(SiriusDialog):
         tab2_layout.addWidget(SiriusSpinbox(
             self, fw_ch+'-SP'), 0, 1, alignment=Qt.AlignCenter)
         tab2_layout.addWidget(lb_fw, 0, 2, alignment=Qt.AlignCenter)
-        
+
         tab2_layout.addWidget(QLabel(
             'Delay'), 1, 0, alignment=Qt.AlignRight | Qt.AlignVCenter)
         tab2_layout.addWidget(SiriusSpinbox(
@@ -237,21 +237,21 @@ class AdvancedInterlockDetails(SiriusDialog):
     def _genDiagLayout(self, chs_dict):
         lay = QGridLayout()
         lay.setAlignment(Qt.AlignTop)
-        lay.setSpacing(9)
+        lay.setSpacing(12)
 
         # Interlocks Delay
         lb_dly = SiriusLabel(self, self.prefix+chs_dict['Delay']+'-RB')
         lb_dly.showUnits = True
 
-        lay.addWidget(QLabel('Interlocks Delay'), 0, 0)
+        lay.addWidget(QLabel('Interlocks Delay'), 0, 0, alignment=Qt.AlignRight)
         lay.addWidget(SiriusSpinbox(
-            self, self.prefix+chs_dict['Delay']+'-SP'), 0, 1)
-        lay.addWidget(lb_dly, 0, 2)
+            self, self.prefix+chs_dict['Delay']+'-SP'), 0, 1, alignment=Qt.AlignLeft)
+        lay.addWidget(lb_dly, 0, 2, alignment=Qt.AlignLeft)
 
         # HW Interlock
-        lay.addWidget(QLabel('HW Interlock'), 1, 0)
+        lay.addWidget(QLabel('HW Interlock'), 1, 0, alignment=Qt.AlignRight)
         lay.addWidget(SiriusLedAlert(
-            self, self.prefix+chs_dict['HW']), 1, 2, alignment=Qt.AlignCenter)
+            self, self.prefix+chs_dict['HW']), 1, 2, alignment=Qt.AlignLeft)
 
         # Manual Interlock, End Switches and Logic Inversions
         keys = ['Manual', 'EndSw', 'Beam Inv',
@@ -259,16 +259,17 @@ class AdvancedInterlockDetails(SiriusDialog):
         row = 2
         column = 0
         for key in keys:
-            lay.addWidget(QLabel(chs_dict[key][0]), row, column)
+            lay.addWidget(QLabel(chs_dict[key][0]), row, column, alignment=Qt.AlignRight)
             lay.addWidget(PyDMStateButton(
-                self, self.prefix+chs_dict[key][1]+'-Sel'), row, column+1)
+                self, self.prefix+chs_dict[key][1]+'-Sel'), row, column+1, alignment=Qt.AlignLeft)
             lay.addWidget(SiriusLedState(
                 self, self.prefix+chs_dict[key][1]+'-Sts'),
-                row, column+2, alignment=Qt.AlignCenter)
+                row, column+2, alignment=Qt.AlignLeft)
             row += 1
             if row == 4:
                 row = 0
                 column += 3
+                lay.setColumnMinimumWidth(2, 130)
 
         return lay
 

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/ssa_currents.py
@@ -181,12 +181,36 @@ class SSACurrentsDetails(SiriusDialog):
 
                 lb_a_1 = SiriusLabel(self, pv_a_1)
                 lb_a_1.showUnits = True
+                lb_a_1.precisionFromPV = False
+                lb_a_1.precision = 2
+                lb_a_1.setStyleSheet("""
+                    background: #349ae3;
+                    """)
+
                 lb_a_2 = SiriusLabel(self, pv_a_2)
                 lb_a_2.showUnits = True
+                lb_a_2.precisionFromPV = False
+                lb_a_2.precision = 2
+                lb_a_2.setStyleSheet("""
+                    background: #349ae3;
+                    """)
+
                 lb_b_1 = SiriusLabel(self, pv_b_1)
                 lb_b_1.showUnits = True
+                lb_b_1.precisionFromPV = False
+                lb_b_1.precision = 2
+                lb_b_1.setStyleSheet("""
+                    background: #349ae3;
+                    """)
+
                 lb_b_2 = SiriusLabel(self, pv_b_2)
                 lb_b_2.showUnits = True
+                lb_b_2.precisionFromPV = False
+                lb_b_2.precision = 2
+                lb_b_2.setStyleSheet("""
+                    background: #349ae3;
+                    """)
+
 
                 if row_label == 'left':
                     lay.addWidget(QLabel(
@@ -294,16 +318,20 @@ class SSACurrentsDetails(SiriusDialog):
         column = 0
         if self.section == 'SI':
             # Heat Sinks
-            for i in range(2, 9, 2):
+            for i in range(1, 9):
                 label = QLabel(
                     f'<h4>Heat Sink {i}</h4>', alignment=Qt.AlignCenter)
                 label.setStyleSheet("min-width:6em;")
                 lb_1 = SiriusLabel(self, self._substitute_macros(
                     self.prefix+chs_dict['HS'], i, curr_num='1'))
                 lb_1.showUnits = True
+                lb_1.precisionFromPV = False
+                lb_1.precision = 2
                 lb_2 = SiriusLabel(self, self._substitute_macros(
                     self.prefix+chs_dict['HS'], i, curr_num='2'))
                 lb_2.showUnits = True
+                lb_2.precisionFromPV = False
+                lb_2.precision = 2
 
                 lay.addWidget(label, row, column)
                 lay.addWidget(lb_1, row+1, column)
@@ -313,19 +341,6 @@ class SSACurrentsDetails(SiriusDialog):
                 if column > 1:
                     row += 3
                     column = 0
-
-            # Pre Amp
-            label = QLabel('<h4>PreAmp</h4>', alignment=Qt.AlignCenter)
-            lb_1 = SiriusLabel(self, self._substitute_macros(
-                self.prefix+chs_dict['PreAmp'], curr_num='1'))
-            lb_1.showUnits = True
-            lb_2 = SiriusLabel(self, self._substitute_macros(
-                self.prefix+chs_dict['PreAmp'], curr_num='2'))
-            lb_2.showUnits = True
-
-            lay.addWidget(label, row, 0, 1, 2)
-            lay.addWidget(lb_1, row+1, 0, 1, 2)
-            lay.addWidget(lb_2, row+2, 0, 1, 2)
 
         else:
             # Heat Sinks

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -4232,7 +4232,7 @@ SEC_2_CHANNELS = {
                 'Diagnostics': {
                     'General': {
                         'Manual': ['Manual Interlock', 'RA-RaSIA01:RF-LLRF:IntlkManual'],
-                        'EndSw': ['End Switches', 'RA-RaSIA01:RF-LLRF:EndSwLogicInv'],
+                        'EndSw': ['End Switches Logic Inversion', 'RA-RaSIA01:RF-LLRF:EndSwLogicInv'],
                         'Delay': 'RA-RaSIA01:RF-LLRF:IntlkDly',
                         'HW': 'RA-RaSIA01:RF-LLRF:FDLHwTrig-Mon',
                         'Beam Inv': ['Logic Inv. LLRF Beam Trip', 'RA-RaSIA01:RF-LLRF:OrbitIntlkLogicInv'],
@@ -4318,7 +4318,7 @@ SEC_2_CHANNELS = {
                     '815': ['Ext LLRF 3', 'RA-RaSIA01:RF-LLRF:FIMLLRF3'],
                     '816 1': ['End Switch Up 1', 'RA-RaSIA01:RF-LLRF:FIMTunerHigh'],
                     '817 1': ['End Switch Down 1', 'RA-RaSIA01:RF-LLRF:FIMTunerLow'],
-                    '816 2': ['End Switch Up 2', 'RA-RaSIA01:RF-LLRF:FIMPLG2Up'],
+                    '816 2': ['Cryo Mod Intlk (End Switch Up 2)', 'RA-RaSIA01:RF-LLRF:FIMPLG2Up'],
                     '817 2': ['End Switch Down 2', 'RA-RaSIA01:RF-LLRF:FIMPLG2Down'],
                     '853': ['Quench Condition 1', 'RA-RaSIA01:RF-LLRF:FIMQuenchCond1'],
                     '857': ['E-Quench', 'RA-RaSIA01:RF-LLRF:FIMEQuench'],
@@ -4341,7 +4341,7 @@ SEC_2_CHANNELS = {
                 'Diagnostics': {
                     'General': {
                         'Manual': ['Manual Interlock', 'RA-RaSIB01:RF-LLRF:IntlkManual'],
-                        'EndSw': ['End Switches', 'RA-RaSIB01:RF-LLRF:EndSwLogicInv'],
+                        'EndSw': ['End Switches Logic Inversion', 'RA-RaSIB01:RF-LLRF:EndSwLogicInv'],
                         'Delay': 'RA-RaSIB01:RF-LLRF:IntlkDly',
                         'HW': 'RA-RaSIB01:RF-LLRF:FDLHwTrig-Mon',
                         'Beam Inv': ['Logic Inv. LLRF Beam Trip', 'RA-RaSIB01:RF-LLRF:OrbitIntlkLogicInv'],
@@ -4427,7 +4427,7 @@ SEC_2_CHANNELS = {
                     '815': ['Ext LLRF 3', 'RA-RaSIB01:RF-LLRF:FIMLLRF3'],
                     '816 1': ['End Switch Up 1', 'RA-RaSIB01:RF-LLRF:FIMTunerHigh'],
                     '817 1': ['End Switch Down 1', 'RA-RaSIB01:RF-LLRF:FIMTunerLow'],
-                    '816 2': ['End Switch Up 2', 'RA-RaSIB01:RF-LLRF:FIMPLG2Up'],
+                    '816 2': ['Cryo Mod Intlk (End Switch Up 2)', 'RA-RaSIB01:RF-LLRF:FIMPLG2Up'],
                     '817 2': ['End Switch Down 2', 'RA-RaSIB01:RF-LLRF:FIMPLG2Down'],
                     '853': ['Quench Condition 1', 'RA-RaSIB01:RF-LLRF:FIMQuenchCond1'],
                     '857': ['E-Quench', 'RA-RaSIB01:RF-LLRF:FIMEQuench'],


### PR DESCRIPTION
**SSA Current**
- _SSA 01 Current Details example (The same goes for the other SSA Currents)_

<img width="1805" height="936" alt="image" src="https://github.com/user-attachments/assets/ff580237-f3fb-401d-8853-c366c3627bcc" />


**LLRF Interlock**
- _Advanced Details -> Diagnostics (A example, the same goes for B)_

<img width="1125" height="916" alt="image" src="https://github.com/user-attachments/assets/1e1cc87f-f265-4bb3-84bf-70d679b05cff" />

<img width="1394" height="916" alt="image" src="https://github.com/user-attachments/assets/fd93eb66-e983-40c1-9dfe-11c54c1b94b0" />

