### PR TITLE
Remove rb 04 scrn

### DIFF
--- a/pyqt-apps/siriushla/as_ap_injcontrol/tbts.py
+++ b/pyqt-apps/siriushla/as_ap_injcontrol/tbts.py
@@ -141,7 +141,6 @@ class TLControlWindow(BaseWindow):
                 ('TB-02:DI-Scrn-1', ('TB-01:PS-CH-2', ), ('TB-01:PS-CV-2', )),
                 ('TB-02:DI-Scrn-2', ('TB-02:PS-CH-1', ), ('TB-02:PS-CV-1', )),
                 ('TB-03:DI-Scrn', ('TB-02:PS-CH-2', ), ('TB-02:PS-CV-2', )),
-                ('TB-04:DI-Scrn', ('TB-04:PS-CH-1', ), ('TB-04:PS-CV-1', ))
             )
         elif self.tl == 'ts':
             devices = (

--- a/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
+++ b/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
@@ -9,9 +9,12 @@ from siriushla import util
 
 def get_scrn_list(sec):
     if sec == 'TB':
+        # NOTE: TB-04:DI-Scrn was removed during the March 2026 shutdown
+        # as part of septum-related modifications to mitigate
+        # secondary current loops induced by its pulsed field.
         return ['TB-01:DI-Scrn-1', 'TB-01:DI-Scrn-2',
                 'TB-02:DI-Scrn-1', 'TB-02:DI-Scrn-2',
-                'TB-03:DI-Scrn', 'TB-04:DI-Scrn']
+                'TB-03:DI-Scrn']
     elif sec == 'BO':
         return ['BO-01D:DI-Scrn-1', 'BO-01D:DI-Scrn-2',
                 'BO-02U:DI-Scrn']

--- a/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
+++ b/pyqt-apps/siriushla/as_di_scrns/list_scrns.py
@@ -9,9 +9,6 @@ from siriushla import util
 
 def get_scrn_list(sec):
     if sec == 'TB':
-        # NOTE: TB-04:DI-Scrn was removed during the March 2026 shutdown
-        # as part of septum-related modifications to mitigate
-        # secondary current loops induced by its pulsed field.
         return ['TB-01:DI-Scrn-1', 'TB-01:DI-Scrn-2',
                 'TB-02:DI-Scrn-1', 'TB-02:DI-Scrn-2',
                 'TB-03:DI-Scrn']

--- a/pyqt-apps/siriushla/si_ap_idff/main.py
+++ b/pyqt-apps/siriushla/si_ap_idff/main.py
@@ -545,5 +545,5 @@ class IDFFWindow(SiriusMainWindow):
             self._idffdev.rampup_corr_currents(
                 nrpts=50, time_interval=10, dry_run=False)
         else:
-            # NOTE: lauunch a popup warning window...
+            # NOTE: launch a popup warning window...
             pass


### PR DESCRIPTION
TB-04:DI-Scrn was removed during the March 2026 shutdown as part of septum-related modifications to mitigate secondary current loops induced by its pulsed field.