### PR TITLE
FEAT: EVG / EVR / EVE / FOUT updates in Timing GUI

### DIFF
--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -1203,10 +1203,8 @@ class EventList(BaseList):
             pvname = device.substitute(propty=device.propty+'DelayRaw-RB')
             rb = SiriusLabel(self, init_channel=pvname)
         elif prop == 'description':
-            pvname = device.substitute(propty=device.propty+'Desc-SP')
-            sp = PyDMLineEdit(self, init_channel=pvname)
-            pvname = device.substitute(propty=device.propty+'Desc-RB')
-            rb = SiriusLabel(self, init_channel=pvname)
+            pvname = device.substitute(propty=device.propty+'Desc-Cte')
+            sp = SiriusLabel(self, init_channel=pvname)
         elif prop == 'code':
             pvname = device.substitute(propty=device.propty+'Code-Mon')
             sp = SiriusLabel(self, init_channel=pvname)
@@ -1224,14 +1222,16 @@ class ClockList(BaseList):
         'frequency': 4.8,
         'mux_div': 6,
         'mux_enbl': 4.8,
+        'description': 9.7,
         }
     _LABELS = {
         'name': 'Name',
         'frequency': 'Freq. [Hz]',
         'mux_div': 'Mux Divisor',
         'mux_enbl': 'Enabled',
+        'description': 'Description',
         }
-    _ALL_PROPS = ('name', 'mux_enbl', 'frequency', 'mux_div')
+    _ALL_PROPS = ('name', 'mux_enbl', 'frequency', 'mux_div', 'description')
 
     def __init__(self, name=None, parent=None, prefix='',
                  props=set(), obj_names=list(), has_search=False):
@@ -1243,6 +1243,7 @@ class ClockList(BaseList):
         self.setObjectName('ASApp')
 
     def _createObjs(self, device, prop):
+        sp = rb = None
         if prop == 'frequency':
             pvname = device.substitute(propty=device.propty+'Freq-SP')
             sp = SiriusSpinbox(self, init_channel=pvname)
@@ -1252,9 +1253,8 @@ class ClockList(BaseList):
             pvname = device.substitute(propty=device.propty+'Freq-RB')
             rb = SiriusLabel(self, init_channel=pvname)
         elif prop == 'name':
-            rb = QLabel(device.propty, self)
-            rb.setAlignment(Qt.AlignCenter)
-            return (rb, )
+            sp = QLabel(device.propty, self)
+            sp.setAlignment(Qt.AlignCenter)
         elif prop == 'mux_enbl':
             pvname = device.substitute(propty=device.propty+'MuxEnbl-Sel')
             sp = PyDMStateButton(self, init_channel=pvname)
@@ -1265,7 +1265,12 @@ class ClockList(BaseList):
             sp = SiriusSpinbox(self, init_channel=pvname)
             pvname = device.substitute(propty=device.propty+'MuxDiv-RB')
             rb = SiriusLabel(self, init_channel=pvname)
-        return sp, rb
+        elif prop == 'description':
+            pvname = device.substitute(propty=device.propty+'Desc-Cte')
+            sp = SiriusLabel(self, init_channel=pvname)
+        if rb is None:
+            return (sp, )
+        return (sp, rb)
 
 
 # ###################### Event Distributors ######################

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -678,7 +678,13 @@ class EVG(BaseWidget):
             '', gbox_log, (ld_logstp, self.sb_logstp, self.led_logstp))
 
         ld_logrst = QLabel('<b>Reset Log</b>', self)
-        self.sb_logrst = PyDMStateButton(self, self.get_pvname('rstlog'))
+        self.pb_logrst = SiriusPushButton(self,
+                                          init_channel=self.get_pvname('rstlog'),
+                                          pressValue=1, releaseValue=0)
+        self.pb_logrst.setIcon(qta.icon('mdi.restart'))
+        self.pb_logrst.setObjectName('rstbt')
+        self.pb_logrst.setStyleSheet(
+            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.sb_logrst, self.led_logrst))
@@ -2278,7 +2284,13 @@ class _EVR_EVE(BaseWidget):
             '', gbox_log, (ld_logstp, self.sb_logstp, self.led_logstp))
 
         ld_logrst = QLabel('<b>Reset Log</b>', self)
