### PR TITLE
RF.ENH: LLRF Booster and Sirius GUI update

### DIFF
--- a/pyqt-apps/scripts/sirius-hla-si-rf-control.py
+++ b/pyqt-apps/scripts/sirius-hla-si-rf-control.py
@@ -7,7 +7,8 @@ import sys
 
 from siriushla.as_rf_control.advanced_details import ADCDACDetails, \
     AutoStartDetails, CalEqDetails, CalSysDetails, HardwareDetails, \
-    LoopsDetails, RampsDetails, RFInputsDetails, TuningDetails
+    LoopsDetails, RampsDetails, RFInputsDetails, TuningDetails, \
+    TempVariationDetails
 from siriushla.as_rf_control.control import RFMainControl
 from siriushla.as_rf_control.details import CavityStatusDetails, FDLDetails, \
     LLRFInterlockDetails, SlowLoopErrorDetails, SlowLoopParametersDetails, \
@@ -39,6 +40,7 @@ specific_system_windows = {
     'rf-inputs': RFInputsDetails,
     'tuning': TuningDetails,
     'fdl': FDLDetails,
+    'temp-variations': TempVariationDetails
 }
 
 general_windows = {

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/__init__.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/__init__.py
@@ -10,3 +10,4 @@ from .ramps import RampsDetails
 from .rf_inputs import RFInputsDetails
 from .ssa_currents import SSACurrentsDetails
 from .tuning import TuningDetails
+from .temp_variations import TempVariationDetails

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/temp_variations.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/temp_variations.py
@@ -27,7 +27,7 @@ class TempVariationDetails(SiriusDialog):
         self.system = system
         self.chs = SEC_2_CHANNELS[self.section]
         self.setObjectName(self.section+'App')
-        self.title = 'Temperature Variation Details'
+        self.title = 'CM Temp Details'
         self.title += (f' - {self.system}' if self.section == 'SI' else '')
         self.setWindowTitle(self.title)
         if self.section == 'SI':

--- a/pyqt-apps/siriushla/as_rf_control/advanced_details/temp_variations.py
+++ b/pyqt-apps/siriushla/as_rf_control/advanced_details/temp_variations.py
@@ -1,0 +1,181 @@
+"""Temperature Variations advanced details."""
+
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, \
+    QVBoxLayout, QWidget
+
+from pyqtgraph import InfiniteLine, mkPen
+
+from pydm.widgets.channel import PyDMChannel
+
+from ...widgets import SiriusDialog, SiriusLabel, SiriusTimePlot, \
+    SiriusLineEdit
+from ..custom_widgets import RFTitleFrame
+from ..util import DEFAULT_STYLESHEET, SEC_2_CHANNELS
+
+
+class TempVariationDetails(SiriusDialog):
+    """Temperature Variations advanced details."""
+
+    def __init__(self, parent=None, prefix='', section='', system=''):
+        """Init."""
+        super().__init__(parent)
+        self.prefix = prefix
+        self.prefix += ('-' if prefix and not prefix.endswith('-') else '')
+        self.section = section
+        self.system = system
+        self.chs = SEC_2_CHANNELS[self.section]
+        self.setObjectName(self.section+'App')
+        self.title = 'Temperature Variation Details'
+        self.title += (f' - {self.system}' if self.section == 'SI' else '')
+        self.setWindowTitle(self.title)
+        if self.section == 'SI':
+            self.syst_dict = self.chs['TempVariations'][self.system]
+        self._setupUi()
+
+    def _setupUi(self):
+        self.setStyleSheet(DEFAULT_STYLESHEET)
+        lay = QVBoxLayout(self)
+        lay.setAlignment(Qt.AlignTop)
+
+        title_frame = RFTitleFrame(self, self.system)
+        lay_title = QVBoxLayout(title_frame)
+        lay_title.addWidget(QLabel(
+            f'<h4>{self.title}</h4>', alignment=Qt.AlignCenter))
+
+        wid_temp_var = QWidget(self)
+        wid_temp_var.setMinimumSize(1300, 500)
+        wid_temp_var.setMaximumSize(1300, 500)
+        wid_temp_var.setLayout(
+            self._TempMonLayout(self.syst_dict))
+
+        lay.addWidget(title_frame)
+        lay.addWidget(wid_temp_var)
+
+    def _TempMonLayout(self, chs_dict):
+        main_layout = QGridLayout()
+
+        gbox_temp = QGroupBox('Temperature Variation')
+        lay_var = QGridLayout()
+        gbox_temp.setLayout(lay_var)
+
+        pen = mkPen(color='k', width=2, style=Qt.DashLine)
+
+        graph_temp = SiriusTimePlot(self)
+        graph_temp.setShowXGrid(True)
+        graph_temp.setShowYGrid(True)
+        graph_temp.setShowLegend(True)
+        graph_temp.setAutoRangeX(True)
+        graph_temp.setAutoRangeY(True)
+        graph_temp.setBackgroundColor(QColor(255, 255, 255))
+        graph_temp.setTimeSpan(1800)
+        graph_temp.maxRedrawRate = 2
+
+        self.ref_lines = {}
+        self.ref_channels = {}
+
+        tags_a = ['BT110', 'BT111', 'BT112']
+        tags_b = ['BT210', 'BT211', 'BT212']
+
+        tags = tags_a if self.system == "A" else tags_b
+        addr = 'TempRate'
+        lims = ['Max', 'Min']
+        for tag in tags:
+            graph_temp.addYChannel(
+                y_channel=self.prefix+chs_dict['Temp'][tag][addr][0],
+                color=chs_dict['Temp'][tag][addr][1], name=tag,
+                lineStyle=Qt.SolidLine, lineWidth=1)
+
+            self.ref_lines[tag] = {}
+            self.ref_channels[tag] = {}
+
+            for lim in lims:
+                pv_lim = self.prefix+chs_dict['Temp'][tag][lim]
+                line = InfiniteLine(
+                    pos=0, angle=0, pen=pen)
+                graph_temp.addItem(line)
+                self.ref_lines[tag][lim] = line
+                channel = PyDMChannel(
+                    address=pv_lim,
+                    value_slot=lambda val, t=tag, l=lim: self._getTempLim(t, l, val)
+                )
+                channel.connect()
+                self.ref_channels[tag][lim] = channel
+
+        graph_temp.setLabel('left', 'K/min')
+
+        lay_var.addWidget(graph_temp, 0, 0)
+
+        gbox_delta = QGroupBox('Delta')
+        lay_delta = QGridLayout()
+        gbox_delta.setLayout(lay_delta)
+
+        graph_delta = SiriusTimePlot(self)
+        graph_delta.setShowXGrid(True)
+        graph_delta.setShowYGrid(True)
+        graph_delta.setShowLegend(True)
+        graph_delta.setAutoRangeX(True)
+        graph_delta.setAutoRangeY(True)
+        graph_delta.setBackgroundColor(QColor(255, 255, 255))
+        graph_delta.setTimeSpan(1800)
+        graph_delta.maxRedrawRate = 2
+
+        self.ref_lines_delta = {}
+        self.ref_channels_delta = {}
+
+        delta = 'Delta A' if self.system == "A" else 'Delta B'
+
+        graph_delta.addYChannel(
+            y_channel=self.prefix+chs_dict[delta]['Diff'],
+            color='green', name='Diff',
+            lineStyle=Qt.SolidLine, lineWidth=1)
+
+        for lim in lims:
+            pv_lim_delta = self.prefix+chs_dict[delta][lim]
+            line_delta = InfiniteLine(
+                pos=0, angle=0, pen=pen)
+            graph_delta.addItem(line_delta)
+            self.ref_lines_delta[lim] = line_delta
+            channel_delta = PyDMChannel(
+                address=pv_lim_delta,
+                value_slot=lambda val, l=lim: self._getDeltaLim(l, val)
+            )
+            channel_delta.connect()
+            self.ref_channels_delta[lim] = channel_delta
+
+        graph_delta.setLabel('left', 'K')
+
+        lay_delta.addWidget(graph_delta, 0, 0)
+
+        gbox_interval = QGroupBox('Interval Time Setpoint')
+        gbox_interval.setFixedSize(400, 70)
+        lay_interval = QGridLayout()
+        gbox_interval.setLayout(lay_interval)
+
+        interval = 'Interval A' if self.system == "A" else 'Interval B'
+
+        interval_time_lbl = QLabel(f'<h4>{interval}</h4>',
+                                   alignment=Qt.AlignCenter)
+        interval_time_sp = SiriusLineEdit(self,
+                                       init_channel=self.prefix+chs_dict[interval])
+        interval_time_rb = SiriusLabel(self,
+                                       init_channel=self.prefix+chs_dict[interval])
+
+        lay_interval.addWidget(interval_time_lbl, 0, 0, alignment=Qt.AlignCenter)
+        lay_interval.addWidget(interval_time_sp, 0, 1, alignment=Qt.AlignCenter)
+        lay_interval.addWidget(interval_time_rb, 0, 2, alignment=Qt.AlignCenter)
+
+        main_layout.addWidget(gbox_temp, 1, 0)
+        main_layout.addWidget(gbox_delta, 1, 1)
+        main_layout.addWidget(gbox_interval, 0, 0, alignment=Qt.AlignLeft)
+
+        return main_layout
+
+    def _getTempLim(self, tag, lim, value):
+        if value is not None:
+            self.ref_lines[tag][lim].setPos(float(value))
+
+    def _getDeltaLim(self, lim, value):
+        if value is not None:
+            self.ref_lines_delta[lim].setPos(float(value))

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -3,7 +3,7 @@
 from functools import partial as _part
 
 import qtawesome as qta
-from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit, channel
+from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
 from pyqtgraph import InfiniteLine, mkPen
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
@@ -960,7 +960,7 @@ class RFMainControl(SiriusMainWindow):
                 'Cal Eq', 'cal-eq', systems[i], buttons)
             if self.section == "SI":
                 self._addDetailButton(
-                    'Temp Variation', 'temp-variations', systems[i], buttons)
+                    'CM Temp', 'temp-variations', systems[i], buttons)
                 gbox = QGroupBox(f'System {systems[i]}', self)
                 gbox_lay = QGridLayout()
                 gbox_lay.setHorizontalSpacing(9)
