### PR TITLE
Improve BbB Gui Performance

### DIFF
--- a/pyqt-apps/siriushla/si_di_bbb/acquisition.py
+++ b/pyqt-apps/siriushla/si_di_bbb/acquisition.py
@@ -114,11 +114,11 @@ class _BbBModalAnalysis(QWidget):
             device=self._device,
             acq_type=self.acq_type + '_MD'
         )
-        lb_peak = SiriusLabel(self, self.prop_pref + '_MD_PEAK')
+        lb_peak = SiriusLabel(self, self.prop_pref + 'MD_PEAK')
         lb_peak.showUnits = True
-        lb_pfrq = SiriusLabel(self, self.prop_pref + '_MD_FREQ')
+        lb_pfrq = SiriusLabel(self, self.prop_pref + 'MD_FREQ')
         lb_pfrq.showUnits = True
-        lb_tune = SiriusLabel(self, self.prop_pref + '_MD_TUNE')
+        lb_tune = SiriusLabel(self, self.prop_pref + 'MD_TUNE')
         lb_mnum = SiriusLabel(self, self.prop_pref+'MD_MAXMODE')
         lb_mamp = SiriusLabel(self, self.prop_pref+'MD_MAXVAL')
 

--- a/pyqt-apps/siriushla/si_di_bbb/bbb.py
+++ b/pyqt-apps/siriushla/si_di_bbb/bbb.py
@@ -1,27 +1,40 @@
 """BbB Control Module."""
 
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, \
-    QGroupBox, QSpacerItem, QSizePolicy as QSzPlcy, QPushButton, QHBoxLayout
 import qtawesome as qta
 from pydm.widgets import PyDMEnumComboBox
-
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy as QSzPlcy,
+    QSpacerItem,
+    QWidget
+)
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..util import connect_window, connect_newprocess
-from ..widgets.windows import create_window_from_widget
-from ..widgets import SiriusMainWindow, SiriusLedAlert, PyDMStateButton, \
-    PyDMLedMultiChannel, DetachableTabWidget, SiriusLabel, SiriusPushButton, \
+from ..util import connect_newprocess, connect_window
+from ..widgets import (
+    DetachableTabWidget,
+    PyDMLedMultiChannel,
+    PyDMStateButton,
+    SiriusLabel,
+    SiriusLedAlert,
+    SiriusMainWindow,
+    SiriusPushButton,
     SiriusSpinbox
-
-from .acquisition import BbBAcqSRAM, BbBAcqBRAM, BbBAcqSB
-from .coefficients import BbBCoefficientsWidget
+)
+from ..widgets.windows import create_window_from_widget
+from .acquisition import BbBAcqBRAM, BbBAcqSB, BbBAcqSRAM
 from .advanced_settings import BbBAdvancedSettingsWidget
-from .pwr_amps import BbBPwrAmpsWidget
-from .masks import BbBMasksWidget
+from .coefficients import BbBCoefficientsWidget
 from .drive import BbBDriveSettingsWidget
 from .environment import BbBEnvironmMonWidget
+from .masks import BbBMasksWidget
+from .pwr_amps import BbBPwrAmpsWidget
 from .timing import BbBTimingWidget
 from .util import get_bbb_icon, set_bbb_color
 
@@ -35,18 +48,19 @@ class BbBControlWindow(SiriusMainWindow):
         self.prefix = prefix
         self.device = _PVName(device)
         self.dev_pref = self.device.substitute(prefix=prefix)
-        self.setWindowTitle(device+' Control Window')
+        self.setWindowTitle(device + ' Control Window')
         self.setObjectName('SIApp')
         self.setWindowIcon(get_bbb_icon())
         self._setupUi()
 
     def _setupUi(self):
         label = QLabel(
-            '<h1>'+self.device+'</h1>', self,
-            alignment=Qt.AlignCenter)
+            '<h1>' + self.device + '</h1>', self, alignment=Qt.AlignCenter
+        )
 
         main_wid = BbBMainSettingsWidget(
-            self, self.prefix, self.device, resume=False)
+            self, self.prefix, self.device, resume=False
+        )
         coeff_wid = BbBCoefficientsWidget(self, self.prefix, self.device)
         drive_wid = BbBDriveSettingsWidget(self, self.prefix, self.device)
         sram_wid = BbBAcqSRAM(self, self.prefix, self.device)
@@ -57,7 +71,8 @@ class BbBControlWindow(SiriusMainWindow):
         pwr_amp_wid = BbBPwrAmpsWidget(self, self.prefix, self.device)
         env_wid = BbBEnvironmMonWidget(self, self.prefix, self.device)
         advanced_wid = BbBAdvancedSettingsWidget(
-            self, self.prefix, self.device)
+            self, self.prefix, self.device
+        )
 
         tab = DetachableTabWidget(self)
         tab.setObjectName('SITab')
@@ -85,18 +100,16 @@ class BbBControlWindow(SiriusMainWindow):
 class BbBMainSettingsWidget(QWidget):
     """BbB Main Senttings Widget."""
 
-    def __init__(self, parent=None, prefix=_vaca_prefix, device='',
-                 resume=True):
+    def __init__(
+        self, parent=None, prefix=_vaca_prefix, device='', resume=True
+    ):
         """Init."""
         super().__init__(parent)
         set_bbb_color(self, device)
         self._prefix = prefix
         self._device = _PVName(device)
         self.dev_pref = self._device.substitute(prefix=prefix)
-        typ2label = {
-            'H': 'Horizontal',
-            'V': 'Vertical',
-            'L': 'Longitudinal'}
+        typ2label = {'H': 'Horizontal', 'V': 'Vertical', 'L': 'Longitudinal'}
         self._label = typ2label[self._device[-1]]
         self._is_resumed = resume
         self._setupUi()
@@ -108,13 +121,15 @@ class BbBMainSettingsWidget(QWidget):
         lay = QGridLayout(self)
         lay.setAlignment(Qt.AlignTop | Qt.AlignCenter)
         if self._is_resumed:
-            led_gensts = SiriusLedAlert(self, self.dev_pref+':ERRSUM')
+            led_gensts = SiriusLedAlert(self, self.dev_pref + ':ERRSUM')
             dev_label = QLabel(
-                '<h3>'+self._label+'</h3>', self, alignment=Qt.AlignCenter)
+                '<h3>' + self._label + '</h3>', self, alignment=Qt.AlignCenter
+            )
             self.pb_detail = QPushButton(qta.icon('fa5s.ellipsis-v'), '', self)
             self.pb_detail.setObjectName('dtls')
             self.pb_detail.setStyleSheet(
-                '#dtls{min-width:20px;max-width:20px;icon-size:15px;}')
+                '#dtls{min-width:20px;max-width:20px;icon-size:15px;}'
+            )
             cmd = ['sirius-hla-si-di-bbb.py', '-dev', self.dev_pref]
             if self._prefix:
                 cmd.extend(['-p', self._prefix])
@@ -151,19 +166,19 @@ class BbBMainSettingsWidget(QWidget):
 
     def _setupFeedbackSettings(self):
         ld_fbenbl = QLabel('Enable', self)
-        pb_fbenbl = PyDMStateButton(self, self.dev_pref+':FBCTRL')
+        pb_fbenbl = PyDMStateButton(self, self.dev_pref + ':FBCTRL')
 
         ld_coefsel = QLabel('Coeficient Set', self)
-        cb_coefsel = PyDMEnumComboBox(self, self.dev_pref+':SETSEL')
+        cb_coefsel = PyDMEnumComboBox(self, self.dev_pref + ':SETSEL')
 
         ld_sftgain = QLabel('Shift Gain', self)
-        sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
+        sb_sftgain = SiriusSpinbox(self, self.dev_pref + ':SHIFTGAIN')
 
         ld_downspl = QLabel('Downsampling', self)
-        sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
+        sb_downspl = SiriusSpinbox(self, self.dev_pref + ':PROC_DS')
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
-        sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
+        sb_satthrs = SiriusSpinbox(self, self.dev_pref + ':SAT_THRESHOLD')
 
         lay = QGridLayout()
         lay.addWidget(ld_fbenbl, 1, 0)