-        self.sb_logrst = PyDMStateButton(self, self.get_pvname('rstlog'))
+        self.pb_logrst = SiriusPushButton(self,
+                                          init_channel=self.get_pvname('rstlog'),
+                                          pressValue=1, releaseValue=0)
+        self.pb_logrst.setIcon(qta.icon('mdi.restart'))
+        self.pb_logrst.setObjectName('rstbt')
+        self.pb_logrst.setStyleSheet(
+            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.sb_logrst, self.led_logrst))

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -687,18 +687,17 @@ class EVG(BaseWidget):
             '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
-            '', gbox_log, (ld_logrst, self.sb_logrst, self.led_logrst))
+            '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))
 
-        ld_logpul = QLabel('<b>Pull</b>', self)
-        self.bt_logpul = SiriusPushButton(
-            parent=self, init_channel=self.get_pvname('pull'),
-            pressValue=1, releaseValue=0)  # ?
-        self.bt_logpul.setIcon(qta.icon('fa5s.arrow-down'))
-        self.bt_logpul.setObjectName('bt')
-        self.bt_logpul.setStyleSheet(
-            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
-        gb_logpul = self._create_small_group(
-            '', gbox_log, (ld_logpul, self.bt_logpul))
+        ld_enbstp = QLabel('<b>Enable Log</b>', self)
+        pvname_enbstp_sel = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sel')
+        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
+        pvname_enbstp_sts = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sts')
+        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
+        gb_enbstp = self._create_small_group(
+            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
 
         ld_logcnt = QLabel('<b>Log Count</b>', self, alignment=Qt.AlignCenter)
         self.lb_logcnt = SiriusLabel(self, self.get_pvname('LOGCOUNT'))
@@ -740,7 +739,7 @@ class EVG(BaseWidget):
         lay_log = QGridLayout(gbox_log)
         lay_log.addWidget(gb_logstp, 0, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logrst, 0, 1, alignment=Qt.AlignTop)
-        lay_log.addWidget(gb_logpul, 0, 2, alignment=Qt.AlignTop)
+        lay_log.addWidget(gb_enbstp, 0, 2, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logevt, 1, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logutc, 1, 1, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logsub, 1, 2, alignment=Qt.AlignTop)
@@ -2293,18 +2292,17 @@ class _EVR_EVE(BaseWidget):
             '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
-            '', gbox_log, (ld_logrst, self.sb_logrst, self.led_logrst))
+            '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))
 
-        ld_logpul = QLabel('<b>Pull</b>', self)
-        self.bt_logpul = SiriusPushButton(
-            parent=self, init_channel=self.get_pvname('pull'),
-            pressValue=1, releaseValue=0)  # ?
-        self.bt_logpul.setIcon(qta.icon('fa5s.arrow-down'))
-        self.bt_logpul.setObjectName('bt')
-        self.bt_logpul.setStyleSheet(
-            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
-        gb_logpul = self._create_small_group(
-            '', gbox_log, (ld_logpul, self.bt_logpul))
+        ld_enbstp = QLabel('<b>Enable Log</b>', self)
+        pvname_enbstp_sel = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sel')
+        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
+        pvname_enbstp_sts = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sts')
+        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
+        gb_enbstp = self._create_small_group(
+            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
 
         ld_logcnt = QLabel('<b>Log Count</b>', self, alignment=Qt.AlignCenter)
         self.lb_logcnt = SiriusLabel(self, self.get_pvname('LOGCOUNT'))
@@ -2346,7 +2344,7 @@ class _EVR_EVE(BaseWidget):
         lay_log = QGridLayout(gbox_log)
         lay_log.addWidget(gb_logstp, 0, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logrst, 0, 1, alignment=Qt.AlignTop)
-        lay_log.addWidget(gb_logpul, 0, 2, alignment=Qt.AlignTop)
+        lay_log.addWidget(gb_enbstp, 0, 2, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logevt, 1, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logutc, 1, 1, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logsub, 1, 2, alignment=Qt.AlignTop)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -574,22 +574,26 @@ class EVG(BaseWidget):
         dialog.setWindowIcon(self.windowIcon())
         lay = QVBoxLayout(dialog)
 
+        timestamp_wid = QWidget(self)
+        lay_v = QVBoxLayout(timestamp_wid)
+
         tstamptab = QTabWidget(self)
+        tstamptab.setObjectName('ASTab')
+        lay.addWidget(tstamptab)
 
-        gbox_tim = QGroupBox()
-        tstamptab.addTab(gbox_tim, 'Timestamp')
-
+        # OTP
         props = {
             'name', 'state', 'event', 'evtcnt', 'evtcntrst'}
         obj_names = ['OTP{0:02d}'.format(i) for i in range(24)]
         obj_names = [self.device.substitute(propty=o) for o in obj_names]
         self.otps_wid = EVGOTPList(
-            name=None, parent=self, prefix=self.prefix,
+            name='Internal Trigger (OTP)', parent=self, prefix=self.prefix,
             props=props, obj_names=obj_names)
         self.otps_wid.setObjectName('otps_wid')
-        tstamptab.addTab(self.otps_wid, 'OTP')
 
-        lay.addWidget(tstamptab)
+        # Timestamp
+        gbox_tim = QGroupBox('Timestamp', self)
+        lay_v.addWidget(gbox_tim)
 
         lb = QLabel('<b>Get UTC</b>')
         pvname = self.get_pvname('GetUTC-Cmd')
@@ -645,7 +649,7 @@ class EVG(BaseWidget):
 
         # Timestamp Log enable
         gbox_enbl = QGroupBox('Timestamp Log Enable', self)
-        lay.addWidget(gbox_enbl)
+        lay_v.addWidget(gbox_enbl)
 
         lay_enbl = QGridLayout(gbox_enbl)
         lay_enbl.setHorizontalSpacing(15)
@@ -669,7 +673,7 @@ class EVG(BaseWidget):
 
         # Timestamp Log
         gbox_log = QGroupBox('Timestamp Log', self)
-        lay.addWidget(gbox_log)
+        lay_v.addWidget(gbox_log)
 
         ld_logstp = QLabel('<b>Stop Log</b>', self)
         self.sb_logstp = PyDMStateButton(self, self.get_pvname('stoplog'))
@@ -681,10 +685,10 @@ class EVG(BaseWidget):
         self.pb_logrst = SiriusPushButton(self,
                                           init_channel=self.get_pvname('rstlog'),
                                           pressValue=1, releaseValue=0)
-        self.pb_logrst.setIcon(qta.icon('mdi.restart'))
+        self.pb_logrst.setIcon(qta.icon('fa5s.sync'))
         self.pb_logrst.setObjectName('rstbt')
         self.pb_logrst.setStyleSheet(
-            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
+            '#rstbt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))
@@ -747,7 +751,7 @@ class EVG(BaseWidget):
 
         # Timestamp Log Buffer
         gbox_buf = QGroupBox('Timestamp Log Buffer', self)
-        lay.addWidget(gbox_buf)
+        lay_v.addWidget(gbox_buf)
 
         ld_bufcnt = QLabel('<b>Log Count</b>', self)
         self.lb_bufcnt = SiriusLabel(self, self.get_pvname('LOGSOFTCNT'))
@@ -808,6 +812,9 @@ class EVG(BaseWidget):
         lay_logbuf.addWidget(gb_bufutc, 1, 0, 1, 2)
         lay_logbuf.addWidget(gb_bufsub, 1, 2, 1, 2)
         lay_logbuf.addWidget(gb_bufevt, 1, 4, 1, 2)
+
+        tstamptab.addTab(timestamp_wid, 'Timestamp')
+        tstamptab.addTab(self.otps_wid, 'OTP')
 
         return dialog
 
@@ -1448,13 +1455,18 @@ class FOUT(BaseWidget):
         gb = self._create_small_group('', info_wid, (lb, rb))
         info_lay.addWidget(gb, 0, 2, alignment=Qt.AlignTop)
 
-        but_opt = QPushButton('OTP', self)
-        but_opt.setToolTip('Open Internal Triggers (OTP) Details')
-        but_opt.setObjectName('but')
-        but_opt.setDefault(False)
-        but_opt.setAutoDefault(False)
-        but_opt.clicked.connect(self._open_otp_dialog)
-        info_lay.addWidget(but_opt, 0, 3, alignment=Qt.AlignCenter)
+        but_otp = QPushButton(self)
+        but_otp.setToolTip('Open OTP Window')
+        but_otp.setIcon(qta.icon('fa5s.ellipsis-v'))
+        but_otp.setObjectName('but')
+        but_otp.setDefault(False)
+        but_otp.setAutoDefault(False)
+        but_otp.setStyleSheet(
+            '#but{min-width:15px; max-width:15px;\
+            min-height:25px; max-height:25px;\
+            icon-size:20px;}')
+        but_otp.clicked.connect(self._open_otp_dialog)
+        info_lay.addWidget(but_otp, 0, 3, alignment=Qt.AlignTop)
 
         lb = QLabel("<b>Download</b>")
         pvname = self.get_pvname('Download-Cmd')
@@ -2300,10 +2312,10 @@ class _EVR_EVE(BaseWidget):
         self.pb_logrst = SiriusPushButton(self,
                                           init_channel=self.get_pvname('rstlog'),
                                           pressValue=1, releaseValue=0)
-        self.pb_logrst.setIcon(qta.icon('mdi.restart'))
+        self.pb_logrst.setIcon(qta.icon('fa5s.sync'))
         self.pb_logrst.setObjectName('rstbt')
         self.pb_logrst.setStyleSheet(
-            '#bt{min-width:25px; max-width:25px; icon-size:20px;}')
+            '#rstbt{min-width:25px; max-width:25px; icon-size:20px;}')
         self.led_logrst = SiriusLedState(self, self.get_pvname('RSTLOGRBV'))
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -574,8 +574,22 @@ class EVG(BaseWidget):
         dialog.setWindowIcon(self.windowIcon())
         lay = QVBoxLayout(dialog)
 
-        gbox_tim = QGroupBox('Timestamp', self)
-        lay.addWidget(gbox_tim)
+        tstamptab = QTabWidget(self)
+
+        gbox_tim = QGroupBox()
+        tstamptab.addTab(gbox_tim, 'Timestamp')
+
+        props = {
+            'name', 'state', 'event', 'evtcnt', 'evtcntrst'}
+        obj_names = ['OTP{0:02d}'.format(i) for i in range(24)]
+        obj_names = [self.device.substitute(propty=o) for o in obj_names]
+        self.otps_wid = EVGOTPList(
+            name=None, parent=self, prefix=self.prefix,
+            props=props, obj_names=obj_names)
+        self.otps_wid.setObjectName('otps_wid')
+        tstamptab.addTab(self.otps_wid, 'OTP')
+
+        lay.addWidget(tstamptab)
 
         lb = QLabel('<b>Get UTC</b>')
         pvname = self.get_pvname('GetUTC-Cmd')
@@ -1415,6 +1429,14 @@ class FOUT(BaseWidget):
         gb = self._create_small_group('', info_wid, (lb, rb))
         info_lay.addWidget(gb, 0, 2, alignment=Qt.AlignTop)
 
+        but_opt = QPushButton('OTP', self)
+        but_opt.setToolTip('Open Internal Triggers (OTP) Details')
+        but_opt.setObjectName('but')
+        but_opt.setDefault(False)
+        but_opt.setAutoDefault(False)
+        but_opt.clicked.connect(self._open_otp_dialog)
+        info_lay.addWidget(but_opt, 0, 3, alignment=Qt.AlignCenter)
+
         lb = QLabel("<b>Download</b>")
         pvname = self.get_pvname('Download-Cmd')
         sp = SiriusPushButton(
@@ -1461,6 +1483,31 @@ class FOUT(BaseWidget):
             self.downconn_wind.show()
         else:
             self.downconn_wind.showNormal()
+
+    def _create_otp_dialog(self):
+        dialog = SiriusDialog()
+        dialog.setObjectName('ASApp')
+        dialog.setWindowTitle(self.device + ' OTP')
+        dialog.setWindowIcon(self.windowIcon())
+
+        lay = QVBoxLayout(dialog)
+        props = {
+            'name', 'state', 'event', 'evtcnt', 'evtcntrst'}
+        obj_names = ['OTP{0:02d}'.format(i) for i in range(24)]
+        obj_names = [self.device.substitute(propty=o) for o in obj_names]
+        otps_wid = FOUTOTPList(
+            name='Internal Trigger (OTP)', parent=self, prefix=self.prefix,
+            props=props, obj_names=obj_names)
+        otps_wid.setObjectName('otps_wid')
+        lay.addWidget(otps_wid)
+        return dialog
+
+    def _open_otp_dialog(self):
+        if not hasattr(self, 'otps_wid'):
+            self.otps_wid = self._create_otp_dialog()
+            self.otps_wid.show()
+        else:
+            self.otps_wid.showNormal()
 
 
 # ###################### Event Receivers ######################
@@ -2583,6 +2630,10 @@ class LLTriggerList(BaseList):
                 devt = EVR
             elif devt == 'EVE':
                 devt = EVE
+            elif devt == 'EVG':
+                devt = EVG
+            elif devt == 'FOUT':
+                devt = FOUT
             else:
                 devt = AFC
             sp = QPushButton(outlb.device_name, self)
@@ -2752,6 +2803,22 @@ class AFCOUTList(LLTriggerList):
         'name', 'state', 'event', 'source', 'widthraw', 'width', 'polarity',
         'pulses', 'delayraw', 'delay', 'dir', 'evtcnt', 'evtcntrst',
         'log', 'hl_trigger')
+
+
+class EVGOTPList(LLTriggerList):
+    """Template for control of Timing devices Internal Triggers."""
+
+    _ALL_PROPS = (
+        'name', 'state', 'event', 'widthraw', 'width', 'polarity', 'pulses',
+        'delayraw', 'delay', 'evtcnt', 'evtcntrst', 'log', 'hl_trigger')
+
+
+class FOUTOTPList(LLTriggerList):
+    """Template for control of Timing devices Internal Triggers."""
+
+    _ALL_PROPS = (
+        'name', 'state', 'event', 'widthraw', 'width', 'polarity', 'pulses',
+        'delayraw', 'delay', 'evtcnt', 'evtcntrst', 'log', 'hl_trigger')
 
 
 # ###################### Digital Inputs ######################

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -693,16 +693,6 @@ class EVG(BaseWidget):
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))
 
-        ld_enbstp = QLabel('<b>Enable Log</b>', self)
-        pvname_enbstp_sel = self.device.substitute(
-            propty=self.device.propty+'StopSoftLog-Sel')
-        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
-        pvname_enbstp_sts = self.device.substitute(
-            propty=self.device.propty+'StopSoftLog-Sts')
-        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
-        gb_enbstp = self._create_small_group(
-            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
-
         ld_logcnt = QLabel('<b>Log Count</b>', self, alignment=Qt.AlignCenter)
         self.lb_logcnt = SiriusLabel(self, self.get_pvname('LOGCOUNT'))
         self.lb_logcnt.showUnits = True
@@ -743,11 +733,10 @@ class EVG(BaseWidget):
         lay_log = QGridLayout(gbox_log)
         lay_log.addWidget(gb_logstp, 0, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logrst, 0, 1, alignment=Qt.AlignTop)
-        lay_log.addWidget(gb_enbstp, 0, 2, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logevt, 1, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logutc, 1, 1, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logsub, 1, 2, alignment=Qt.AlignTop)
-        lay_log.addWidget(fr_logcnt, 0, 3, 2, 1, alignment=Qt.AlignCenter)
+        lay_log.addWidget(fr_logcnt, 0, 2, 2, 1, alignment=Qt.AlignTop)
 
         # Timestamp Log Buffer
         gbox_buf = QGroupBox('Timestamp Log Buffer', self)
@@ -770,25 +759,43 @@ class EVG(BaseWidget):
         gb_bufrst = self._create_small_group(
             '', gbox_buf, (ld_bufrst, self.bt_bufrst))
 
+        ld_enbstp = QLabel('<b>Enable Log Buffer</b>', self)
+        pvname_enbstp_sel = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sel')
+        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
+        pvname_enbstp_sts = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sts')
+        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
+        gb_enbstp = self._create_small_group(
+            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
+
         ld_bufutc = QLabel('<b>UTC buffer</b>', self)
         fmt = "%d/%m/%y %H:%M:%S"
-        func = _np.vectorize(
-            lambda tstp: _datetime.fromtimestamp(tstp).strftime(fmt)
-            if tstp != 0
-            else 0
-        )  # from timestamp to datetime format
+
+        # from timestamp to datetime format
+        def format_timestamp(tstp):
+            if tstp == 0:
+                return 0
+            return _datetime.fromtimestamp(tstp).strftime(fmt)
+
         self.tb_bufutc = self._create_logbuffer_table(
-            prop='UTCbuffer', transform=func
+            prop='UTCbuffer', transform=format_timestamp
         )
         gb_bufutc = self._create_small_group(
             '', gbox_buf, (ld_bufutc, self.tb_bufutc))
 
         ld_bufsub = QLabel('<b>Subsec buffer</b>', self)
         rffreq = _PV("RF-Gen:GeneralFreq-RB").value
-        func = lambda vec: _np.round(vec * 4 / rffreq, decimals=10)
+
         # from EVG clock to seconds
+        def format_time(clk):
+            value = clk * 4 / rffreq * 1e6
+            return f"{value:,.3f}".replace(",", " ") + " µs"
+
         self.tb_bufsub = self._create_logbuffer_table(
-            prop='SUBSECbuffer', transform=func)
+            prop="SUBSECbuffer",
+            transform=format_time,
+        )
         gb_bufsub = self._create_small_group(
             '', gbox_buf, (ld_bufsub, self.tb_bufsub))
 
@@ -807,8 +814,9 @@ class EVG(BaseWidget):
                     )
 
         lay_logbuf = QGridLayout(gbox_buf)
-        lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 3)
-        lay_logbuf.addWidget(gb_bufrst, 0, 3, 1, 3)
+        lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 2)
+        lay_logbuf.addWidget(gb_bufrst, 0, 2, 1, 2)
+        lay_logbuf.addWidget(gb_enbstp, 0, 4, 1, 2)
         lay_logbuf.addWidget(gb_bufutc, 1, 0, 1, 2)
         lay_logbuf.addWidget(gb_bufsub, 1, 2, 1, 2)
         lay_logbuf.addWidget(gb_bufevt, 1, 4, 1, 2)