@@ -1578,20 +1578,19 @@ class RFMainControl(SiriusMainWindow):
 
                 graph.addYChannel(
                     y_channel=self.prefix+self.chs['RF Area'][f'{systems[i]}']['Temp'],
-                    name=f'Temp_{systems[i]}', color='red', lineStyle=Qt.SolidLine, lineWidth=1)
+                    name=f'Temp_{systems[i]}', color='red',
+                    lineStyle=Qt.SolidLine, lineWidth=1)
 
                 pv_lim = self.prefix+self.chs['RF Area'][f'{systems[i]}'][lim]
-                lim_line = InfiniteLine(
-                    pos=0, angle=0, pen=pen)
-                graph.addItem(lim_line)
-                self.ref_line[lim] = lim_line
 
-                ch_lim = channel.PyDMChannel(
-                    address=pv_lim,
-                    value_slot=lambda val, l=lim: self._getUpperLim(l, val)
+                self.lim_line = InfiniteLine(angle=0, pen=pen)
+                graph.addItem(self.lim_line)
+                self.ref_line[lim] = self.lim_line
+
+                ch_lim = SiriusConnectionSignal(pv_lim)
+                ch_lim.new_value_signal[float].connect(
+                    lambda val, l=lim: self._getUpperLim(l, val)
                 )
-
-                ch_lim.connect()
                 self.ref_channel[lim] = ch_lim
 
                 graph.setLabel('left', '°C')

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -3,7 +3,7 @@
 from functools import partial as _part
 
 import qtawesome as qta
-from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
+from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit, channel
 from pyqtgraph import InfiniteLine, mkPen
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
@@ -958,8 +958,9 @@ class RFMainControl(SiriusMainWindow):
                 'Cal Sys', 'cal-sys', systems[i], buttons)
             self._addDetailButton(
                 'Cal Eq', 'cal-eq', systems[i], buttons)