@@ -181,7 +196,8 @@ class BbBMainSettingsWidget(QWidget):
             wid = QWidget()
             wid.setLayout(lay)
             fb_label = QLabel(
-                '<h4>Feedback Settings</h4>', self, alignment=Qt.AlignCenter)
+                '<h4>Feedback Settings</h4>', self, alignment=Qt.AlignCenter
+            )
             lay.setContentsMargins(0, 0, 0, 0)
             lay.setVerticalSpacing(12)
             lay.addWidget(fb_label, 0, 0, 1, 2)
@@ -190,7 +206,7 @@ class BbBMainSettingsWidget(QWidget):
             wid.setLayout(lay)
 
             ld_gensts = QLabel('Setup Status', self)
-            led_gensts = SiriusLedAlert(self, self.dev_pref+':ERRSUM')
+            led_gensts = SiriusLedAlert(self, self.dev_pref + ':ERRSUM')
             lay.addWidget(ld_gensts, 6, 0)
             lay.addWidget(led_gensts, 6, 1)
         return wid
@@ -200,22 +216,29 @@ class BbBMainSettingsWidget(QWidget):
             ld_status = QLabel('<h4>Status</h4>', self)
 
             chs2vals = {
-                self.dev_pref+':CLKMISS': 0,
-                self.dev_pref+':PLL_UNLOCK': 0,
-                self.dev_pref+':DCM_UNLOCK': 0,
-                self.dev_pref+':ADC_OVR': 0,
-                self.dev_pref+':SAT': 0,
-                self.dev_pref+':FID_ERR': 0,
+                self.dev_pref + ':CLKMISS': 0,
+                self.dev_pref + ':PLL_UNLOCK': 0,
+                self.dev_pref + ':DCM_UNLOCK': 0,
+                self.dev_pref + ':ADC_OVR': 0,
+                self.dev_pref + ':SAT': 0,
+                self.dev_pref + ':FID_ERR': 0,
             }
             led_status = PyDMLedMultiChannel(self, chs2vals)
             led_status.setStyleSheet(
-                'QLed{min-width:1.29em; max-width:1.29em;}')
+                'QLed{min-width:1.29em; max-width:1.29em;}'
+            )
             wind = create_window_from_widget(
-                BbBStatusWidget, title='BbB Status Details')
+                BbBStatusWidget, title='BbB Status Details'
+            )
             connect_window(
-                led_status, wind, resume=True,
-                parent=self, signal=led_status.clicked,
-                prefix=self._prefix, device=self._device)
+                led_status,
+                wind,
+                resume=True,
+                parent=self,
+                signal=led_status.clicked,
+                prefix=self._prefix,
+                device=self._device,
+            )
 
             wid = QWidget()
             lay = QGridLayout(wid)
@@ -233,8 +256,9 @@ class BbBMainSettingsWidget(QWidget):
 class BbBStatusWidget(QWidget):
     """."""
 
-    def __init__(self, parent=None, prefix=_vaca_prefix, device='',
-                 resume=False):
+    def __init__(
+        self, parent=None, prefix=_vaca_prefix, device='', resume=False
+    ):
         """Init."""
         super().__init__(parent)
         self.setObjectName('SIApp')
@@ -246,34 +270,37 @@ class BbBStatusWidget(QWidget):
 
     def _setupUi(self):
         ld_clkmis = QLabel('Clock missing', alignment=Qt.AlignCenter)
-        led_clkmis = SiriusLedAlert(self, self.dev_pref+':CLKMISS')
-        lb_clkmis = SiriusLabel(self, self.dev_pref+':CLKMISS_COUNT')
+        led_clkmis = SiriusLedAlert(self, self.dev_pref + ':CLKMISS')
+        lb_clkmis = SiriusLabel(self, self.dev_pref + ':CLKMISS_COUNT')
 
         ld_pllulk = QLabel('PLL Unlocked', alignment=Qt.AlignCenter)
-        led_pllulk = SiriusLedAlert(self, self.dev_pref+':PLL_UNLOCK')
-        lb_pllulk = SiriusLabel(self, self.dev_pref+':PLL_UNLOCK_COUNT')
+        led_pllulk = SiriusLedAlert(self, self.dev_pref + ':PLL_UNLOCK')
+        lb_pllulk = SiriusLabel(self, self.dev_pref + ':PLL_UNLOCK_COUNT')
 
         ld_dcmulk = QLabel('DCM unlocked', alignment=Qt.AlignCenter)
-        led_dcmulk = SiriusLedAlert(self, self.dev_pref+':DCM_UNLOCK')
-        lb_dcmulk = SiriusLabel(self, self.dev_pref+':DCM_UNLOCK_COUNT')
+        led_dcmulk = SiriusLedAlert(self, self.dev_pref + ':DCM_UNLOCK')
+        lb_dcmulk = SiriusLabel(self, self.dev_pref + ':DCM_UNLOCK_COUNT')
 
         ld_avcovr = QLabel('ADC Overrange', alignment=Qt.AlignCenter)
-        led_avcovr = SiriusLedAlert(self, self.dev_pref+':ADC_OVR')
-        lb_avcovr = SiriusLabel(self, self.dev_pref+':ADC_OVR_COUNT')
+        led_avcovr = SiriusLedAlert(self, self.dev_pref + ':ADC_OVR')
+        lb_avcovr = SiriusLabel(self, self.dev_pref + ':ADC_OVR_COUNT')
 
         ld_outsat = QLabel('Output satured', alignment=Qt.AlignCenter)
-        led_outsat = SiriusLedAlert(self, self.dev_pref+':SAT')
-        lb_outsat = SiriusLabel(self, self.dev_pref+':SAT_COUNT')
+        led_outsat = SiriusLedAlert(self, self.dev_pref + ':SAT')
+        lb_outsat = SiriusLabel(self, self.dev_pref + ':SAT_COUNT')
 
         ld_fiderr = QLabel('Fiducial Error', alignment=Qt.AlignCenter)
-        led_fiderr = SiriusLedAlert(self, self.dev_pref+':FID_ERR')
-        lb_fiderr = SiriusLabel(self, self.dev_pref+':FID_ERR_COUNT')
+        led_fiderr = SiriusLedAlert(self, self.dev_pref + ':FID_ERR')
+        lb_fiderr = SiriusLabel(self, self.dev_pref + ':FID_ERR_COUNT')
 
         ld_intvl = QLabel('Interval [s]', alignment=Qt.AlignCenter)
-        lb_intvl = SiriusLabel(self, self.dev_pref+':RST_COUNT')
+        lb_intvl = SiriusLabel(self, self.dev_pref + ':RST_COUNT')
         pb_intvl = SiriusPushButton(
-            self, init_channel=self.dev_pref+':CNTRST', pressValue=1,
-            releaseValue=0)
+            self,
+            init_channel=self.dev_pref + ':CNTRST',
+            pressValue=1,
+            releaseValue=0,
+        )
         pb_intvl.setText('Reset')
         pb_intvl.setToolTip('Reset Counts')
         pb_intvl.setIcon(qta.icon('fa5s.sync'))
@@ -286,14 +313,22 @@ class BbBStatusWidget(QWidget):
         if self._is_resumed:
             lay.addWidget(
                 QLabel('<h3>Status</h3>', self, alignment=Qt.AlignCenter),
-                0, 0, 1, 3)
+                0,
+                0,
+                1,
+                3,
+            )
             lay.addItem(
-                QSpacerItem(1, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, 0)
+                QSpacerItem(1, 10, QSzPlcy.Ignored, QSzPlcy.Fixed), 1, 0
+            )
         lay.addWidget(
             QLabel('<h4>Description</h4>', self, alignment=Qt.AlignCenter),
-            2, 1)
+            2,
+            1,
+        )
         lay.addWidget(
-            QLabel('<h4>Count</h4>', self, alignment=Qt.AlignCenter), 2, 2)
+            QLabel('<h4>Count</h4>', self, alignment=Qt.AlignCenter), 2, 2
+        )
         lay.addWidget(led_clkmis, 3, 0)
         lay.addWidget(ld_clkmis, 3, 1)
         lay.addWidget(lb_clkmis, 3, 2)
@@ -341,25 +376,25 @@ class BbBInfoWidget(QGroupBox):
         self.setTitle('System Information')
 
         ld_rffreq = QLabel('Nominal RF Frequency', self)
-        lb_rffreq = SiriusLabel(self, self.dev_pref+':RF_FREQ')
+        lb_rffreq = SiriusLabel(self, self.dev_pref + ':RF_FREQ')
         lb_rffreq.showUnits = True
 
         ld_revfrq = QLabel('Revolution Frequency', self)