@@ -2320,16 +2328,6 @@ class _EVR_EVE(BaseWidget):
         gb_logrst = self._create_small_group(
             '', gbox_log, (ld_logrst, self.pb_logrst, self.led_logrst))
 
-        ld_enbstp = QLabel('<b>Enable Log</b>', self)
-        pvname_enbstp_sel = self.device.substitute(
-            propty=self.device.propty+'StopSoftLog-Sel')
-        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
-        pvname_enbstp_sts = self.device.substitute(
-            propty=self.device.propty+'StopSoftLog-Sts')
-        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
-        gb_enbstp = self._create_small_group(
-            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
-
         ld_logcnt = QLabel('<b>Log Count</b>', self, alignment=Qt.AlignCenter)
         self.lb_logcnt = SiriusLabel(self, self.get_pvname('LOGCOUNT'))
         self.lb_logcnt.showUnits = True
@@ -2370,11 +2368,10 @@ class _EVR_EVE(BaseWidget):
         lay_log = QGridLayout(gbox_log)
         lay_log.addWidget(gb_logstp, 0, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logrst, 0, 1, alignment=Qt.AlignTop)
-        lay_log.addWidget(gb_enbstp, 0, 2, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logevt, 1, 0, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logutc, 1, 1, alignment=Qt.AlignTop)
         lay_log.addWidget(gb_logsub, 1, 2, alignment=Qt.AlignTop)
-        lay_log.addWidget(fr_logcnt, 0, 3, 2, 1, alignment=Qt.AlignCenter)
+        lay_log.addWidget(fr_logcnt, 0, 2, 2, 1, alignment=Qt.AlignTop)
 
         # Timestamp Log Buffer
         gbox_buf = QGroupBox('Timestamp Log Buffer', self)
@@ -2396,13 +2393,43 @@ class _EVR_EVE(BaseWidget):
         gb_bufrst = self._create_small_group(
             '', gbox_buf, (ld_bufrst, self.bt_bufrst))
 
+        ld_enbstp = QLabel('<b>Enable Log Buffer</b>', self)
+        pvname_enbstp_sel = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sel')
+        self.sb_enbstp = PyDMStateButton(self, init_channel=pvname_enbstp_sel)
+        pvname_enbstp_sts = self.device.substitute(
+            propty=self.device.propty+'StopSoftLog-Sts')
+        self.led_enbstp = PyDMLed(self, init_channel=pvname_enbstp_sts)
+        gb_enbstp = self._create_small_group(
+            '', gbox_log, (ld_enbstp, self.sb_enbstp, self.led_enbstp))
+
         ld_bufutc = QLabel('<b>UTC buffer</b>', self)
-        self.tb_bufutc = self._create_logbuffer_table('UTCbuffer')
+        fmt = "%d/%m/%y %H:%M:%S"
+
+        # from timestamp to datetime format
+        def format_timestamp(tstp):
+            if tstp == 0:
+                return 0
+            return _datetime.fromtimestamp(tstp).strftime(fmt)
+
+        self.tb_bufutc = self._create_logbuffer_table(
+            prop='UTCbuffer', transform=format_timestamp
+        )
         gb_bufutc = self._create_small_group(
             '', gbox_buf, (ld_bufutc, self.tb_bufutc))
 
         ld_bufsub = QLabel('<b>Subsec buffer</b>', self)
-        self.tb_bufsub = self._create_logbuffer_table('SUBSECbuffer')
+        rffreq = _PV("RF-Gen:GeneralFreq-RB").value
+
+        # from EVG clock to seconds
+        def format_time(clk):
+            value = clk * 4 / rffreq * 1e6
+            return f"{value:,.3f}".replace(",", " ") + " µs"
+
+        self.tb_bufsub = self._create_logbuffer_table(
+            prop="SUBSECbuffer",
+            transform=format_time,
+        )
         gb_bufsub = self._create_small_group(
             '', gbox_buf, (ld_bufsub, self.tb_bufsub))
 
@@ -2421,8 +2448,9 @@ class _EVR_EVE(BaseWidget):
                     )
 
         lay_logbuf = QGridLayout(gbox_buf)
