### PR TITLE
BUG: (IDFF.RAMP) do not initialize Table-RB PV (not valid for UE44).

### DIFF
--- a/pyqt-apps/siriushla/si_ap_idff/main.py
+++ b/pyqt-apps/siriushla/si_ap_idff/main.py
@@ -538,8 +538,6 @@ class IDFFWindow(SiriusMainWindow):
         # PVNames to initialize depend whether a soft or hard IDFF
         if issubclass(idffclass, IDFFCtrlSoft):
             props2init_ctrl += ('ConfigName-RB',)
-        else:
-            props2init_ctrl += ('Table-RB',)
         props2init_corrs = ('Current-Mon', 'Current-SP',)
         idffdev = IDFF(
             self._idffname,


### PR DESCRIPTION
Depends on https://github.com/lnls-sirius/dev-packages/pull/1238 for full support

Does not address the need to display the tables on the GUI