-        lb_revfrq = SiriusLabel(self, self.dev_pref+':FREV')
+        lb_revfrq = SiriusLabel(self, self.dev_pref + ':FREV')
         lb_revfrq.showUnits = True
 
         ld_hn = QLabel('Harmonic Number', self)
-        lb_hn = SiriusLabel(self, self.dev_pref+':HARM_NUM')
+        lb_hn = SiriusLabel(self, self.dev_pref + ':HARM_NUM')
 
         ld_gtwrvw = QLabel('Gateway Revision', self)
-        lb_gtwrvw = SiriusLabel(self, self.dev_pref+':REVISION')
+        lb_gtwrvw = SiriusLabel(self, self.dev_pref + ':REVISION')
 
         ld_gtwtyp = QLabel('Gateway Type', self)
-        lb_gtwtyp = SiriusLabel(self, self.dev_pref+':GW_TYPE')
+        lb_gtwtyp = SiriusLabel(self, self.dev_pref + ':GW_TYPE')
         lb_gtwtyp.displayFormat = SiriusLabel.DisplayFormat.Hex
 
         ld_ipaddr = QLabel('IP Address', self)
-        lb_ipaddr = SiriusLabel(self, self.dev_pref+':IP_ADDR')
+        lb_ipaddr = SiriusLabel(self, self.dev_pref + ':IP_ADDR')
 
         lay = QGridLayout(self)
         lay.setVerticalSpacing(15)
@@ -376,5 +411,4 @@ class BbBInfoWidget(QGroupBox):
         lay.addWidget(ld_ipaddr, 5, 0)
         lay.addWidget(lb_ipaddr, 5, 1)
 
-        self.setStyleSheet(
-            "SiriusLabel{qproperty-alignment: AlignCenter;}")
+        self.setStyleSheet('SiriusLabel{qproperty-alignment: AlignCenter;}')

--- a/pyqt-apps/siriushla/si_di_bbb/coefficients.py
+++ b/pyqt-apps/siriushla/si_di_bbb/coefficients.py
@@ -63,7 +63,8 @@ class BbBCoefficientsWidget(QWidget):
         le_coefdesc = PyDMLineEdit(self, self.dev_pref+':DESC_COEFF')
         graph_coefs = WfmGraph(wid)
         graph_coefs.add_scatter_curve(
-            ychannel=self.dev_pref+':COEFF', lineStyle=Qt.SolidLine)
+            ychannel=self.dev_pref+':COEFF', lineStyle=Qt.SolidLine,
+            symbol='o')
 
         graph_fftmag = WfmGraph(wid)
         graph_fftmag.setObjectName('graph')
@@ -78,7 +79,7 @@ class BbBCoefficientsWidget(QWidget):
         graph_fftmag.add_scatter_curve(
             ychannel=self.dev_pref+':FTF_GTUNE',
             xchannel=self.dev_pref+':FTF_FTUNE',
-            name='Tune', color=QColor('red'))
+            name='Tune', color=QColor('red'), symbol='o')
 
         graph_fftphs = WfmGraph(wid)
         graph_fftphs.setLabel('left', text='Phase [°]')
@@ -91,7 +92,7 @@ class BbBCoefficientsWidget(QWidget):
         graph_fftphs.add_scatter_curve(
             ychannel=self.dev_pref+':FTF_PTUNE',
             xchannel=self.dev_pref+':FTF_FTUNE',
-            name='Tune', color=QColor('red'))
+            name='Tune', color=QColor('red'), symbol='o')
 
         ld_fractune = QLabel(
             '<h4> Marker:</h4>', wid, alignment=Qt.AlignLeft | Qt.AlignVCenter)
@@ -304,7 +305,8 @@ class BbBCoefficientsWidget(QWidget):
 
         graph_coef0 = WfmGraph(self)
         graph_coef0.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET0', lineStyle=Qt.SolidLine)
+            ychannel=self.dev_pref+':CSET0', lineStyle=Qt.SolidLine,
+            symbol='o')
 
         ld_coef1 = QLabel('<h4>Set 1</h4>', self)
         ld_coef1.setStyleSheet('max-width: 3em;')
@@ -316,7 +318,8 @@ class BbBCoefficientsWidget(QWidget):
 
         graph_coef1 = WfmGraph(self)
         graph_coef1.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET1', lineStyle=Qt.SolidLine)
+            ychannel=self.dev_pref+':CSET1', lineStyle=Qt.SolidLine,
+            symbol='o')
 
         ld_coef2 = QLabel('<h4>Set 2</h4>', self)
         ld_coef2.setStyleSheet('max-width: 3em;')
@@ -328,7 +331,8 @@ class BbBCoefficientsWidget(QWidget):
 
         graph_coef2 = WfmGraph(self)
         graph_coef2.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET2', lineStyle=Qt.SolidLine)
+            ychannel=self.dev_pref+':CSET2', lineStyle=Qt.SolidLine,
+            symbol='o')
 
         ld_coef3 = QLabel('<h4>Set 3</h4>', self)
         ld_coef3.setStyleSheet('max-width: 3em;')
@@ -339,7 +343,8 @@ class BbBCoefficientsWidget(QWidget):
 
         graph_coef3 = WfmGraph(self)
         graph_coef3.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET3', lineStyle=Qt.SolidLine)
+            ychannel=self.dev_pref+':CSET3', lineStyle=Qt.SolidLine,
+            symbol='o')
 
         gbox_coefview = QGroupBox('Coefficient Sets View', self)
         gbox_coefview.setLayout(QGridLayout())

--- a/pyqt-apps/siriushla/si_di_bbb/coefficients.py
+++ b/pyqt-apps/siriushla/si_di_bbb/coefficients.py
@@ -1,17 +1,21 @@
 """BbB Coefficients Module."""
 
 import numpy as _np
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QGroupBox, QTabWidget
 import qtawesome as qta
 from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit, PyDMPushButton
-
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QGridLayout, QGroupBox, QLabel, QTabWidget, QWidget
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
-from ..widgets import SiriusLedAlert, SiriusLabel, PyDMStateButton, \
-    SiriusLedState, SiriusSpinbox
+from ..widgets import (
+    PyDMStateButton,
+    SiriusLabel,
+    SiriusLedAlert,
+    SiriusLedState,
+    SiriusSpinbox
+)
 from .custom_widgets import WfmGraph
 from .util import set_bbb_color
 
@@ -60,11 +64,13 @@ class BbBCoefficientsWidget(QWidget):
     def _setupCoefficientsEditWidget(self, parent=None):
         wid = QGroupBox('Edit Coefficients', parent or self)
 
-        le_coefdesc = PyDMLineEdit(self, self.dev_pref+':DESC_COEFF')
+        le_coefdesc = PyDMLineEdit(self, self.dev_pref + ':DESC_COEFF')
         graph_coefs = WfmGraph(wid)
         graph_coefs.add_scatter_curve(
-            ychannel=self.dev_pref+':COEFF', lineStyle=Qt.SolidLine,
-            symbol='o')
+            ychannel=self.dev_pref + ':COEFF',
+            lineStyle=Qt.SolidLine,
+            symbol='o',
+        )
 
         graph_fftmag = WfmGraph(wid)
         graph_fftmag.setObjectName('graph')