-        lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 3)
-        lay_logbuf.addWidget(gb_bufrst, 0, 3, 1, 3)
+        lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 2)
+        lay_logbuf.addWidget(gb_bufrst, 0, 2, 1, 2)
+        lay_logbuf.addWidget(gb_enbstp, 0, 4, 1, 2)
         lay_logbuf.addWidget(gb_bufutc, 1, 0, 1, 2)
         lay_logbuf.addWidget(gb_bufsub, 1, 2, 1, 2)
         lay_logbuf.addWidget(gb_bufevt, 1, 4, 1, 2)

--- a/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
+++ b/pyqt-apps/siriushla/as_ti_control/low_level_devices.py
@@ -793,6 +793,15 @@ class EVG(BaseWidget):
         gb_bufevt = self._create_small_group(
             '', gbox_buf, (ld_bufevt, self.tb_bufevt))
 
+        # sync tables vertical scroll
+        tables = [self.tb_bufutc, self.tb_bufsub, self.tb_bufevt]
+        for source in tables:
+            for target in tables:
+                if source is not target:
+                    source.verticalScrollBar().valueChanged.connect(
+                        target.verticalScrollBar().setValue
+                    )
+
         lay_logbuf = QGridLayout(gbox_buf)
         lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 3)
         lay_logbuf.addWidget(gb_bufrst, 0, 3, 1, 3)