-
-            if self.section == 'SI':
+            if self.section == "SI":
+                self._addDetailButton(
+                    'Temp Variation', 'temp-variations', systems[i], buttons)
                 gbox = QGroupBox(f'System {systems[i]}', self)
                 gbox_lay = QGridLayout()
                 gbox_lay.setHorizontalSpacing(9)
@@ -994,13 +995,13 @@ class RFMainControl(SiriusMainWindow):
 
     def _handle_rmptab_visibility(self, unit_type):
         for pos in ['Top', 'Bottom']:
-            for pv_id in ['CavPwr', 'PowFwd', 'PowRev']:
+            for pv_id in ['CavPwr', 'PowFwd', 'PowRev', 'SSAFwd', 'SSARev']:
                 self.ramp_chn_wid[unit_type][pos][pv_id].setVisible(True)
         cur_unit = 'mV'
         if unit_type == 'mV':
             cur_unit = 'W'
         for pos in ['Top', 'Bottom']:
-            for pv_id in ['CavPwr', 'PowFwd', 'PowRev']:
+            for pv_id in ['CavPwr', 'PowFwd', 'PowRev', 'SSAFwd', 'SSARev']:
                 self.ramp_chn_wid[cur_unit][pos][pv_id].setVisible(False)
 
     def _rampMonLayout(self):
@@ -1056,9 +1057,6 @@ class RFMainControl(SiriusMainWindow):
         self.cb_ramp.addItems(["W", "mV"])
         self.cb_ramp.currentTextChanged.connect(self._handle_rmptab_visibility)
 
-        self.lb_c3phsbot = SiriusLabel(
-            self, self.prefix+'BO-05D:RF-P5Cav:Cell3BotPhs-Mon')
-        self.lb_c3phsbot.showUnits = True
         self.lb_cavvgapbot = SiriusLabel(
             self, self.prefix+'BO-05D:RF-P5Cav:Cell3BotVGap-Mon')
         self.lb_cavvgapbot.showUnits = True
@@ -1080,9 +1078,6 @@ class RFMainControl(SiriusMainWindow):
                     if unit_type == 'mV':
                         wid_dict[pv_id].setVisible(False)
 
-        self.lb_c3phstop = SiriusLabel(
-            self, self.prefix+'BO-05D:RF-P5Cav:Cell3TopPhs-Mon')
-        self.lb_c3phstop.showUnits = True
         self.lb_cavvgaptop = SiriusLabel(
             self, self.prefix+'BO-05D:RF-P5Cav:Cell3TopVGap-Mon')
         self.lb_cavvgaptop.showUnits = True
@@ -1098,23 +1093,23 @@ class RFMainControl(SiriusMainWindow):
             '<h4>Power Fwd.</h4>', self, alignment=Qt.AlignCenter), 3, 0)
         lay.addWidget(QLabel(
             '<h4>Power Rev.</h4>', self, alignment=Qt.AlignCenter), 4, 0)