@@ -72,41 +78,57 @@ class BbBCoefficientsWidget(QWidget):
         graph_fftmag.setLabel('left', text='Magnitude [dB]')
         graph_fftmag.setLabel('bottom', text='Fractional Freq.')
         graph_fftmag.add_scatter_curve(
-            ychannel=self.dev_pref+':FTF_MAG',
-            xchannel=self.dev_pref+':FTF_FREQ',
-            color=QColor('blue'), lineWidth=2, lineStyle=Qt.SolidLine,
-            symbolSize=4)
+            ychannel=self.dev_pref + ':FTF_MAG',
+            xchannel=self.dev_pref + ':FTF_FREQ',
+            color=QColor('blue'),
+            lineWidth=2,
+            lineStyle=Qt.SolidLine,
+            symbolSize=4,
+        )
         graph_fftmag.add_scatter_curve(
-            ychannel=self.dev_pref+':FTF_GTUNE',
-            xchannel=self.dev_pref+':FTF_FTUNE',
-            name='Tune', color=QColor('red'), symbol='o')
+            ychannel=self.dev_pref + ':FTF_GTUNE',
+            xchannel=self.dev_pref + ':FTF_FTUNE',
+            name='Tune',
+            color=QColor('red'),
+            symbol='o',
+        )
 
         graph_fftphs = WfmGraph(wid)
         graph_fftphs.setLabel('left', text='Phase [°]')
         graph_fftphs.setLabel('bottom', text='Fractional Freq.')
         graph_fftphs.add_scatter_curve(
-            ychannel=self.dev_pref+':FTF_PHASE',
-            xchannel=self.dev_pref+':FTF_FREQ',
-            color=QColor('blue'), lineWidth=2, lineStyle=Qt.SolidLine,
-            symbolSize=4)
+            ychannel=self.dev_pref + ':FTF_PHASE',
+            xchannel=self.dev_pref + ':FTF_FREQ',
+            color=QColor('blue'),
+            lineWidth=2,
+            lineStyle=Qt.SolidLine,
+            symbolSize=4,
+        )
         graph_fftphs.add_scatter_curve(
-            ychannel=self.dev_pref+':FTF_PTUNE',
-            xchannel=self.dev_pref+':FTF_FTUNE',
-            name='Tune', color=QColor('red'), symbol='o')
+            ychannel=self.dev_pref + ':FTF_PTUNE',
+            xchannel=self.dev_pref + ':FTF_FTUNE',
+            name='Tune',
+            color=QColor('red'),
+            symbol='o',
+        )
 
         ld_fractune = QLabel(
-            '<h4> Marker:</h4>', wid, alignment=Qt.AlignLeft | Qt.AlignVCenter)
+            '<h4> Marker:</h4>', wid, alignment=Qt.AlignLeft | Qt.AlignVCenter
+        )
         ld_ftval = QLabel(
-            'Frequency [0-1]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        sb_ftval = SiriusSpinbox(wid, self.dev_pref+':FTF_TUNE')
+            'Frequency [0-1]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter
+        )
+        sb_ftval = SiriusSpinbox(wid, self.dev_pref + ':FTF_TUNE')
         ld_ftgain = QLabel(
-            'Gain [dB]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        lb_ftgain = Label(wid, self.dev_pref+':FTF_GTUNE')
+            'Gain [dB]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter
+        )
+        lb_ftgain = Label(wid, self.dev_pref + ':FTF_GTUNE')
         lb_ftgain.precisionFromPV = False
         lb_ftgain.precision = 2
         ld_ftphs = QLabel(
-            'Phase [°]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter)
-        lb_ftphs = Label(wid, self.dev_pref+':FTF_PTUNE')
+            'Phase [°]', wid, alignment=Qt.AlignRight | Qt.AlignVCenter
+        )
+        lb_ftphs = Label(wid, self.dev_pref + ':FTF_PTUNE')
         lb_ftphs.precisionFromPV = False
         lb_ftphs.precision = 2
 
@@ -139,31 +161,36 @@ class BbBCoefficientsWidget(QWidget):
 
     def _setupCoeffSettingsWidget(self):
         ld_coefchoo = QLabel('Choose Set', self, alignment=Qt.AlignRight)
-        cb_coefchoo = PyDMEnumComboBox(self, self.dev_pref+':LDSET')
+        cb_coefchoo = PyDMEnumComboBox(self, self.dev_pref + ':LDSET')
 
         pb_coefload = PyDMPushButton(
-            parent=self, label='Apply Set', icon=qta.icon('mdi.upload'),
-            init_channel=self.dev_pref+':BO_CPCOEFF', pressValue=1)
-        pb_coefload.setStyleSheet("icon-size:20px;")
+            parent=self,
+            label='Apply Set',
+            icon=qta.icon('mdi.upload'),
+            init_channel=self.dev_pref + ':BO_CPCOEFF',
+            pressValue=1,
+        )
+        pb_coefload.setStyleSheet('icon-size:20px;')
         pb_coefvrfy = PyDMPushButton(
-            parent=self, label='Verify Set',
+            parent=self,
+            label='Verify Set',
             icon=qta.icon('mdi.check-circle-outline'),
-            init_channel=self.dev_pref+':BO_CVERIFY', pressValue=1)
-        pb_coefvrfy.setStyleSheet("icon-size:20px;")
+            init_channel=self.dev_pref + ':BO_CVERIFY',
+            pressValue=1,
+        )
+        pb_coefvrfy.setStyleSheet('icon-size:20px;')
 
         ld_gen = QLabel(
-            '<h4>Generate Coefficients</h4>', self, alignment=Qt.AlignCenter)
-        ld_gengain = QLabel(
-            'Gain [0-1]', self, alignment=Qt.AlignRight)
-        sb_gengain = SiriusSpinbox(self, self.dev_pref+':FLT_GAIN')
+            '<h4>Generate Coefficients</h4>', self, alignment=Qt.AlignCenter
+        )
+        ld_gengain = QLabel('Gain [0-1]', self, alignment=Qt.AlignRight)
+        sb_gengain = SiriusSpinbox(self, self.dev_pref + ':FLT_GAIN')
         ld_genphs = QLabel('Phase [°]', self, alignment=Qt.AlignRight)
-        sb_genphs = SiriusSpinbox(self, self.dev_pref+':FLT_PHASE')
-        ld_genfreq = QLabel(
-            'Frequency [0-1]', self, alignment=Qt.AlignRight)
-        sb_genfreq = SiriusSpinbox(self, self.dev_pref+':FLT_FREQ')
-        ld_genntap = QLabel(
-            'Number of taps', self, alignment=Qt.AlignRight)
-        sb_genntap = SiriusSpinbox(self, self.dev_pref+':FLT_TAPS')
+        sb_genphs = SiriusSpinbox(self, self.dev_pref + ':FLT_PHASE')
+        ld_genfreq = QLabel('Frequency [0-1]', self, alignment=Qt.AlignRight)
+        sb_genfreq = SiriusSpinbox(self, self.dev_pref + ':FLT_FREQ')
+        ld_genntap = QLabel('Number of taps', self, alignment=Qt.AlignRight)
+        sb_genntap = SiriusSpinbox(self, self.dev_pref + ':FLT_TAPS')
 
         wid = QWidget(self)
         lay_genset = QGridLayout(wid)
@@ -194,29 +221,30 @@ class BbBCoefficientsWidget(QWidget):
         gbox_settings = QGroupBox('FeedBack Settings', self)
 
         ld_fbpatt = QLabel('Feedback Mask', self)
-        le_fbpatt = PyDMLineEdit(self, self.dev_pref+':FB_PATTERN')
+        le_fbpatt = PyDMLineEdit(self, self.dev_pref + ':FB_PATTERN')
 
         ld_cfpatt = QLabel('Alternate Mask', self)
-        le_cfpatt = PyDMLineEdit(self, self.dev_pref+':CF_PATTERN')
+        le_cfpatt = PyDMLineEdit(self, self.dev_pref + ':CF_PATTERN')
 
         ld_alter_inuse = QLabel('Alternate Set In Use', self)
         led_alter_inuse = SiriusLedState(
-            self, self.dev_pref+':CF_PATTERN_SUB.VALB')
+            self, self.dev_pref + ':CF_PATTERN_SUB.VALB'
+        )
 
         ld_fbenbl = QLabel('Enable', self)
-        pb_fbenbl = PyDMStateButton(self, self.dev_pref+':FBCTRL')
+        pb_fbenbl = PyDMStateButton(self, self.dev_pref + ':FBCTRL')
 
         ld_coefsel = QLabel('Coeficient Set', self)
-        cb_coefsel = PyDMEnumComboBox(self, self.dev_pref+':SETSEL')
+        cb_coefsel = PyDMEnumComboBox(self, self.dev_pref + ':SETSEL')
 
         ld_sftgain = QLabel('Shift Gain', self)
-        sb_sftgain = SiriusSpinbox(self, self.dev_pref+':SHIFTGAIN')
+        sb_sftgain = SiriusSpinbox(self, self.dev_pref + ':SHIFTGAIN')
 
         ld_downspl = QLabel('Downsampling', self)
-        sb_downspl = SiriusSpinbox(self, self.dev_pref+':PROC_DS')
+        sb_downspl = SiriusSpinbox(self, self.dev_pref + ':PROC_DS')
 
         ld_satthrs = QLabel('Sat. Threshold [%]', self)
