### PR TITLE
Fix BO Tune GUI

### DIFF
--- a/pyqt-apps/siriushla/as_di_tune/spectrogram.py
+++ b/pyqt-apps/siriushla/as_di_tune/spectrogram.py
@@ -1,3 +1,8 @@
+"""."""
+
+import logging
+import time as _time
+
 import numpy as np
 
 from qtpy.QtGui import QPalette, QColor
@@ -8,6 +13,7 @@ import qtawesome as qta
 
 from siriuspy.namesys import SiriusPVName
 from siriushla.widgets import SiriusSpectrogramView, QSpinBoxPlus
+from siriushla.widgets import SiriusConnectionSignal
 
 
 class BOTuneSpectrogram(SiriusSpectrogramView):
@@ -35,6 +41,12 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         roioffy_channel = self.device.substitute(propty='ROIOffYConv-RB')
         roiwidth_channel = self.device.substitute(propty='ROIWidthConv-RB')
         roiheight_channel = self.device.substitute(propty='ROIHeightConv-RB')
+        self.frame_count_sig = SiriusConnectionSignal(
+            image_channel.substitute(propty='FrameCount-Mon')
+        )
+        self.timing_count_sig = SiriusConnectionSignal(
+            'BO-Glob:TI-TuneProc:NrPulses-RB'
+        )
         super().__init__(parent=parent,
                          image_channel=image_channel,
                          xaxis_channel=xaxis_channel,
@@ -44,6 +56,8 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
                          roiwidth_channel=roiwidth_channel,
                          roiheight_channel=roiheight_channel,
                          background=background)
+        self.redraw_on_xaxis_change = False
+        self.redraw_on_yaxis_change = False
         self.normalizeData = True
         self.ROIColor = QColor('cyan')
         self.format_tooltip = '{0:.3f}, {1:.3f}'
@@ -63,6 +77,9 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
 
     def process_image(self, image):
         """Process data."""
+        # Wait some time so frame counts can update:
+        _time.sleep(0.2)
+
         # Flip data in X axis
         image = np.flip(image, 0)
 
@@ -80,12 +97,21 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
             image = aux
 
         # Manage buffer
-        self.buffer.append(image)
-        if len(self.buffer) > self.nravgs:
-            self.buffer.pop(0)
+        fr_cnt = int(self.frame_count_sig.value or 0)
+        tim_cnt = int(self.timing_count_sig.value or 1)
+        if fr_cnt == tim_cnt:
+            self.buffer.append(image)
+            if len(self.buffer) > self.nravgs:
+                self.buffer.pop(0)
+        else:
+            logging.debug(
+                'Not all acquisition were made. Ignoring current spectrogram'
+            )
         self.buffer_curr_size.emit(str(len(self.buffer)))
 
         # Perform average
+        if not self.buffer:
+            return image
         image = np.mean(self.buffer, axis=0)
 
         # update last data

--- a/pyqt-apps/siriushla/as_di_tune/spectrogram.py
+++ b/pyqt-apps/siriushla/as_di_tune/spectrogram.py
@@ -84,7 +84,7 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         image = np.flip(image, 0)
 
         # Truncate image
-        if self.nravgs > 1 and len(self.buffer) >= 1:
+        if self.nravgs > 1 and self.buffer:
             last_buff_shape = self.buffer[-1].shape
             image_shape = image.shape
             aux = np.zeros(last_buff_shape)
@@ -137,15 +137,18 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
 
     def setBufferSize(self, new_size):
         """Set number of averages, or, buffer size."""
-        if new_size >= 1:
-            self.nravgs = new_size
-            while len(self.buffer) > self.nravgs:
-                self.buffer.pop(0)
-            self.buffer_size_changed.emit(self.nravgs)
+        if new_size < 1:
+            return
+        self.nravgs = new_size
+        del self.buffer[:-new_size]
+        self.buffer_size_changed.emit(self.nravgs)
+        self.buffer_curr_size.emit(str(len(self.buffer)))
 
     def resetBuffer(self):
         """Reset buffer."""
         self.buffer = list()
+        self.buffer_size_changed.emit(self.nravgs)
+        self.buffer_curr_size.emit(str(len(self.buffer)))
 
     def getDataIndex(self):
         """Return index of the spectrogram to send in new_data signal."""
@@ -153,7 +156,10 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
 
     def setIndex2Send(self, new_idx):
         """Set index of the spectrogram to send in new_data signal."""
-        max_idx = self.buffer[-1].shape[0] - 1
+        if self.last_data is None:
+            return
+
+        max_idx = self.last_data.shape[0] - 1
         if new_idx > max_idx:
             self._idx2send = max_idx
         else:

--- a/pyqt-apps/siriushla/as_di_tune/spectrogram.py
+++ b/pyqt-apps/siriushla/as_di_tune/spectrogram.py
@@ -47,6 +47,8 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         self.timing_count_sig = SiriusConnectionSignal(
             'BO-Glob:TI-TuneProc:NrPulses-RB'
         )
+
+        self.needs_update_buffer = False
         super().__init__(parent=parent,
                          image_channel=image_channel,
                          xaxis_channel=xaxis_channel,
@@ -73,6 +75,7 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
             return
         spec_size = self._image_height*self._image_width
         self.image_waveform = new_image[:spec_size]
+        self.needs_update_buffer = True
         self.needs_redraw = True
 
     def process_image(self, image):
@@ -100,9 +103,11 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         fr_cnt = int(self.frame_count_sig.value or 0)
         tim_cnt = int(self.timing_count_sig.value or 1)
         if fr_cnt == tim_cnt:
-            self.buffer.append(image)
-            if len(self.buffer) > self.nravgs:
-                self.buffer.pop(0)
+            if self.needs_update_buffer:
+                self.buffer.append(image)
+                if len(self.buffer) > self.nravgs:
+                    self.buffer.pop(0)
+                self.needs_update_buffer = False
         else:
             logging.debug(
                 'Not all acquisition were made. Ignoring current spectrogram'
@@ -149,6 +154,9 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         self.buffer = list()
         self.buffer_size_changed.emit(self.nravgs)
         self.buffer_curr_size.emit(str(len(self.buffer)))
+        self.image_waveform *= 0
+        self.needs_update_buffer = False
+        self.needs_redraw = True
 
     def getDataIndex(self):
         """Return index of the spectrogram to send in new_data signal."""

--- a/pyqt-apps/siriushla/as_di_tune/spectrogram.py
+++ b/pyqt-apps/siriushla/as_di_tune/spectrogram.py
@@ -115,13 +115,12 @@ class BOTuneSpectrogram(SiriusSpectrogramView):
         self.buffer_curr_size.emit(str(len(self.buffer)))
 
         # Perform average
-        if not self.buffer:
-            return image
-        image = np.mean(self.buffer, axis=0)
+        if self.buffer:
+            image = np.mean(self.buffer, axis=0)
 
         # update last data
         self.last_data = image
-        last_data_size = self.last_data.shape[0]-1
+        last_data_size = image.shape[0]-1
         self.buffer_data_size.emit(last_data_size)
         if not self._idx2send > last_data_size:
             # Emit spectrum data

--- a/pyqt-apps/siriushla/widgets/spectrogram_view.py
+++ b/pyqt-apps/siriushla/widgets/spectrogram_view.py
@@ -344,6 +344,8 @@ class SiriusSpectrogramView(
 
         # Setup the redraw timer.
         self.needs_redraw = False
+        self.redraw_on_xaxis_change = True
+        self.redraw_on_yaxis_change = True
         self.redraw_timer = QTimer(self)
         self.redraw_timer.timeout.connect(self.redrawImage)
         self._redraw_rate = 30
@@ -604,11 +606,11 @@ class SiriusSpectrogramView(
             return
         logging.debug("SpectrogramView Received New Image: Needs Redraw->True")
         self.image_waveform = new_image
-        self.needs_redraw = True
         if not self._image_height and self._image_width:
             self._image_height = new_image.size/self._image_width
         elif not self._image_width and self._image_height:
             self._image_width = new_image.size/self._image_height
+        self.needs_redraw = True
 
     @Slot(np.ndarray)
     @Slot(float)
@@ -630,7 +632,7 @@ class SiriusSpectrogramView(
             self._image_width = new_array.size
         else:
             self._image_height = new_array.size
-        self.needs_redraw = True
+        self.needs_redraw = self.redraw_on_xaxis_change
 
     @Slot(np.ndarray)
     @Slot(float)
@@ -652,7 +654,7 @@ class SiriusSpectrogramView(
             self._image_width = new_array.size
         else:
             self._image_height = new_array.size
-        self.needs_redraw = True
+        self.needs_redraw = self.redraw_on_yaxis_change
 
     @Slot(int)
     def roioffsetx_value_changed(self, new_offset):


### PR DESCRIPTION
This PR solves some bugs and change some undesireble behaviors of the interface of the tune measurement system of the Booster:

 - In the old version, the spectrogram was being updated (and the buffer filled) when the spectrogram PV changed or the Time or frac tune array (x-axis and y-axis) PVs changed. This was not ideal because it spoiled the averaging of different spectogram, since the frac tune array updates all the time, with the update of the RF frequency being controlled by the SI SOFB loop. Now the spectrogram only updates when the spectrogram PV is updated.
 - When the system was not able to acquire all spectra required by the timing trigger, it still updated the buffer with the corrupted spectrogram, which spoiled the average. Now, we check whether all points were acquired before updating the buffer and discard incomplete spectrograms.