+        lay.addWidget(QLabel(
+            '<h4>SSA Fwd.</h4>', self, alignment=Qt.AlignCenter), 5, 0)
+        lay.addWidget(QLabel(
+            '<h4>SSA Rev.</h4>', self, alignment=Qt.AlignCenter), 6, 0)
         lay.addItem(
-            QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Ignored), 5, 0)
+            QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Ignored), 7, 0)
         lay.addWidget(QLabel(
-            '<h4>Phase</h4>', self, alignment=Qt.AlignCenter), 6, 0)
-        lay.addWidget(QLabel(
-            '<h4>Gap Voltage:</h4>', self, alignment=Qt.AlignCenter), 7, 0)
+            '<h4>Gap Voltage:</h4>', self, alignment=Qt.AlignCenter), 8, 0)
 
         lay.addWidget(self.cb_ramp, 1, 0)
-        lay.addWidget(self.lb_c3phsbot, 6, 1)
-        lay.addWidget(self.lb_cavvgapbot, 7, 1, alignment=Qt.AlignCenter)
-        lay.addWidget(self.lb_c3phstop, 6, 2)
-        lay.addWidget(self.lb_cavvgaptop, 7, 2, alignment=Qt.AlignCenter)
-        lay.addItem(QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Fixed), 8, 0)
-        lay.addWidget(self.ramp_graph, 9, 0, 1, 3)
-        lay.addLayout(hbox_rb, 10, 0, 1, 3)
+        lay.addWidget(self.lb_cavvgapbot, 8, 1, alignment=Qt.AlignCenter)
+        lay.addWidget(self.lb_cavvgaptop, 8, 2, alignment=Qt.AlignCenter)
+        lay.addItem(QSpacerItem(0, 20, QSzPlcy.Ignored, QSzPlcy.Fixed), 9, 0)
+        lay.addWidget(self.ramp_graph, 10, 0, 1, 3)
+        lay.addLayout(hbox_rb, 11, 0, 1, 3)
         lay.addItem(
-            QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Expanding), 11, 0)
+            QSpacerItem(0, 10, QSzPlcy.Ignored, QSzPlcy.Expanding), 12, 0)
         return lay
 
     def _powerMeterLayout(self):
@@ -1163,18 +1158,24 @@ class RFMainControl(SiriusMainWindow):
             wch, dbch, mvch = dic['W'], dic['dBm'], dic['mV']
             color = dic['color']
             row = idx+1