-        sb_satthrs = SiriusSpinbox(self, self.dev_pref+':SAT_THRESHOLD')
+        sb_satthrs = SiriusSpinbox(self, self.dev_pref + ':SAT_THRESHOLD')
 
         lay_patt = QGridLayout()
         lay_patt.addWidget(ld_fbpatt, 0, 0)
@@ -250,26 +278,26 @@ class BbBCoefficientsWidget(QWidget):
         gbox_settings = QGroupBox('Bunch Cleaning Settings', self)
 
         ld_bcenbl = QLabel('Enable', self)
-        cb_bcenbl = PyDMStateButton(self, self.dev_pref+':CLEAN_ENABLE')
+        cb_bcenbl = PyDMStateButton(self, self.dev_pref + ':CLEAN_ENABLE')
 
         ld_bcamp = QLabel('Amplitude', self)
-        sb_bcamp = SiriusSpinbox(self, self.dev_pref+':CLEAN_AMPL')
-        lb_svamp = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_AMPL')
+        sb_bcamp = SiriusSpinbox(self, self.dev_pref + ':CLEAN_AMPL')
+        lb_svamp = SiriusLabel(self, self.dev_pref + ':CLEAN_SAVE_AMPL')
 
         ld_bctune = QLabel('Tune', self)
-        sb_bctune = SiriusSpinbox(self, self.dev_pref+':CLEAN_TUNE')
-        lb_svfreq = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_FREQ')
+        sb_bctune = SiriusSpinbox(self, self.dev_pref + ':CLEAN_TUNE')
+        lb_svfreq = SiriusLabel(self, self.dev_pref + ':CLEAN_SAVE_FREQ')
 
         ld_bcspan = QLabel('Span', self)
-        le_bcspan = PyDMLineEdit(self, self.dev_pref+':CLEAN_SPAN')
-        lb_svspan = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_SPAN')
+        le_bcspan = PyDMLineEdit(self, self.dev_pref + ':CLEAN_SPAN')
+        lb_svspan = SiriusLabel(self, self.dev_pref + ':CLEAN_SAVE_SPAN')
 
         ld_bcper = QLabel('Period', self)
-        le_bcper = PyDMLineEdit(self, self.dev_pref+':CLEAN_PERIOD')
-        lb_svper = SiriusLabel(self, self.dev_pref+':CLEAN_SAVE_PERIOD')
+        le_bcper = PyDMLineEdit(self, self.dev_pref + ':CLEAN_PERIOD')
+        lb_svper = SiriusLabel(self, self.dev_pref + ':CLEAN_SAVE_PERIOD')
 
         ld_bcpatt = QLabel('Mask', self)
-        le_bcpatt = PyDMLineEdit(self, self.dev_pref+':CLEAN_PATTERN')
+        le_bcpatt = PyDMLineEdit(self, self.dev_pref + ':CLEAN_PATTERN')
 
         lay_clean = QGridLayout(gbox_settings)
         lay_clean.addWidget(QLabel('SAVED VALS.'), 0, 2)
@@ -297,54 +325,59 @@ class BbBCoefficientsWidget(QWidget):
     def _setupCoefficientsViewWidget(self):
         ld_coef0 = QLabel('<h4>Set 0</h4>', self)
         ld_coef0.setStyleSheet('max-width: 3em;')
-        lb_coef0 = SiriusLabel(self, self.dev_pref+':DESC_CSET0')
+        lb_coef0 = SiriusLabel(self, self.dev_pref + ':DESC_CSET0')
         lb_coef0.setStyleSheet('background-color: #DCDCDC;')
-        led_coef0 = SiriusLedAlert(self, self.dev_pref+':CVERIFY.C')
-        led_coef0.setStyleSheet(
-            'min-width: 1.29em; max-width: 1.29em;')
+        led_coef0 = SiriusLedAlert(self, self.dev_pref + ':CVERIFY.C')
+        led_coef0.setStyleSheet('min-width: 1.29em; max-width: 1.29em;')
 
         graph_coef0 = WfmGraph(self)
         graph_coef0.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET0', lineStyle=Qt.SolidLine,
-            symbol='o')
+            ychannel=self.dev_pref + ':CSET0',
+            lineStyle=Qt.SolidLine,
+            symbol='o',
+        )
 
         ld_coef1 = QLabel('<h4>Set 1</h4>', self)
         ld_coef1.setStyleSheet('max-width: 3em;')
-        lb_coef1 = SiriusLabel(self, self.dev_pref+':DESC_CSET1')
+        lb_coef1 = SiriusLabel(self, self.dev_pref + ':DESC_CSET1')
         lb_coef1.setStyleSheet('background-color: #DCDCDC;')
-        led_coef1 = SiriusLedAlert(self, self.dev_pref+':CVERIFY.D')
-        led_coef1.setStyleSheet(
-            'min-width: 1.29em; max-width: 1.29em;')
+        led_coef1 = SiriusLedAlert(self, self.dev_pref + ':CVERIFY.D')
+        led_coef1.setStyleSheet('min-width: 1.29em; max-width: 1.29em;')
 
         graph_coef1 = WfmGraph(self)
         graph_coef1.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET1', lineStyle=Qt.SolidLine,
-            symbol='o')
+            ychannel=self.dev_pref + ':CSET1',
+            lineStyle=Qt.SolidLine,
+            symbol='o',
+        )
 
         ld_coef2 = QLabel('<h4>Set 2</h4>', self)
         ld_coef2.setStyleSheet('max-width: 3em;')
-        lb_coef2 = SiriusLabel(self, self.dev_pref+':DESC_CSET2')
+        lb_coef2 = SiriusLabel(self, self.dev_pref + ':DESC_CSET2')
         lb_coef2.setStyleSheet('background-color: #DCDCDC;')
-        led_coef2 = SiriusLedAlert(self, self.dev_pref+':CVERIFY.G')
-        led_coef2.setStyleSheet(
-            'min-width: 1.29em; max-width: 1.29em;')
+        led_coef2 = SiriusLedAlert(self, self.dev_pref + ':CVERIFY.G')
+        led_coef2.setStyleSheet('min-width: 1.29em; max-width: 1.29em;')
 
         graph_coef2 = WfmGraph(self)
         graph_coef2.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET2', lineStyle=Qt.SolidLine,
-            symbol='o')
+            ychannel=self.dev_pref + ':CSET2',
+            lineStyle=Qt.SolidLine,
+            symbol='o',
+        )
 
         ld_coef3 = QLabel('<h4>Set 3</h4>', self)
         ld_coef3.setStyleSheet('max-width: 3em;')
-        lb_coef3 = SiriusLabel(self, self.dev_pref+':DESC_CSET3')
+        lb_coef3 = SiriusLabel(self, self.dev_pref + ':DESC_CSET3')
         lb_coef3.setStyleSheet('background-color: #DCDCDC;')
-        led_coef3 = SiriusLedAlert(self, self.dev_pref+':CVERIFY.H')
+        led_coef3 = SiriusLedAlert(self, self.dev_pref + ':CVERIFY.H')
         led_coef3.setStyleSheet('min-width: 1.29em; max-width: 1.29em;')
 
         graph_coef3 = WfmGraph(self)
         graph_coef3.add_scatter_curve(
-            ychannel=self.dev_pref+':CSET3', lineStyle=Qt.SolidLine,
-            symbol='o')
+            ychannel=self.dev_pref + ':CSET3',
+            lineStyle=Qt.SolidLine,
+            symbol='o',
+        )
 
         gbox_coefview = QGroupBox('Coefficient Sets View', self)
         gbox_coefview.setLayout(QGridLayout())

--- a/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
@@ -3,12 +3,15 @@
 from functools import partial as _part
 
 import numpy as np
+from pyqtgraph import mkBrush
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from pyqtgraph import mkBrush
 
-from ..widgets import SiriusTimePlot, SiriusConnectionSignal, \
+from ..widgets import (
+    SiriusConnectionSignal,
+    SiriusTimePlot,
     SiriusWaveformPlot
+)
 
 
 class WfmGraph(SiriusWaveformPlot):
@@ -18,8 +21,7 @@ class WfmGraph(SiriusWaveformPlot):
         """."""
         super().__init__(*args, **kwargs)
         self.setObjectName('graph')