@@ -2384,6 +2393,15 @@ class _EVR_EVE(BaseWidget):
         self.tb_bufevt = self._create_logbuffer_table('EVENTbuffer')
         gb_bufevt = self._create_small_group(
             '', gbox_buf, (ld_bufevt, self.tb_bufevt))
+
+        # sync tables vertical scroll
+        tables = [self.tb_bufutc, self.tb_bufsub, self.tb_bufevt]
+        for source in tables:
+            for target in tables:
+                if source is not target:
+                    source.verticalScrollBar().valueChanged.connect(
+                        target.verticalScrollBar().setValue
+                    )
 
         lay_logbuf = QGridLayout(gbox_buf)
         lay_logbuf.addWidget(gb_bufcnt, 0, 0, 1, 3)

--- a/pyqt-apps/siriushla/widgets/waveformtable.py
+++ b/pyqt-apps/siriushla/widgets/waveformtable.py
@@ -11,7 +11,9 @@ class SiriusWaveformTable(PyDMWaveformTable):
     def __init__(self, parent=None, init_channel=None, transform=None):
         """."""
         super().__init__(parent, init_channel)
-        self.transform = transform
+        self.transform = (
+            _np.vectorize(transform) if transform is not None else None
+            )
 
     def value_changed(self, new_waveform):
         """


### PR DESCRIPTION
- [OTP configuration in both EVG and FOUT](https://github.com/lnls-sirius/hla/commit/e78cac797bd05bdb6219ebcc6bec5dfa6b7301bd) and [Synchronize tables scrolls](https://github.com/lnls-sirius/hla/commit/84d732d7fc12224818c52e2747c52fb878c965d7)
   - EVG:
       <img width="917" height="982" alt="image" src="https://github.com/user-attachments/assets/d5542d9e-19ba-43be-84ee-647e3c757ca3" />
   - EVR/EVE:
       <img width="806" height="879" alt="image" src="https://github.com/user-attachments/assets/bffbe8b2-e02a-4df8-a2a0-fc8b028cf727" />

   - FOUT:
       <img width="689" height="348" alt="image" src="https://github.com/user-attachments/assets/8b562d42-c9ce-4f8b-827e-6bb5a4ab7497" />

- [Change the Reset Log from State Button to Push Button](https://github.com/lnls-sirius/hla/commit/d43532b191e6be2d81c0017f26e824fa74f6c0dc) and [Remove Pull button and add Enable Log state button](https://github.com/lnls-sirius/hla/commit/c1cd70e6846fbf3ec5a701a89b1679ab82577534)
   <img width="769" height="200" alt="image" src="https://github.com/user-attachments/assets/550f8397-159f-4fce-8952-090a37a5b494" />

- [Change Descriptions to -Cte and add a Descriptions column in clocks](https://github.com/lnls-sirius/hla/commit/64ffd607cb27f7a1b59e44ea40b752e13c37fbde)
   <img width="1402" height="1111" alt="image" src="https://github.com/user-attachments/assets/b5478fc1-9e7b-480f-be48-998fe1c91e03" />