-            if idx > 3 and idx < 8:
-                column = 3
-                row = idx-3
-            elif idx >= 8:
-                column = 0
-                if idx == 8:
-                    lay_vals.addItem(QSpacerItem(
-                        0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
-                elif idx > 11:
+            if self.section == 'SI':
+                if idx > 4 and idx < 10:
+                    column = 3
+                    row = idx-4
+                elif idx >= 10:
+                    column = 0
+                    if idx == 8:
+                        lay_vals.addItem(QSpacerItem(
+                            0, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), row, 0)
+                    elif idx > 14:
+                        column = 3
+                        row = idx-4
+                    row += 1
+            elif self.section == 'BO':
+                if idx > 5 and idx < 8:
                     column = 3
                     row = idx-3
-                row += 1
+            row += 1
 
             # Table
             cbx = QCheckBox(self)
@@ -1260,15 +1261,8 @@ class RFMainControl(SiriusMainWindow):
             cmd = f'{cmd} -d rf-inputs'.split(" ")
             connect_newprocess(pb_rfinp, cmd, is_window=True, parent=self)
 
-            lb_cavphs = QLabel('Phase', self, alignment=Qt.AlignCenter)
-            self.lb_cavphs = SiriusLabel(
-                self, self.prefix+'BO-05D:RF-P5Cav:Cell3Phs-Mon')
-            self.lb_cavphs.showUnits = True
-
             lay_vals.addWidget(pb_rfinp, 0, 0, alignment=Qt.AlignCenter)
             lay_vals.addWidget(lb_rfinp, 0, 1)
-            lay_vals.addWidget(lb_cavphs, 5, 1, alignment=Qt.AlignCenter)
-            lay_vals.addWidget(self.lb_cavphs, 5, 2)
         else:
             for name in data:
                 self.curves[name+' W'].setVisible('Coup' in name)
@@ -1481,6 +1475,7 @@ class RFMainControl(SiriusMainWindow):
         self.tempcirc_graph.backgroundColor = QColor(255, 255, 255)
         self.tempcirc_graph.showXGrid = True
         self.tempcirc_graph.showYGrid = True
+        self.tempcirc_graph.showLegend = True
         self.tempcirc_graph.timeSpan = 1800
         self.tempcirc_graph.maxRedrawRate = 1
         if self.section == 'SI':
@@ -1538,6 +1533,9 @@ class RFMainControl(SiriusMainWindow):
 
             row_t = 0
 
+            self.ref_line = {}
+            self.ref_channel = {}
+
             for i in range(len(systems)):
                 lay_grid_temp = QGridLayout()
                 lb_temp_area_sys = QLabel(f'<h3> • {systems[i]} </h3>', self)
@@ -1564,6 +1562,8 @@ class RFMainControl(SiriusMainWindow):
 
                 lay_rfarea.addLayout(lay_grid_temp)
 
+                pen = mkPen(color='k', width=2, style=Qt.DashLine)
+
                 graph = SiriusTimePlot(self)
                 graph.setObjectName(f'system_temp_{systems[i]}_graph')
                 graph.autoRangeX = True
@@ -1573,9 +1573,27 @@ class RFMainControl(SiriusMainWindow):
                 graph.showYGrid = True
                 graph.timeSpan = 1800
                 graph.maxRedrawRate = 2
+
+                lim = 'Upper A' if systems[i] == "A" else 'Upper B'
+
                 graph.addYChannel(
                     y_channel=self.prefix+self.chs['RF Area'][f'{systems[i]}']['Temp'],
                     name=f'Temp_{systems[i]}', color='red', lineStyle=Qt.SolidLine, lineWidth=1)
+
+                pv_lim = self.prefix+self.chs['RF Area'][f'{systems[i]}'][lim]
+                lim_line = InfiniteLine(
+                    pos=0, angle=0, pen=pen)
+                graph.addItem(lim_line)
+                self.ref_line[lim] = lim_line
+
+                ch_lim = channel.PyDMChannel(
+                    address=pv_lim,
+                    value_slot=lambda val, l=lim: self._getUpperLim(l, val)
+                )
+
+                ch_lim.connect()
+                self.ref_channel[lim] = ch_lim
+
                 graph.setLabel('left', '°C')
                 lay_rfarea.addWidget(graph)
                 lay_rfarea.addItem(QSpacerItem(
@@ -1654,6 +1672,10 @@ class RFMainControl(SiriusMainWindow):
         line.setFrameShadow(QFrame.Sunken)
         return line
 
+    def _getUpperLim(self, lim, value):
+        if value is not None:
+            self.ref_line[lim].setPos(float(value))
+
     def vacuum_widget(self):
         self.vacuum_wid = QWidget()
         lay_vacuum = QVBoxLayout(self.vacuum_wid)
@@ -1677,11 +1699,23 @@ class RFMainControl(SiriusMainWindow):
         self.vacuum_graph.backgroundColor = QColor(255, 255, 255)
         self.vacuum_graph.showXGrid = True
         self.vacuum_graph.showYGrid = True
+        self.vacuum_graph.showLegend = True
         self.vacuum_graph.timeSpan = 1800
         self.vacuum_graph.maxRedrawRate = 1
-        self.vacuum_graph.addYChannel(
-            y_channel=self.prefix+self.chs['Cav Sts']['Vac']['Cells'],
-            name='Vacuum', color='black', lineStyle=Qt.SolidLine, lineWidth=1)
+        if self.section == "BO":
+            self.vacuum_graph.addYChannel(
+                y_channel=self.prefix+self.chs['Cav Sts']['Vac']['Cells'],
+                name='Vacuum', color='black', lineStyle=Qt.SolidLine, lineWidth=1)
+        else:
+            cav_pv = ['POB', 'Taper']
+            systems = ['A', 'B']
+            for sys in systems:
+                for cav in cav_pv:
+                    self.vacuum_graph.addYChannel(
+                        y_channel=self.prefix+self.chs['Cav Sts']['Vac']['Cav Pressure'][sys][cav][0],
+                        name=self.prefix+self.chs['Cav Sts']['Vac']['Cav Pressure'][sys][cav][0][21:26],
+                        color=self.prefix+self.chs['Cav Sts']['Vac']['Cav Pressure'][sys][cav][1],
+                        lineStyle=Qt.SolidLine, lineWidth=1)
         self.vacuum_graph.setLabel('left', '')
         lay_vacuum.addWidget(self.vacuum_graph)
         return self.vacuum_wid

--- a/pyqt-apps/siriushla/as_rf_control/control.py
+++ b/pyqt-apps/siriushla/as_rf_control/control.py
@@ -1481,11 +1481,11 @@ class RFMainControl(SiriusMainWindow):
         if self.section == 'SI':
             self.tempcirc_graph.addYChannel(
                 y_channel=self.prefix+self.chs['TL Sts']['A']['Circulator Temp. In']['label'],
-                name='CTIn', color='magenta',
+                name='A', color='magenta',
                 lineStyle=Qt.SolidLine, lineWidth=1)
             self.tempcirc_graph.addYChannel(
-                y_channel=self.prefix+self.chs['TL Sts']['A']['label']['Circulator Temp. Out'],
-                name='CTOut', color='darkRed',
+                y_channel=self.prefix+self.chs['TL Sts']['B']['Circulator Temp. In']['label'],
+                name='B', color='darkRed',
                 lineStyle=Qt.SolidLine, lineWidth=1)
         else:
             self.tempcirc_graph.addYChannel(

--- a/pyqt-apps/siriushla/as_rf_control/util.py
+++ b/pyqt-apps/siriushla/as_rf_control/util.py
@@ -362,6 +362,18 @@ SEC_2_CHANNELS = {
                 'mV': 'BO-05D:RF-P5Cav:RevAmp-Mon',
                 'color': 'red',
             },
+            'SSA Forward': {
+                'W': 'RA-ToBO:RF-SSAmpTower:FwdOutPwrW-Mon',
+                'dBm': 'RA-ToBO:RF-SSAmpTower:FwdOutPwrdBm-Mon',
+                'mV': 'RA-ToBO:RF-SSAmpTower:FwdOutAmp-Mon',
+                'color': 'brown',
+            },
+            'SSA Reverse': {
+                'W': 'RA-ToBO:RF-SSAmpTower:RevOutPwrW-Mon',
+                'dBm': 'RA-ToBO:RF-SSAmpTower:RevOutPwrdBm-Mon',
+                'mV': 'RA-ToBO:RF-SSAmpTower:RevOutAmp-Mon',
+                'color': 'purple',
+            },
         },
         'CavVGap': 'BO-05D:RF-P5Cav:Cell3VGap-Mon',
         'TempMon': {
@@ -380,24 +392,32 @@ SEC_2_CHANNELS = {
                 'Bottom': {
                     'CavPwr': 'BO-05D:RF-P5Cav:Cell3BotPwrW-Mon',
                     'PowFwd': 'BO-05D:RF-P5Cav:FwdBotPwrW-Mon',
-                    'PowRev': 'BO-05D:RF-P5Cav:RevBotPwrW-Mon'
+                    'PowRev': 'BO-05D:RF-P5Cav:RevBotPwrW-Mon',
+                    'SSAFwd': 'RA-ToBO:RF-SSAmpTower:FwdBotPwrW-Mon',
+                    'SSARev': 'RA-ToBO:RF-SSAmpTower:RevBotPwrW-Mon',
                 },
                 'Top': {
                     'CavPwr': 'BO-05D:RF-P5Cav:Cell3TopPwrW-Mon',
                     'PowFwd': 'BO-05D:RF-P5Cav:FwdTopPwrW-Mon',
-                    'PowRev': 'BO-05D:RF-P5Cav:RevTopPwrW-Mon'
+                    'PowRev': 'BO-05D:RF-P5Cav:RevTopPwrW-Mon',
+                    'SSAFwd': 'RA-ToBO:RF-SSAmpTower:FwdTopPwrW-Mon',
+                    'SSARev': 'RA-ToBO:RF-SSAmpTower:RevTopPwrW-Mon',
                 }
             },
             'mV': {
                 'Bottom': {
                     'CavPwr': 'BO-05D:RF-P5Cav:Cell3BotAmp-Mon',
                     'PowFwd': 'BO-05D:RF-P5Cav:FwdBotAmp-Mon',
-                    'PowRev': 'BO-05D:RF-P5Cav:RevBotAmp-Mon'
+                    'PowRev': 'BO-05D:RF-P5Cav:RevBotAmp-Mon',
+                    'SSAFwd': 'RA-ToBO:RF-SSAmpTower:FwdBotAmp-Mon',
+                    'SSARev': 'RA-ToBO:RF-SSAmpTower:RevBotAmp-Mon',
                 },
                 'Top': {
                     'CavPwr': 'BO-05D:RF-P5Cav:Cell3TopAmp-Mon',
                     'PowFwd': 'BO-05D:RF-P5Cav:FwdTopAmp-Mon',
-                    'PowRev': 'BO-05D:RF-P5Cav:RevTopAmp-Mon'
+                    'PowRev': 'BO-05D:RF-P5Cav:RevTopAmp-Mon',
+                    'SSAFwd': 'RA-ToBO:RF-SSAmpTower:FwdTopAmp-Mon',
+                    'SSARev': 'RA-ToBO:RF-SSAmpTower:RevTopAmp-Mon',
                 }
             }
         },
@@ -1729,7 +1749,17 @@ SEC_2_CHANNELS = {
                 'Cond': 'RA-RaSIA01:RF-LLRF:VacuumFastRly-Mon',
                 'Cells ok': 'SI-03SP:RF-P7Cav:Pressure-Mon',
                 'Coupler ok': 'SI-03SP:RF-P7Cav:CoupPressure-Mon',
-            }
+                'Cav Pressure': {
+                    'A': {
+                        'POB': ['SI-03SP:RF-CryoMod-1:BP101_CCG_POBPressure-Mon', 'black'],
+                        'Taper': ['SI-03SP:RF-CryoMod-1:BP103_CCG_TaperPressure-Mon', 'green']
+                    },
+                    'B': {
+                        'POB': ['SI-03SP:RF-CryoMod-2:BP201_CCG_POBPressure-Mon', 'darkRed'],
+                        'Taper': ['SI-03SP:RF-CryoMod-2:BP203_CCG_TaperPressure-Mon', 'chocolate']
+                    },
+                },
+            },
         },
         'Cryo Sts': {
             'A': {
@@ -1916,11 +1946,13 @@ SEC_2_CHANNELS = {
                 'Geral': 'RA-RaSIA02:RF-THSensor:TempUp-Mon',
                 'Temp': 'RA-RaSIA02:RF-THSensor:Temp-Mon',
                 'Humidity': 'RA-RaSIA02:RF-THSensor:Humidity-Mon',
+                'Upper A': 'RA-RaSIA02:RF-THSensor:TempUpperLimit-Cte'
             },
             'B': {
                 'Geral': 'RA-RaSIB02:RF-THSensor:TempUp-Mon',
                 'Temp': 'RA-RaSIB02:RF-THSensor:Temp-Mon',
                 'Humidity': 'RA-RaSIB02:RF-THSensor:Humidity-Mon',
+                'Upper B': 'RA-RaSIB02:RF-THSensor:TempUpperLimit-Cte'
             },
         },
         'SSA': {
@@ -2350,6 +2382,12 @@ SEC_2_CHANNELS = {
                 'W': 'RA-ToSIA02:RF-SSAmpTower:RevOutPwrW-Mon',
                 'color': 'darkGreen'
             },
+            'A - Fwd Load': {
+                'mV': 'RA-TL:RF-Load-SIA:FwdInAmp-Mon',
+                'dBm': 'RA-TL:RF-Load-SIA:FwdInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Load-SIA:FwdInPwrW-Mon',
+                'color': 'yellow'
+            },
             'A - Cav': {
                 'mV': 'SI-03SP:RF-SRFCav-A:Amp-Mon',
                 'dBm': 'SI-03SP:RF-SRFCav-A:PwrdBm-Mon',
@@ -2368,11 +2406,17 @@ SEC_2_CHANNELS = {
                 'W': 'SI-03SP:RF-SRFCav-A:RevPwrW-Mon',
                 'color': 'darkBlue'
             },
-            'A - Fwd Load': {
-                'mV': 'RA-TL:RF-Load-SIA:FwdInAmp-Mon',
-                'dBm': 'RA-TL:RF-Load-SIA:FwdInPwrdBm-Mon',
-                'W': 'RA-TL:RF-Load-SIA:FwdInPwrW-Mon',
-                'color': 'yellow'
+            'A - FwdInCirc': {
+                'mV': 'RA-TL:RF-Circulator-SIA:FwdInAmp-Mon',
+                'dBm': 'RA-TL:RF-Circulator-SIA:FwdInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Circulator-SIA:FwdInPwrW-Mon',
+                'color': 'green'
+            },
+            'A - RevInCirc': {
+                'mV': 'RA-TL:RF-Circulator-SIA:RevInAmp-Mon',
+                'dBm': 'RA-TL:RF-Circulator-SIA:RevInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Circulator-SIA:RevInPwrW-Mon',
+                'color': 'brown'
             },
             'B - Fwd SSA 3': {
                 'mV': 'RA-ToSIB03:RF-SSAmpTower:FwdOutAmp-Mon',
@@ -2398,6 +2442,12 @@ SEC_2_CHANNELS = {
                 'W': 'RA-ToSIB04:RF-SSAmpTower:RevOutPwrW-Mon',
                 'color': 'chocolate'
             },
+            'B - Fwd Load': {
+                'mV': 'RA-TL:RF-Load-SIB:FwdInAmp-Mon',
+                'dBm': 'RA-TL:RF-Load-SIB:FwdInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Load-SIB:FwdInPwrW-Mon',
+                'color': 'darkSlateGrey'
+            },
             'B - Cav': {
                 'mV': 'SI-03SP:RF-SRFCav-B:Amp-Mon',
                 'dBm': 'SI-03SP:RF-SRFCav-B:PwrdBm-Mon',
@@ -2416,11 +2466,17 @@ SEC_2_CHANNELS = {
                 'W': 'SI-03SP:RF-SRFCav-B:RevPwrW-Mon',
                 'color': 'saddlebrown'
             },
-            'B - Fwd Load': {
-                'mV': 'RA-TL:RF-Load-SIB:FwdInAmp-Mon',
-                'dBm': 'RA-TL:RF-Load-SIB:FwdInPwrdBm-Mon',
-                'W': 'RA-TL:RF-Load-SIB:FwdInPwrW-Mon',
-                'color': 'darkSlateGrey'
+            'B - FwdInCirc': {
+                'mV': 'RA-TL:RF-Circulator-SIB:FwdInAmp-Mon',
+                'dBm': 'RA-TL:RF-Circulator-SIB:FwdInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Circulator-SIB:FwdInPwrW-Mon',
+                'color': 'gray'
+            },
+            'B - RevInCirc': {
+                'mV': 'RA-TL:RF-Circulator-SIB:RevInAmp-Mon',
+                'dBm': 'RA-TL:RF-Circulator-SIB:RevInPwrdBm-Mon',
+                'W': 'RA-TL:RF-Circulator-SIB:RevInPwrW-Mon',
+                'color': 'darkOrange'
             },
         },
         'CavVGap': {
@@ -4920,6 +4976,58 @@ SEC_2_CHANNELS = {
                 'r/Q': 'SI-03SP:RF-SRFCav-B:RoverQ-Cte',
                 'Q0': 'SI-03SP:RF-SRFCav-B:Q0-Cte'
             }
+        },
+        'TempVariations': {
+            'A': {
+                'Temp': {
+                    'BT110': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-1:BT110_HeVesselHeaterTempRate-Mon', 'magenta'],
+                        'Max': 'SI-03SP:RF-CryoMod-1:BT110_HeVesselHeaterTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-1:BT110_HeVesselHeaterTempMinRate-Mon'
+                    },
+                    'BT111': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-1:BT111_CavBotTempRate-Mon', 'darkRed'],
+                        'Max': 'SI-03SP:RF-CryoMod-1:BT111_CavBotTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-1:BT111_CavBotTempMinRate-Mon'
+                    },
+                    'BT112': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-1:BT112_CavTopTempRate-Mon', 'blue'],
+                        'Max': 'SI-03SP:RF-CryoMod-1:BT112_CavTopTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-1:BT112_CavTopTempMinRate-Mon'
+                    },
+                },
+                'Delta A': {
+                    'Diff': 'SI-03SP:RF-CryoMod-1:CavTopBotTempDiff-Mon',
+                    'Max': 'SI-03SP:RF-CryoMod-1:CavTopBotTempMaxDiff-Mon',
+                    'Min': 'SI-03SP:RF-CryoMod-1:CavTopBotTempMinDiff-Mon'
+                },
+                'Interval A': 'SI-03SP:RF-CryoMod-1:CavTempRateTimeInterval-SP'
+            },
+            'B': {
+                'Temp': {
+                    'BT210': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-2:BT210_HeVesselHeaterTempRate-Mon', 'magenta'],
+                        'Max': 'SI-03SP:RF-CryoMod-2:BT210_HeVesselHeaterTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-2:BT210_HeVesselHeaterTempMinRate-Mon'
+                    },
+                    'BT211': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-2:BT211_CavBotTempRate-Mon', 'darkRed'],
+                        'Max': 'SI-03SP:RF-CryoMod-2:BT211_CavBotTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-2:BT211_CavBotTempMinRate-Mon'
+                    },
+                    'BT212': {
+                        'TempRate': ['SI-03SP:RF-CryoMod-2:BT212_CavTopTempRate-Mon', 'blue'],
+                        'Max': 'SI-03SP:RF-CryoMod-2:BT212_CavTopTempMaxRate-Mon',
+                        'Min': 'SI-03SP:RF-CryoMod-2:BT212_CavTopTempMinRate-Mon'
+                    },
+                },
+                'Delta B': {
+                    'Diff': 'SI-03SP:RF-CryoMod-2:CavTopBotTempDiff-Mon',
+                    'Max': 'SI-03SP:RF-CryoMod-2:CavTopBotTempMaxDiff-Mon',
+                    'Min': 'SI-03SP:RF-CryoMod-2:CavTopBotTempMinDiff-Mon'
+                },
+                'Interval B': 'SI-03SP:RF-CryoMod-2:CavTempRateTimeInterval-SP'
+            },
         },
         'ACPanel': {
             'A': {


### PR DESCRIPTION
**RF Booster GUI Update**
- Add SSA Forward and Reverse PVs, and remove Phase PV label:
<img width="428" height="681" alt="image" src="https://github.com/user-attachments/assets/5198a8fc-d710-4f72-8c08-9129a17cdc3e" />
<img width="428" height="681" alt="image" src="https://github.com/user-attachments/assets/0340a223-79b1-4a5a-ba01-f85abaf46a54" />


**RF Sirius GUI Update**
- Create a new button 'Temp Variations' in Advanced Details tab to open a new window with temperature variations and temperature delta graphs.
<img width="725" height="463" alt="image" src="https://github.com/user-attachments/assets/81474a53-a2b5-42c9-9597-47cc81256089" />

   - Cryo Module 1:   
<img width="1444" height="720" alt="image" src="https://github.com/user-attachments/assets/c0666b8f-924d-4049-99cb-e6b002e390e9" />

   - Cryo Module 2:   
<img width="1444" height="720" alt="image" src="https://github.com/user-attachments/assets/bfbcfba7-74bb-42d8-8c55-3975b6ec6a62" />

- Move FwdLoad PV label to the left column, and add FwdInCirc and RevInCirc PVs.
<img width="441" height="389" alt="image" src="https://github.com/user-attachments/assets/a7427f3e-9c82-480b-a4d8-d052c5c68284" />

- Add upper limits in Room temperature graph.
<img width="587" height="550" alt="image" src="https://github.com/user-attachments/assets/92a8fb87-c6f3-4f70-82d4-0c3aee933a69" />

-  Add legends in Circulator temperature graph.
<img width="587" height="278" alt="image" src="https://github.com/user-attachments/assets/78f2aadf-01d7-4391-aab7-2793acb4dba6" />

- Add new Cavity Pressure PVs (Pump Out Box and Taper), and show legends in Vacuum graph.
<img width="580" height="768" alt="image" src="https://github.com/user-attachments/assets/4d9badc9-2266-4649-97a6-53995d4b306b" />