-        self.setStyleSheet(
-            '#graph {min-height: 6em; min-width: 15em;}')
+        self.setStyleSheet('#graph {min-height: 6em; min-width: 15em;}')
 
         self.maxRedrawRate = 20
 
@@ -38,14 +40,29 @@ class WfmGraph(SiriusWaveformPlot):
         self._curves_names = []
 
     def add_scatter_curve(
-            self, ychannel='', xchannel='', name='', color=QColor('blue'),
-            lineStyle=Qt.NoPen, lineWidth=1, symbol=None, symbolSize=10,
-            nchannel=None, offset=None):
+        self,
+        ychannel='',
+        xchannel='',
+        name='',
+        color=QColor('blue'),
+        lineStyle=Qt.NoPen,
+        lineWidth=1,
+        symbol=None,
+        symbolSize=10,
+        nchannel=None,
+        offset=None,
+    ):
         """."""
         self.addChannel(
-            x_channel='', y_channel='',
-            name=name, color=color, lineStyle=lineStyle, lineWidth=lineWidth,
-            symbol=symbol, symbolSize=symbolSize)
+            x_channel='',
+            y_channel='',
+            name=name,
+            color=color,
+            lineStyle=lineStyle,
+            lineWidth=lineWidth,
+            symbol=symbol,
+            symbolSize=symbolSize,
+        )
         curve = self.curveAtIndex(-1)
         curve.nchannel = None
         curve.offset = offset
@@ -53,38 +70,53 @@ class WfmGraph(SiriusWaveformPlot):
             curve.nchannel = SiriusConnectionSignal(nchannel)
         x_chan_obj = SiriusConnectionSignal(xchannel)
         x_chan_obj.new_value_signal[np.ndarray].connect(
-            _part(self._update_waveform_value, curve, 'X'))
+            _part(self._update_waveform_value, curve, 'X')
+        )
         y_chan_obj = SiriusConnectionSignal(ychannel)
         y_chan_obj.new_value_signal[np.ndarray].connect(
-            _part(self._update_waveform_value, curve, 'Y'))
+            _part(self._update_waveform_value, curve, 'Y')
+        )
         self._curves_names.append(((x_chan_obj, y_chan_obj), curve))
 
     def add_marker(
-            self, xchannel, ychannel, name,
-            color=QColor('blue'), symbol='o', symbolSize=10):
+        self,
+        xchannel,
+        ychannel,
+        name,
+        color=QColor('blue'),
+        symbol='o',
+        symbolSize=10,
+    ):
         """."""
         self.addChannel(
-            x_channel='FAKE:X', y_channel='FAKE:Y',
-            name=name, color=color,
-            lineStyle=Qt.NoPen, lineWidth=1,
-            symbol=symbol, symbolSize=symbolSize)
+            x_channel='FAKE:X',
+            y_channel='FAKE:Y',
+            name=name,
+            color=color,
+            lineStyle=Qt.NoPen,
+            lineWidth=1,
+            symbol=symbol,
+            symbolSize=symbolSize,
+        )
         curve = self.curveAtIndex(-1)
         curve.opts['symbolBrush'] = mkBrush(color)
 
         x_chan_obj = SiriusConnectionSignal(xchannel)
         x_chan_obj.new_value_signal[float].connect(
-            _part(self._update_marker_value, curve, 'X'))
+            _part(self._update_marker_value, curve, 'X')
+        )
         y_chan_obj = SiriusConnectionSignal(ychannel)
         y_chan_obj.new_value_signal[float].connect(
-            _part(self._update_marker_value, curve, 'Y'))
+            _part(self._update_marker_value, curve, 'Y')
+        )
         self._markers[name] = [(x_chan_obj, y_chan_obj), curve]
 
     def _update_marker_value(self, curve, axis, value):
-        func = getattr(curve, 'receive'+axis+'Waveform')
-        func(np.array([value, ]))
+        func = getattr(curve, 'receive' + axis + 'Waveform')
+        func(np.array([value]))
 
     def _update_waveform_value(self, curve, axis, value):
-        func = getattr(curve, 'receive'+axis+'Waveform')
+        func = getattr(curve, 'receive' + axis + 'Waveform')
         offset = curve.offset or 0.0
         value = value + offset
         if curve.nchannel is None:
@@ -104,8 +136,7 @@ class TimeGraph(SiriusTimePlot):
         """."""
         super().__init__(*args, **kwargs)
         self.setObjectName('graph')
-        self.setStyleSheet(
-            '#graph {min-height: 6em; min-width: 8em;}')
+        self.setStyleSheet('#graph {min-height: 6em; min-width: 8em;}')
 
         self.autoRangeX = True
         self.autoRangeY = True

--- a/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
@@ -21,7 +21,7 @@ class WfmGraph(SiriusWaveformPlot):
         self.setStyleSheet(
             '#graph {min-height: 6em; min-width: 15em;}')
 
-        self.maxRedrawRate = 2
+        self.maxRedrawRate = 20
 
         self.autoRangeX = True
         self.autoRangeY = True
@@ -45,9 +45,8 @@ class WfmGraph(SiriusWaveformPlot):
         self.addChannel(
             x_channel='', y_channel='',
             name=name, color=color, lineStyle=lineStyle, lineWidth=lineWidth,
-            symbol='o', symbolSize=symbolSize)
+            symbol=None, symbolSize=symbolSize)
         curve = self.curveAtIndex(-1)
-        curve.opts['symbolBrush'] = mkBrush(color)
         curve.nchannel = None
         curve.offset = offset
         if nchannel is not None:

--- a/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
+++ b/pyqt-apps/siriushla/si_di_bbb/custom_widgets.py
@@ -39,13 +39,13 @@ class WfmGraph(SiriusWaveformPlot):
 
     def add_scatter_curve(
             self, ychannel='', xchannel='', name='', color=QColor('blue'),
-            lineStyle=Qt.NoPen, lineWidth=1, symbolSize=10, nchannel=None,
-            offset=None):
+            lineStyle=Qt.NoPen, lineWidth=1, symbol=None, symbolSize=10,
+            nchannel=None, offset=None):
         """."""
         self.addChannel(
             x_channel='', y_channel='',
             name=name, color=color, lineStyle=lineStyle, lineWidth=lineWidth,
-            symbol=None, symbolSize=symbolSize)
+            symbol=symbol, symbolSize=symbolSize)
         curve = self.curveAtIndex(-1)
         curve.nchannel = None
         curve.offset = offset

--- a/pyqt-apps/siriushla/si_di_bbb/drive.py
+++ b/pyqt-apps/siriushla/si_di_bbb/drive.py
@@ -171,15 +171,18 @@ class BbBDriveSettingsWidget(QWidget):
         graph_exct.add_scatter_curve(
             ychannel=dev_pref+':DRIVE0_MASK',
             xchannel=dev_pref+':SRAM_XSC',
-            name='Drive0', color=QColor('red'))
+            name='Drive0', color=QColor('red'),
+            symbol='o')
         graph_exct.add_scatter_curve(
             ychannel=dev_pref+':DRIVE1_MASK',
             xchannel=dev_pref+':SRAM_XSC',
-            name='Drive1', color=QColor('magenta'), offset=0.02)
+            name='Drive1', color=QColor('magenta'),
+            symbol='o', offset=0.02)
         graph_exct.add_scatter_curve(
             ychannel=dev_pref+':DRIVE2_MASK',
             xchannel=dev_pref+':SRAM_XSC',
-            name='Drive2', color=QColor('orange'), offset=0.04)
+            name='Drive2', color=QColor('orange'),
+            symbol='o', offset=0.04)
         graph_exct.setLabel('left', '')
 
         self.layout().addWidget(graph_exct, 3, 0, 1, 5)

--- a/pyqt-apps/siriushla/si_di_bbb/drive.py
+++ b/pyqt-apps/siriushla/si_di_bbb/drive.py
@@ -2,26 +2,30 @@
 
 import os as _os
 
-from qtpy.QtGui import QPixmap, QColor
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QSpacerItem, \
-    QHBoxLayout
 from pydm.widgets import PyDMEnumComboBox, PyDMLineEdit
-
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QColor, QPixmap
+from qtpy.QtWidgets import (
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QSpacerItem,
+    QWidget
+)
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
 from ..widgets import PyDMStateButton, SiriusFrame, SiriusLabel, SiriusSpinbox
-
-from .util import set_bbb_color
 from .custom_widgets import WfmGraph
+from .util import set_bbb_color
 
 
 class BbBSingleDriveSettingsWidget(QWidget):
     """BbB Drive Settings Widget."""
 
     def __init__(
-            self, parent=None, prefix=_vaca_prefix, device='', dr_num=None):
+        self, parent=None, prefix=_vaca_prefix, device='', dr_num=None
+    ):
         """Init."""
         super().__init__(parent)
         set_bbb_color(self, device)
@@ -38,16 +42,20 @@ class BbBSingleDriveSettingsWidget(QWidget):
     def _setupUi(self):
         if self._driver_num is None:
             ld_drive = QLabel(
-                '<h3>Drive Pattern Generator</h3>', self,
-                alignment=Qt.AlignCenter)
+                '<h3>Drive Pattern Generator</h3>',
+                self,
+                alignment=Qt.AlignCenter,
+            )
         else:
             ld_drive = QWidget(self)
             ld_drive.setLayout(QHBoxLayout())
             labd = QLabel(
                 f'<h3>Driver {self._driver_num:d}, NCO BITS: </h3>',
-                ld_drive, alignment=Qt.AlignRight)
+                ld_drive,
+                alignment=Qt.AlignRight,
+            )
             labd.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
-            lab = SiriusLabel(ld_drive, self.dev_pref+'BITS')
+            lab = SiriusLabel(ld_drive, self.dev_pref + 'BITS')
             lab.setStyleSheet('font-size: 13pt; font-weight: bold;')
             lab.setAlignment(Qt.AlignLeft | Qt.AlignVCenter)
             ld_drive.layout().addStretch()
@@ -56,29 +64,29 @@ class BbBSingleDriveSettingsWidget(QWidget):
             ld_drive.layout().addStretch()
 
         ld_amp = QLabel('Amplitude', self)
-        sb_amp = SiriusSpinbox(self, self.dev_pref+'AMPL')
+        sb_amp = SiriusSpinbox(self, self.dev_pref + 'AMPL')
 
         ld_freq = QLabel('Frequency', self)
-        sb_freq = SiriusSpinbox(self, self.dev_pref+'FREQ')
+        sb_freq = SiriusSpinbox(self, self.dev_pref + 'FREQ')
 
         ld_wav = QLabel('Waveform', self)
-        cb_wav = PyDMEnumComboBox(self, self.dev_pref+'WAVEFORM')
+        cb_wav = PyDMEnumComboBox(self, self.dev_pref + 'WAVEFORM')
 
         ld_tmod = QLabel('Time MODulation', self)
-        cb_tmod = PyDMStateButton(self, self.dev_pref+'MOD')
+        cb_tmod = PyDMStateButton(self, self.dev_pref + 'MOD')
 
         ld_span = QLabel('Span', self)
-        sb_span = SiriusSpinbox(self, self.dev_pref+'SPAN')
+        sb_span = SiriusSpinbox(self, self.dev_pref + 'SPAN')
 
         ld_perd = QLabel('Period', self)
-        sb_perd = SiriusSpinbox(self, self.dev_pref+'PERIOD')
+        sb_perd = SiriusSpinbox(self, self.dev_pref + 'PERIOD')
 
         ld_patt = QLabel('Drive Pattern', self)
-        le_patt = PyDMLineEdit(self, self.dev_pref+'PATTERN')
+        le_patt = PyDMLineEdit(self, self.dev_pref + 'PATTERN')
 
-        lb_actfreq = SiriusLabel(self, self.dev_pref+'FREQ_ACT_STRING')
-        lb_actspan = SiriusLabel(self, self.dev_pref+'SPAN_ACT_STRING')
-        lb_actperd = SiriusLabel(self, self.dev_pref+'PERIOD_ACT')
+        lb_actfreq = SiriusLabel(self, self.dev_pref + 'FREQ_ACT_STRING')
+        lb_actspan = SiriusLabel(self, self.dev_pref + 'SPAN_ACT_STRING')
+        lb_actperd = SiriusLabel(self, self.dev_pref + 'PERIOD_ACT')
 
         lay = QGridLayout(self)
         lay.addWidget(ld_drive, 0, 1, 1, 3)
@@ -102,8 +110,11 @@ class BbBSingleDriveSettingsWidget(QWidget):
         lay.addItem(QSpacerItem(1, 10), 9, 1)
         lay.addItem(QSpacerItem(1, 10), 13, 1)
         if self._driver_num in {None, 1}:
-            pixmap = QPixmap(_os.path.join(
-                _os.path.abspath(_os.path.dirname(__file__)), 'drive.png'))
+            pixmap = QPixmap(
+                _os.path.join(
+                    _os.path.abspath(_os.path.dirname(__file__)), 'drive.png'
+                )
+            )
             il_drive = QLabel(self)
             il_drive.setPixmap(pixmap)
             il_drive.setScaledContents(True)
@@ -152,13 +163,14 @@ class BbBDriveSettingsWidget(QWidget):
     def _setupUi(self):
         self.setLayout(QGridLayout())
         ld_drive = QLabel(
-            '<h2>Drive Pattern Generators</h2>',
-            self, alignment=Qt.AlignCenter)
+            '<h2>Drive Pattern Generators</h2>', self, alignment=Qt.AlignCenter
+        )
         self.layout().addWidget(ld_drive, 0, 0, 1, 5)
         for i in range(3):
             drive = BbBSingleDriveSettingsWidget(
-                prefix=self._prefix, device=self._device, dr_num=i)
-            self.layout().addWidget(drive, 1, 2*i)
+                prefix=self._prefix, device=self._device, dr_num=i
+            )
+            self.layout().addWidget(drive, 1, 2 * i)
         self.layout().setColumnStretch(1, 2)
         self.layout().setColumnStretch(3, 2)
 
@@ -169,20 +181,28 @@ class BbBDriveSettingsWidget(QWidget):
         graph_exct.showLegend = True
         graph_exct.axisColor = QColor('black')
         graph_exct.add_scatter_curve(
-            ychannel=dev_pref+':DRIVE0_MASK',
-            xchannel=dev_pref+':SRAM_XSC',
-            name='Drive0', color=QColor('red'),
-            symbol='o')
+            ychannel=dev_pref + ':DRIVE0_MASK',
+            xchannel=dev_pref + ':SRAM_XSC',
+            name='Drive0',
+            color=QColor('red'),
+            symbol='o',
+        )
         graph_exct.add_scatter_curve(
-            ychannel=dev_pref+':DRIVE1_MASK',
-            xchannel=dev_pref+':SRAM_XSC',
-            name='Drive1', color=QColor('magenta'),
-            symbol='o', offset=0.02)
+            ychannel=dev_pref + ':DRIVE1_MASK',
+            xchannel=dev_pref + ':SRAM_XSC',
+            name='Drive1',
+            color=QColor('magenta'),
+            symbol='o',
+            offset=0.02,
+        )
         graph_exct.add_scatter_curve(
-            ychannel=dev_pref+':DRIVE2_MASK',
-            xchannel=dev_pref+':SRAM_XSC',
-            name='Drive2', color=QColor('orange'),
-            symbol='o', offset=0.04)
+            ychannel=dev_pref + ':DRIVE2_MASK',
+            xchannel=dev_pref + ':SRAM_XSC',
+            name='Drive2',
+            color=QColor('orange'),
+            symbol='o',
+            offset=0.04,
+        )
         graph_exct.setLabel('left', '')
 
         self.layout().addWidget(graph_exct, 3, 0, 1, 5)

--- a/pyqt-apps/siriushla/si_di_bbb/main.py
+++ b/pyqt-apps/siriushla/si_di_bbb/main.py
@@ -1,18 +1,22 @@
 """BbB Main Module."""
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QGridLayout, QLabel, QWidget, QHBoxLayout, \
-    QPushButton, QComboBox
-
+from qtpy.QtWidgets import (
+    QComboBox,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QWidget
+)
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 
 from ..util import connect_window
 from ..widgets import SiriusMainWindow
 from ..widgets.windows import create_window_from_widget
-
 from .bbb import BbBMainSettingsWidget
-from .util import get_bbb_icon, set_bbb_color
 from .gpio import BbBGPIOWidget
+from .util import get_bbb_icon, set_bbb_color
 
 
 class BbBMainWindow(SiriusMainWindow):
@@ -30,13 +34,17 @@ class BbBMainWindow(SiriusMainWindow):
 
     def _setupUi(self):
         self._ld_bbb = QLabel(
-            '<h3>BbB Control Window</h3>', self, alignment=Qt.AlignCenter)
+            '<h3>BbB Control Window</h3>', self, alignment=Qt.AlignCenter
+        )
 
         self._but_fbe = QPushButton('FBE', self)
 
         window = create_window_from_widget(
-            BbBGPIOWidget, title='Front-Back End', icon=get_bbb_icon(),
-            is_main=True)
+            BbBGPIOWidget,
+            title='Front-Back End',
+            icon=get_bbb_icon(),
+            is_main=True,
+        )
         connect_window(
             self._but_fbe, window, self, prefix=self.prefix, device=''
         )  # device will be filled by the QComboBox callback
@@ -61,7 +69,7 @@ class BbBMainWindow(SiriusMainWindow):
         lay = QGridLayout(cwt)
 
         for col, idc in enumerate(idcs_types):
-            dev_pref = 'SI-Glob:DI-BbBProc-'+idc
+            dev_pref = 'SI-Glob:DI-BbBProc-' + idc
 
             wid = BbBMainSettingsWidget(self, self.prefix, dev_pref)
             set_bbb_color(wid, dev_pref)

--- a/pyqt-apps/siriushla/si_di_bbb/masks.py
+++ b/pyqt-apps/siriushla/si_di_bbb/masks.py
@@ -2,8 +2,7 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QColor
-from qtpy.QtWidgets import QLabel, QWidget, QGridLayout, QSpacerItem
-
+from qtpy.QtWidgets import QGridLayout, QLabel, QSpacerItem, QWidget
 from siriuspy.envars import VACA_PREFIX as _vaca_prefix
 from siriuspy.namesys import SiriusPVName as _PVName
 
@@ -25,10 +24,11 @@ class BbBMasksWidget(QWidget):
 
     def _setupUi(self):
         ld_exct_masks = QLabel(
-            '<h3>Excitation Masks</h3>', self, alignment=Qt.AlignCenter)
+            '<h3>Excitation Masks</h3>', self, alignment=Qt.AlignCenter
+        )
         ld_spec_masks = QLabel(
-            '<h3>Spectrum Averaging Masks</h3>', self,
-            alignment=Qt.AlignCenter)
+            '<h3>Spectrum Averaging Masks</h3>', self, alignment=Qt.AlignCenter
+        )
 
         graph_exct = WfmGraph(self)
         graph_exct.setAutoRangeY(False)
@@ -36,29 +36,44 @@ class BbBMasksWidget(QWidget):
         graph_exct.showLegend = True
         graph_exct.axisColor = QColor('black')
         graph_exct.add_scatter_curve(
-            ychannel=self.dev_pref+':FB_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='Feedback', color=QColor('blue'), symbol='o')
+            ychannel=self.dev_pref + ':FB_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='Feedback',
+            color=QColor('blue'),
+            symbol='o',
+        )
         graph_exct.add_scatter_curve(
-            ychannel=self.dev_pref+':CF_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='Alternate', color=QColor('green'),
-            symbol='o', offset=0.02)
+            ychannel=self.dev_pref + ':CF_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='Alternate',
+            color=QColor('green'),
+            symbol='o',
+            offset=0.02,
+        )
         graph_exct.add_scatter_curve(
-            ychannel=self.dev_pref+':DRIVE0_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive0', color=QColor('red'),
-            symbol='o', offset=0.04)
+            ychannel=self.dev_pref + ':DRIVE0_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='Drive0',
+            color=QColor('red'),
+            symbol='o',
+            offset=0.04,
+        )
         graph_exct.add_scatter_curve(
-            ychannel=self.dev_pref+':DRIVE1_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive1', color=QColor('magenta'),
-            symbol='o', offset=0.06)
+            ychannel=self.dev_pref + ':DRIVE1_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='Drive1',
+            color=QColor('magenta'),
+            symbol='o',
+            offset=0.06,
+        )
         graph_exct.add_scatter_curve(
-            ychannel=self.dev_pref+':DRIVE2_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive2', color=QColor('orange'),
-            symbol='o', offset=0.08)
+            ychannel=self.dev_pref + ':DRIVE2_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='Drive2',
+            color=QColor('orange'),
+            symbol='o',
+            offset=0.08,
+        )
         graph_exct.setLabel('left', '')
 
         graph_spec = WfmGraph(self)
@@ -67,15 +82,20 @@ class BbBMasksWidget(QWidget):
         graph_spec.showLegend = True
         graph_spec.axisColor = QColor('black')
         graph_spec.add_scatter_curve(
-            ychannel=self.dev_pref+':SRAM_ACQ_MASK',
-            xchannel=self.dev_pref+':SRAM_XSC',
-            name='SRAM', color=QColor('red'),
-            symbol='o')
+            ychannel=self.dev_pref + ':SRAM_ACQ_MASK',
+            xchannel=self.dev_pref + ':SRAM_XSC',
+            name='SRAM',
+            color=QColor('red'),
+            symbol='o',
+        )
         graph_spec.add_scatter_curve(
-            ychannel=self.dev_pref+':BRAM_ACQ_MASK',
-            xchannel=self.dev_pref+':BRAM_XSC',
-            name='BRAM', color=QColor('blue'),
-            symbol='o', offset=0.02)
+            ychannel=self.dev_pref + ':BRAM_ACQ_MASK',
+            xchannel=self.dev_pref + ':BRAM_XSC',
+            name='BRAM',
+            color=QColor('blue'),
+            symbol='o',
+            offset=0.02,
+        )
         graph_spec.setLabel('left', '')
 
         lay = QGridLayout(self)

--- a/pyqt-apps/siriushla/si_di_bbb/masks.py
+++ b/pyqt-apps/siriushla/si_di_bbb/masks.py
@@ -38,23 +38,27 @@ class BbBMasksWidget(QWidget):
         graph_exct.add_scatter_curve(
             ychannel=self.dev_pref+':FB_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='Feedback', color=QColor('blue'))
+            name='Feedback', color=QColor('blue'), symbol='o')
         graph_exct.add_scatter_curve(
             ychannel=self.dev_pref+':CF_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='Alternate', color=QColor('green'), offset=0.02)
+            name='Alternate', color=QColor('green'),
+            symbol='o', offset=0.02)
         graph_exct.add_scatter_curve(
             ychannel=self.dev_pref+':DRIVE0_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive0', color=QColor('red'), offset=0.04)
+            name='Drive0', color=QColor('red'),
+            symbol='o', offset=0.04)
         graph_exct.add_scatter_curve(
             ychannel=self.dev_pref+':DRIVE1_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive1', color=QColor('magenta'), offset=0.06)
+            name='Drive1', color=QColor('magenta'),
+            symbol='o', offset=0.06)
         graph_exct.add_scatter_curve(
             ychannel=self.dev_pref+':DRIVE2_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='Drive2', color=QColor('orange'), offset=0.08)
+            name='Drive2', color=QColor('orange'),
+            symbol='o', offset=0.08)
         graph_exct.setLabel('left', '')
 
         graph_spec = WfmGraph(self)
@@ -65,11 +69,13 @@ class BbBMasksWidget(QWidget):
         graph_spec.add_scatter_curve(
             ychannel=self.dev_pref+':SRAM_ACQ_MASK',
             xchannel=self.dev_pref+':SRAM_XSC',
-            name='SRAM', color=QColor('red'))
+            name='SRAM', color=QColor('red'),
+            symbol='o')
         graph_spec.add_scatter_curve(
             ychannel=self.dev_pref+':BRAM_ACQ_MASK',
             xchannel=self.dev_pref+':BRAM_XSC',
-            name='BRAM', color=QColor('blue'), offset=0.02)
+            name='BRAM', color=QColor('blue'),
+            symbol='o', offset=0.02)
         graph_spec.setLabel('left', '')
 
         lay = QGridLayout(self)


### PR DESCRIPTION
The BbB GUIs were always very slow due to plots update, which compromised their performance as a whole. This PR drops the usage of markers in graphs, adopting lines with unit line width, which greatly improves the performance of graphs. Now, SRAM and BRAM plots can be updated up to 10Hz (limited by IOC maximum update rate) without compromising user experience.

This PR also fixes some PV names used in the modal analysis windows.